### PR TITLE
Remove generic arg from InvalidFormError

### DIFF
--- a/spec/form_spec.cr
+++ b/spec/form_spec.cr
@@ -356,7 +356,7 @@ describe "Avram::Form" do
       it "raises an exception" do
         params = {"name" => "", "age" => "30"}
 
-        expect_raises Avram::InvalidFormError(UserForm) do
+        expect_raises Avram::InvalidFormError do
           UserForm.create!(params)
         end
       end
@@ -487,7 +487,7 @@ describe "Avram::Form" do
         user = UserQuery.new.first
         params = {"name" => ""}
 
-        expect_raises Avram::InvalidFormError(UserForm) do
+        expect_raises Avram::InvalidFormError do
           UserForm.update! user, with: params
         end
       end

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -36,18 +36,19 @@ module Avram
   end
 
   # Raised when using the create! or update! methods on a form when it does not have the proper attributes
-  class InvalidFormError(T) < AvramError
-    getter form
+  class InvalidFormError < AvramError
+    getter form_errors : Hash(Symbol, Array(String))
 
-    def initialize(@form : T)
+    def initialize(form)
       message = String.build do |message|
         message << "Could not save #{form.class.name}."
         message << "\n"
         message << "\n"
-        @form.errors.each do |field_name, errors|
+        form.errors.each do |field_name, errors|
           message << "  ▸ #{field_name}: #{errors.join(", ")}\n"
         end
       end
+      @form_errors = form.errors
       super message
     end
   end

--- a/src/avram/form.cr
+++ b/src/avram/form.cr
@@ -295,7 +295,7 @@ abstract class Avram::Form(T)
     if save
       record.not_nil!
     else
-      raise Avram::InvalidFormError(typeof(self)).new(form: self)
+      raise Avram::InvalidFormError.new(form: self)
     end
   end
 


### PR DESCRIPTION
Crystal has issues with Generics and downcasting. Let's just add the
errors to the form and make it non-generic.