### PR TITLE
Allow adding UUID columns (that are not associations)

### DIFF
--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -13,6 +13,7 @@ describe Avram::Migrator::AlterTableStatement do
       add joined_at : Time, default: :now
       add updated_at : Time, fill_existing_with: :now
       add future_time : Time, default: Time.new
+      add new_id : UUID, default: UUID.new("46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0")
       remove :old_field
       remove_belongs_to :employee
     end
@@ -30,6 +31,7 @@ describe Avram::Migrator::AlterTableStatement do
       ADD joined_at timestamptz NOT NULL DEFAULT NOW(),
       ADD updated_at timestamptz,
       ADD future_time timestamptz NOT NULL DEFAULT '#{Time.new.to_utc}',
+      ADD new_id uuid NOT NULL DEFAULT '46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0',
       DROP old_field,
       DROP employee_id
     SQL

--- a/src/avram/migrator/column_default_helpers.cr
+++ b/src/avram/migrator/column_default_helpers.cr
@@ -1,7 +1,7 @@
 module Avram::Migrator::ColumnDefaultHelpers
-  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol
+  alias ColumnDefaultType = String | Time | Int32 | Int64 | Float32 | Float64 | Bool | Symbol | UUID
 
-  def value_to_string(type : String.class | Time.class, value : String | Time)
+  def value_to_string(type : String.class | Time.class | UUID.class, value : String | Time | UUID)
     "'#{value}'"
   end
 
@@ -42,6 +42,10 @@ module Avram::Migrator::ColumnDefaultHelpers
   end
 
   def default_value(type : Time.class, default : Symbol)
+    " DEFAULT #{value_to_string(type, default)}"
+  end
+
+  def default_value(type : UUID.class, default : UUID)
     " DEFAULT #{value_to_string(type, default)}"
   end
 end


### PR DESCRIPTION
Adding a simple UUID column failed with "undefined method add_column"
because the UUID type was not recognized for default values.

A static default for UUIDs is kind of ... unintuitive ... anyway, but this gets me going for now.
What I think should be the next step is to maybe allow passing a block or something to fill_existing_with: ... in order to get a different value for each entry in the db. But I see that as a separate task to tackle?

(Storing a UUID in postgres can be done in UUID, but generating one requires an extension, so I opted out of something like DEFAULT generate_uuid_v1()).