### PR TITLE
add rollback_to feature

### DIFF
--- a/script/test
+++ b/script/test
@@ -14,6 +14,9 @@ then
     $COMPOSE lucky db.drop
     $COMPOSE lucky db.create
     $COMPOSE lucky db.migrate
+    printf "\nRolling back to 20180802180356\n"
+    $COMPOSE lucky db.rollback_to 20180802180356
+    printf "\nRolling back remainder\n"
     $COMPOSE lucky db.rollback_all
     $COMPOSE lucky db.migrate.one
     $COMPOSE lucky db.migrate
@@ -26,7 +29,7 @@ if [ $# -eq 0 ]
 then
     printf "\nChecking that tasks build correctly\n\n"
     $COMPOSE shards build
-    
+
     printf "\nChecking code formatting\n\n"
     if ! $COMPOSE crystal tool format --check src spec config > /dev/null; then
         printf "\nCode is not formatted.\n"

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -122,6 +122,14 @@ class Avram::Migrator::Runner
     end
   end
 
+  def rollback_to(last_version : Int64)
+    setup_migration_tracking_tables
+    subset = migrated_migrations.select do |mm|
+      mm.new.version.to_i64 > last_version
+    end
+    subset.reverse.each &.new.down
+  end
+
   def ensure_migrated!
     if pending_migrations.any?
       raise "There are pending migrations. Please run lucky db.migrate"

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -128,6 +128,7 @@ class Avram::Migrator::Runner
       mm.new.version.to_i64 > last_version
     end
     subset.reverse.each &.new.down
+    puts "Done rolling back to #{last_version}".colorize(:green)
   end
 
   def ensure_migrated!

--- a/src/avram/tasks/db/rollback_to.cr
+++ b/src/avram/tasks/db/rollback_to.cr
@@ -1,0 +1,16 @@
+require "colorize"
+
+class Db::RollbackTo < LuckyCli::Task
+  summary "Rollback to a specific migration"
+
+  def call(version : String? = nil)
+    Avram::Migrator.run do
+      version = version || ARGV.first?
+      if version && version.to_i64?
+        Avram::Migrator::Runner.new.rollback_to(version.to_i64)
+      else
+        raise "Migration version is required. Example: lucky db.rollback_to 20180802180356".colorize(:red).to_s
+      end
+    end
+  end
+end

--- a/src/avram/tasks/db/rollback_to.cr
+++ b/src/avram/tasks/db/rollback_to.cr
@@ -3,9 +3,9 @@ require "colorize"
 class Db::RollbackTo < LuckyCli::Task
   summary "Rollback to a specific migration"
 
-  def call(version : String? = nil)
+  def call
     Avram::Migrator.run do
-      version = version || ARGV.first?
+      version = ARGV.first?
       if version && version.to_i64?
         Avram::Migrator::Runner.new.rollback_to(version.to_i64)
       else


### PR DESCRIPTION
Wow, that was easier than I thought!

But I don't understand the specs well enough to be sure that these tasks don't have specs. Is there somewhere I'm missing that a task spec belongs?

Also you'll notice that I changed the messaging a bit in the test script. Since I put this before `rollback_all` I wanted to make sure I could visually compare (assuming that's our test method) what the message says we are rolling back to vs what actually got rolled back.

If this goes in, I'll be happy to update the docs (over on the lucky webpage right?). The doc should say something like "rollback_to <last stable integer timestamp>" and make it clear that we are *not* rolling back the migration named in the time stamp, we are rolling back *to* the state that that migration provided.