### PR TITLE
Add sequence to Avram::Box

### DIFF
--- a/spec/box_spec.cr
+++ b/spec/box_spec.cr
@@ -1,0 +1,19 @@
+require "./spec_helper"
+
+describe "Sequences" do
+  it "increases a value every time it's called" do
+    BaseBox::SEQUENCES["name"] = 0
+
+    tag1 = TagBox.create
+    tag2 = TagBox.create
+
+    tag1.name.should eq("name-1")
+    tag2.name.should eq("name-2")
+  end
+
+  it "can be overridden" do
+    tag = TagBox.create(&.name("not-a-sequence"))
+
+    tag.name.should eq("not-a-sequence")
+  end
+end

--- a/spec/support/base_box.cr
+++ b/spec/support/base_box.cr
@@ -1,6 +1,4 @@
 abstract class BaseBox < Avram::Box
-  SEQUENCES = {} of String => Int32
-
   def self.build
     new.build
   end
@@ -11,11 +9,5 @@ abstract class BaseBox < Avram::Box
 
   def build_pair
     [build, build]
-  end
-
-  def sequence(value : String) : String
-    SEQUENCES[value] ||= 0
-    SEQUENCES[value] += 1
-    "#{value}-#{SEQUENCES[value]}"
   end
 end

--- a/spec/support/boxes/tag_box.cr
+++ b/spec/support/boxes/tag_box.cr
@@ -1,5 +1,5 @@
 class TagBox < BaseBox
   def initialize
-    name sequence("tag")
+    name sequence("name")
   end
 end

--- a/src/avram/box.cr
+++ b/src/avram/box.cr
@@ -1,6 +1,8 @@
 abstract class Avram::Box
   getter form
 
+  SEQUENCES = {} of String => Int32
+
   macro inherited
     {% unless @type.abstract? %}
       {% form = @type.name.gsub(/Box/, "::BaseForm").id %}
@@ -36,5 +38,23 @@ abstract class Avram::Box
 
   def self.create_pair
     2.times { new.create }
+  end
+
+  # Returns a value with a number to use for unique values.
+  #
+  # Usage:
+  #
+  # ```crystal
+  # class UserBox < Avram::Box
+  #   def initialize
+  #     username sequence("username")            # => username-1, username-2, etc.
+  #     email "#{sequence("email")}@example.com" # => email-1@example.com, email-2@example.com, etc.
+  #   end
+  # end
+  # ```
+  def sequence(value : String) : String
+    SEQUENCES[value] ||= 0
+    SEQUENCES[value] += 1
+    "#{value}-#{SEQUENCES[value]}"
   end
 end


### PR DESCRIPTION
_Note: just adding this because I ran into it while developing and it was about as easy to impliment it as it was to make an issue. Feel free to push back 🙂_

Unique values are a good thing and application developers should use
them. However, testing with unique values can be a pain since you need
to create a new value explicitly in tests instead of using a default
value via a Box.

This makes sequences (some code that I found in the Avram tests)
included by default in every box. This seems like a thing that users
shouldn't have to build into every app themselves.