### PR TITLE
Add Form#param_key

### DIFF
--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -35,7 +35,16 @@ private class ValueColumnModelForm < ValueColumnModel::BaseForm
   fillable value
 end
 
+private class ParamKeyForm < ValueColumnModel::BaseForm
+  param_key :custom_param
+end
+
 describe "Avram::Form" do
+  it "allows overriding the form_name" do
+    ParamKeyForm.new.form_name.should eq "custom_param"
+    ParamKeyForm.form_name.should eq "custom_param"
+  end
+
   it "generates the correct form_name" do
     LimitedUserForm.new.form_name.should eq "limited_user"
     LimitedUserForm.form_name.should eq "limited_user"

--- a/spec/virtual_form_spec.cr
+++ b/spec/virtual_form_spec.cr
@@ -37,6 +37,10 @@ private class CanUseSameVirtualFieldTwiceInVirtualForm < Avram::VirtualForm
   virtual name : String
 end
 
+private class ParamKeyForm < Avram::VirtualForm
+  param_key :custom_param
+end
+
 describe Avram::VirtualForm do
   it "has create/update args for virtual fields" do
     UserWithVirtual.create(password: "p@ssword") do |form, _user|
@@ -52,6 +56,11 @@ describe Avram::VirtualForm do
   it "sets a form_name" do
     TestVirtualForm.new.form_name.should eq "test_virtual"
     TestVirtualForm.form_name.should eq "test_virtual"
+  end
+
+  it "allows overriding the form_name" do
+    ParamKeyForm.new.form_name.should eq "custom_param"
+    ParamKeyForm.form_name.should eq "custom_param"
   end
 
   it "sets up initializers for params and no params" do

--- a/src/avram/form.cr
+++ b/src/avram/form.cr
@@ -5,6 +5,7 @@ require "./needy_initializer_and_save_methods"
 require "./virtual"
 require "./mark_as_failed"
 require "./form_errors"
+require "./param_key_override"
 
 abstract class Avram::Form(T)
   include Avram::Validations
@@ -14,6 +15,7 @@ abstract class Avram::Form(T)
   include Avram::NestedForm
   include Avram::MarkAsFailed
   include Avram::FormErrors
+  include Avram::ParamKeyOverride
 
   enum SaveStatus
     Saved

--- a/src/avram/param_key_override.cr
+++ b/src/avram/param_key_override.cr
@@ -1,0 +1,7 @@
+module Avram::ParamKeyOverride
+  macro param_key(key)
+    def self.form_name
+      {{ key.id.stringify }}
+    end
+  end
+end

--- a/src/avram/virtual_form.cr
+++ b/src/avram/virtual_form.cr
@@ -1,10 +1,12 @@
 require "./virtual"
 require "./form_errors"
+require "./param_key_override"
 
 class Avram::VirtualForm
   include Avram::Virtual
   include Avram::Validations
   include Avram::FormErrors
+  include Avram::ParamKeyOverride
 
   @params : Avram::Paramable
   getter params


### PR DESCRIPTION
Closes #70

This allows someone to customize what param key is used. Especially
helpful with JSON APIs where you care more about what the key is.

For HTML forms it doesn't really matter since the end user never really
uses them.