### PR TITLE
Raise pretty error message when connection fails

### DIFF
--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -1,0 +1,11 @@
+require "./spec_helper"
+
+describe Avram::Connection do
+  it "displays a helpful error when failing to connect" do
+    conn = Avram::Connection.new("postgres://root:root@localhost:5432/tacoman")
+    message = Regex.new("Failed to connect to databse 'tacoman' with username root.")
+    expect_raises(Avram::ConnectionError, message) do
+      conn.try_connection!
+    end
+  end
+end

--- a/spec/connection_spec.cr
+++ b/spec/connection_spec.cr
@@ -3,7 +3,15 @@ require "./spec_helper"
 describe Avram::Connection do
   it "displays a helpful error when failing to connect" do
     conn = Avram::Connection.new("postgres://root:root@localhost:5432/tacoman")
-    message = Regex.new("Failed to connect to databse 'tacoman' with username root.")
+    message = Regex.new("Failed to connect to databse 'tacoman' with username 'root'.")
+    expect_raises(Avram::ConnectionError, message) do
+      conn.try_connection!
+    end
+  end
+
+  it "suggests trying a password when no password supplied and connection fails" do
+    conn = Avram::Connection.new("postgres://root@localhost:5432/tacoman")
+    message = Regex.new("You didn't supply a password, did you mean to?")
     expect_raises(Avram::ConnectionError, message) do
       conn.try_connection!
     end

--- a/src/avram/connection.cr
+++ b/src/avram/connection.cr
@@ -9,11 +9,9 @@ class Avram::Connection
   end
 
   def try_connection!
-    begin
-      DB.open(@connection_string)
-    rescue DB::ConnectionRefused
-      raise ConnectionError.new(connection_uri)
-    end
+    DB.open(@connection_string)
+  rescue DB::ConnectionRefused
+    raise ConnectionError.new(connection_uri)
   end
 
   private def connection_uri

--- a/src/avram/connection.cr
+++ b/src/avram/connection.cr
@@ -1,0 +1,22 @@
+# Handles the connection to the DB.
+class Avram::Connection
+  def self.open(connection_string : String) : DB::Database
+    conn = self.new(connection_string)
+    conn.try_connection!
+  end
+
+  def initialize(@connection_string : String)
+  end
+
+  def try_connection!
+    begin
+      DB.open(@connection_string)
+    rescue DB::ConnectionRefused
+      raise ConnectionError.new(connection_uri)
+    end
+  end
+
+  private def connection_uri
+    URI.parse(@connection_string)
+  end
+end

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -59,4 +59,22 @@ module Avram
       super message
     end
   end
+
+  class ConnectionError < AvramError
+    def initialize(connection_details : URI)
+      error = String.build do |message|
+        message << "Failed to connect to databse '#{connection_details.path.try(&.[1..-1])}' with username #{connection_details.user}.\n"
+        message << "You can try these steps to help:"
+        message << '\n'
+        message << '\n'
+        message << "  ▸ Ensure you have the correct settings in config/database.cr\n"
+        message << "  ▸ Does the database exist? If not, be sure to create it.\n"
+        message << "  ▸ Check that you have access to connect to #{connection_details.host} on port #{connection_details.port}\n"
+        if connection_details.password.blank?
+          message << "  ▸ You didn't supply a password, did you mean to?\n"
+        end
+      end
+      super error
+    end
+  end
 end

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -63,12 +63,12 @@ module Avram
   class ConnectionError < AvramError
     def initialize(connection_details : URI)
       error = String.build do |message|
-        message << "Failed to connect to databse '#{connection_details.path.try(&.[1..-1])}' with username #{connection_details.user}.\n"
-        message << "You can try these steps to help:"
+        message << "Failed to connect to databse '#{connection_details.path.try(&.[1..-1])}' with username '#{connection_details.user}'.\n"
+        message << "Try this..."
         message << '\n'
         message << '\n'
-        message << "  ▸ Ensure you have the correct settings in config/database.cr\n"
-        message << "  ▸ Does the database exist? If not, be sure to create it.\n"
+        message << "  ▸ Check connection settings in 'config/database.cr'\n"
+        message << "  ▸ Be sure the database exists (lucky db.create)\n"
         message << "  ▸ Check that you have access to connect to #{connection_details.host} on port #{connection_details.port}\n"
         if connection_details.password.blank?
           message << "  ▸ You didn't supply a password, did you mean to?\n"

--- a/src/avram/repo.cr
+++ b/src/avram/repo.cr
@@ -15,7 +15,7 @@ class Avram::Repo
   end
 
   def self.db
-    @@db ||= DB.open(settings.url)
+    @@db ||= Connection.open(settings.url)
   end
 
   def self.current_transaction : DB::Transaction?


### PR DESCRIPTION
closes #81 (though, this is an alternative to doing that)

Prior to this, you'd get a `DB::ConnectionRefused error` as well as some `PQ` related errors. Now you get a nice error message that helps to explain what went wrong, and possible ways to fix it. 

