### PR TITLE
renamed destroy_all to truncate.

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -568,7 +568,7 @@ describe Avram::Query do
     it "truncates the table" do
       10.times { UserBox.create }
       UserQuery.new.select_count.should eq 10
-      UserQuery.new.truncate
+      UserQuery.truncate
       UserQuery.new.select_count.should eq 0
     end
   end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -563,4 +563,13 @@ describe Avram::Query do
       end
     end
   end
+
+  describe "truncate" do
+    it "truncates the table" do
+      10.times { UserBox.create }
+      UserQuery.new.select_count.should eq 10
+      UserQuery.new.truncate
+      UserQuery.new.select_count.should eq 0
+    end
+  end
 end

--- a/src/avram/query.cr
+++ b/src/avram/query.cr
@@ -2,7 +2,7 @@ require "./queryable"
 
 abstract class Avram::Query
   # runs a SQL `TRUNCATE` on the current table
-  def truncate
+  def self.truncate
     Avram::Repo.run do |db|
       db.exec "TRUNCATE TABLE #{@@table_name}"
     end

--- a/src/avram/query.cr
+++ b/src/avram/query.cr
@@ -1,7 +1,8 @@
 require "./queryable"
 
 abstract class Avram::Query
-  def destroy_all
+  # runs a SQL `TRUNCATE` on the current table
+  def truncate
     Avram::Repo.run do |db|
       db.exec "TRUNCATE TABLE #{@@table_name}"
     end

--- a/src/avram/repo.cr
+++ b/src/avram/repo.cr
@@ -22,6 +22,7 @@ class Avram::Repo
     transactions[Fiber.current.object_id]?
   end
 
+  # runs a SQL `TRUNCATE` on all tables in the database
   def self.truncate
     DatabaseCleaner.new.truncate
   end


### PR DESCRIPTION
fixes #110

I also documented the Repo.truncate just so we don't get the two confused. 