### PR TITLE
Ensure proper ordering in the `first?` method

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -101,9 +101,10 @@ describe Avram::Query do
       UserBox.new.name("First").create
       UserBox.new.name("Last").create
 
-      user = UserQuery.new.first?
+      user = (user_query = UserQuery.new).first?
       user.should_not be_nil
       user.not_nil!.name.should eq "First"
+      user_query.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users ORDER BY id ASC LIMIT 1"
     end
 
     it "returns nil if no record found" do
@@ -169,9 +170,10 @@ describe Avram::Query do
       UserBox.new.name("First").create
       UserBox.new.name("Last").create
 
-      last = UserQuery.new.last?
+      last = (user_query = UserQuery.new).last?
       last.should_not be_nil
       last && last.name.should eq "Last"
+      user_query.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users ORDER BY id DESC LIMIT 1"
     end
 
     it "returns nil if last record is not found" do

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -93,7 +93,7 @@ module Avram::Queryable(T)
   end
 
   def first?
-    query.limit(1)
+    ordered_query.limit(1)
     results.first?
   end
 


### PR DESCRIPTION
Make it match the ordering that the `last?` method uses. Fixes #115.