### PR TITLE
Table name is guessed. No requires required

### DIFF
--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -88,6 +88,12 @@ describe Avram::Model do
         price = PriceBox.new.line_item_id(item.id).create
         price.line_item.should eq item
       end
+
+      it "returns associated model when using 'table' and 'foreign_key'" do
+        post = PostWithCustomTable::SaveOperation.create!(title: "foo")
+        comment = CommentForCustomPost::SaveOperation.create!(body: "bar", post_id: post.id)
+        comment.post_with_custom_table.should eq(post)
+      end
     end
 
     describe "has_many" do

--- a/spec/support/admin.cr
+++ b/spec/support/admin.cr
@@ -1,5 +1,3 @@
-require "./sign_in_credential"
-
 class Admin < Avram::Model
   COLUMN_SQL = "admins.id, admins.created_at, admins.updated_at, admins.name"
 

--- a/spec/support/comment.cr
+++ b/spec/support/comment.cr
@@ -1,5 +1,3 @@
-require "./post"
-
 class Comment < Avram::Model
   skip_default_columns
 
@@ -8,5 +6,18 @@ class Comment < Avram::Model
     timestamps
     column body : String
     belongs_to post : Post
+  end
+end
+
+class CommentForCustomPost < Avram::Model
+  skip_default_columns
+
+  table :comments do
+    primary_key custom_id : Int64
+    timestamps
+    column body : String
+    belongs_to post_with_custom_table : PostWithCustomTable,
+      table: :posts,
+      foreign_key: :post_id
   end
 end

--- a/spec/support/employee.cr
+++ b/spec/support/employee.cr
@@ -1,5 +1,3 @@
-require "./manager"
-
 class Employee < Avram::Model
   table do
     column name : String

--- a/spec/support/line_item_product.cr
+++ b/spec/support/line_item_product.cr
@@ -1,6 +1,3 @@
-require "./line_item"
-require "./product"
-
 class LineItemProduct < Avram::Model
   skip_default_columns
 

--- a/spec/support/manager.cr
+++ b/spec/support/manager.cr
@@ -1,5 +1,3 @@
-require "./employee"
-
 class Manager < Avram::Model
   table do
     column name : String

--- a/spec/support/post.cr
+++ b/spec/support/post.cr
@@ -1,5 +1,3 @@
-require "./comment"
-
 class Post < Avram::Model
   skip_default_columns
 
@@ -12,5 +10,20 @@ class Post < Avram::Model
     has_many comments : Comment
     has_many taggings : Tagging
     has_many tags : Tag, through: :taggings
+  end
+end
+
+# This is a regular post, but with a custom table name
+# This is to test that 'belongs_to' can accept a 'table' in the
+# CommentForCustomPost model
+class PostWithCustomTable < Avram::Model
+  skip_default_columns
+
+  table :posts do
+    primary_key custom_id : Int64
+    timestamps
+
+    column title : String
+    column published_at : Time?
   end
 end

--- a/spec/support/price.cr
+++ b/spec/support/price.cr
@@ -1,5 +1,3 @@
-require "./line_item"
-
 class Price < Avram::Model
   skip_default_columns
 

--- a/spec/support/sign_in_credential.cr
+++ b/spec/support/sign_in_credential.cr
@@ -1,5 +1,3 @@
-require "./user"
-
 class SignInCredential < Avram::Model
   table do
     belongs_to user : User

--- a/spec/support/user.cr
+++ b/spec/support/user.cr
@@ -1,5 +1,3 @@
-require "./sign_in_credential"
-
 class User < Avram::Model
   COLUMN_SQL = "users.id, users.created_at, users.updated_at, users.name, users.age, users.nickname, users.joined_at, users.average_score"
 

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -38,17 +38,17 @@ class Avram::BaseQueryTemplate
       {% end %}
 
       {% for assoc in associations %}
-        def join_{{ assoc[:name] }}
-          inner_join_{{ assoc[:name] }}
+        def join_{{ assoc[:table_name] }}
+          inner_join_{{ assoc[:table_name] }}
         end
 
         {% for join_type in ["Inner", "Left", "Right", "Full"] %}
-          def {{ join_type.downcase.id }}_join_{{ assoc[:name] }}
+          def {{ join_type.downcase.id }}_join_{{ assoc[:table_name] }}
             {% if assoc[:relationship_type] == :belongs_to %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: @@table_name,
-                  to: :{{ assoc[:name] }},
+                  to: :{{ assoc[:table_name] }},
                   primary_key: {{ assoc[:foreign_key] }},
                   foreign_key: primary_key_name
                 )
@@ -56,13 +56,13 @@ class Avram::BaseQueryTemplate
             {% elsif assoc[:through] %}
               {{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
               {{ assoc[:through].id }} do |join_query|
-                join_query.{{ join_type.downcase.id }}_join_{{ assoc[:name] }}
+                join_query.{{ join_type.downcase.id }}_join_{{ assoc[:table_name] }}
               end
             {% else %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: @@table_name,
-                  to: :{{ assoc[:name] }},
+                  to: :{{ assoc[:table_name] }},
                   foreign_key: {{ assoc[:foreign_key] }},
                   primary_key: primary_key_name
                 )
@@ -72,7 +72,7 @@ class Avram::BaseQueryTemplate
         {% end %}
 
 
-        def {{ assoc[:name] }}
+        def {{ assoc[:table_name] }}
           {{ assoc[:type] }}::BaseQuery.new_with_existing_query(query).tap do |assoc_query|
             yield assoc_query
           end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -34,7 +34,7 @@ class Avram::Model
       \{% for assoc in ASSOCIATIONS %}
          \{% if assoc[:relationship_type] == :has_many %}
            define_has_many_base_query(
-             assoc_name: \{{ assoc[:name] }},
+             assoc_name: \{{ assoc[:table_name] }},
              model: \{{ assoc[:type] }},
              foreign_key: \{{ assoc[:foreign_key].id }},
              through: \{{ assoc[:through] }}
@@ -193,6 +193,6 @@ class Avram::Model
   end
 
   macro association(table_name, type, relationship_type, foreign_key = nil, through = nil)
-    {% ASSOCIATIONS << {type: type, name: table_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through} %}
+    {% ASSOCIATIONS << {type: type, table_name: table_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through} %}
   end
 end


### PR DESCRIPTION
This improves an issue where previously you had to require associations.
Now we don't because we no longer resolve the type in the macro.

The one downside is that if you have a table name that is not the
default pluralized snake case, you will need to provide it in
`belongs_to`. I think this is a great tradeoff since the require issue
is annoying and causes a lot of issues. Also most people use those
defaults so it should be fine.