### PR TITLE
Failing test case for incorrect bind params

### DIFF
--- a/spec/preloading_spec.cr
+++ b/spec/preloading_spec.cr
@@ -197,4 +197,11 @@ describe "Preloading" do
 
     posts.results.first.comments.should eq([comment])
   end
+
+  it "can look at a collection of records with a preload" do
+    EmployeeBox.create
+    employees = Employee::BaseQuery.new.preload_manager
+
+    employees.includes?(employees.first)
+  end
 end


### PR DESCRIPTION
https://github.com/luckyframework/avram/issues/51

Here's the stack trace for the failure

```
bind message supplies 2 parameters, but prepared statement "" requires 1 (PQ::PQError)
         from lib/pg/src/pq/connection.cr:198:7 in 'handle_error'
         from lib/pg/src/pq/connection.cr:0:9 in 'handle_async_frames'
         from lib/pg/src/pq/connection.cr:157:7 in 'read'
         from lib/pg/src/pq/connection.cr:152:7 in 'read'
         from lib/pg/src/pq/connection.cr:295:31 in 'expect_frame'
         from lib/pg/src/pq/connection.cr:294:5 in 'expect_frame'
         from lib/pg/src/pg/statement.cr:19:5 in 'perform_query'
         from lib/db/src/db/statement.cr:103:14 in 'perform_query_with_rescue'
         from lib/db/src/db/statement.cr:88:7 in 'query'
         from lib/db/src/db/pool_statement.cr:39:30 in 'query'
         from lib/db/src/db/query_methods.cr:38:7 in 'query'
         from src/avram/queryable.cr:53:7 in 'exec_query'
         from src/avram/queryable.cr:131:5 in 'results'
         from spec/support/employee.cr:6:5 in '->'
         from src/avram/queryable.cr:255:3 in 'results'
         from src/avram/queryable.cr:97:5 in 'first?'
         from src/avram/queryable.cr:101:5 in 'first'
         from spec/preloading_spec.cr:205:5 in '->'
         from /usr/share/crystal/src/spec/methods.cr:255:3 in 'it'
         from spec/preloading_spec.cr:201:3 in '->'
         from /usr/share/crystal/src/spec/context.cr:255:3 in 'describe'
         from /usr/share/crystal/src/spec/methods.cr:16:5 in 'describe'
         from spec/preloading_spec.cr:5:1 in '__crystal_main'
         from /usr/share/crystal/src/crystal/main.cr:97:5 in 'main_user_code'
         from /usr/share/crystal/src/crystal/main.cr:86:7 in 'main'
         from /usr/share/crystal/src/crystal/main.cr:106:3 in 'main'
         from __libc_start_main
         from _start
         from ???

```