### PR TITLE
Add lucky db.migrations.status CLI task

### DIFF
--- a/script/test
+++ b/script/test
@@ -20,6 +20,7 @@ then
     $COMPOSE lucky db.rollback_all
     $COMPOSE lucky db.migrate.one
     $COMPOSE lucky db.migrate
+    $COMPOSE lucky db.migrations.status
 fi
 
 printf "\nRunning specs\n\n"

--- a/shard.yml
+++ b/shard.yml
@@ -30,6 +30,9 @@ dependencies:
   dexter:
     github: luckyframework/dexter
     version: ~> 0.1
+  shell-table:
+    github: luckyframework/shell-table.cr
+    branch: refactor/setter
 
 scripts:
   postinstall: script/precompile_tasks

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -137,18 +137,18 @@ class Avram::Migrator::Runner
     end
   end
 
+  def setup_migration_tracking_tables
+    DB.open(Avram::Repo.settings.url) do |db|
+      db.exec create_table_for_tracking_migrations
+    end
+  end
+
   private def migrated_migrations
     @@migrations.select &.new.migrated?
   end
 
   private def pending_migrations
     @@migrations.select &.new.pending?
-  end
-
-  private def setup_migration_tracking_tables
-    DB.open(Avram::Repo.settings.url) do |db|
-      db.exec create_table_for_tracking_migrations
-    end
   end
 
   private def prepare_for_migration

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -75,6 +75,21 @@ class Avram::Migrator::Runner
     end
   end
 
+  def self.setup_migration_tracking_tables
+    DB.open(Avram::Repo.settings.url) do |db|
+      db.exec create_table_for_tracking_migrations
+    end
+  end
+
+  private def self.create_table_for_tracking_migrations
+    <<-SQL
+    CREATE TABLE IF NOT EXISTS #{MIGRATIONS_TABLE_NAME} (
+      id serial PRIMARY KEY,
+      version bigint NOT NULL
+    )
+    SQL
+  end
+
   private def self.macos_postgres_tools_link
     "https://postgresapp.com/documentation/cli-tools.html".colorize(:green)
   end
@@ -109,12 +124,12 @@ class Avram::Migrator::Runner
   end
 
   def rollback_all
-    setup_migration_tracking_tables
+    self.class.setup_migration_tracking_tables
     migrated_migrations.reverse.each &.new.down
   end
 
   def rollback_one
-    setup_migration_tracking_tables
+    self.class.setup_migration_tracking_tables
     if migrated_migrations.empty?
       puts "Did not roll anything back because the database has no migrations.".colorize(:green)
     else
@@ -123,7 +138,7 @@ class Avram::Migrator::Runner
   end
 
   def rollback_to(last_version : Int64)
-    setup_migration_tracking_tables
+    self.class.setup_migration_tracking_tables
     subset = migrated_migrations.select do |mm|
       mm.new.version.to_i64 > last_version
     end
@@ -137,12 +152,6 @@ class Avram::Migrator::Runner
     end
   end
 
-  def setup_migration_tracking_tables
-    DB.open(Avram::Repo.settings.url) do |db|
-      db.exec create_table_for_tracking_migrations
-    end
-  end
-
   private def migrated_migrations
     @@migrations.select &.new.migrated?
   end
@@ -152,7 +161,7 @@ class Avram::Migrator::Runner
   end
 
   private def prepare_for_migration
-    setup_migration_tracking_tables
+    self.class.setup_migration_tracking_tables
     if pending_migrations.empty?
       unless @quiet
         puts "Did not migrate anything because there are no pending migrations.".colorize(:green)
@@ -164,14 +173,5 @@ class Avram::Migrator::Runner
     raise "Unable to connect to the database. Please check your configuration.".colorize(:red).to_s
   rescue e : Exception
     raise "Unexpected error while running migrations: #{e.message}".colorize(:red).to_s
-  end
-
-  private def create_table_for_tracking_migrations
-    <<-SQL
-    CREATE TABLE IF NOT EXISTS #{MIGRATIONS_TABLE_NAME} (
-      id serial PRIMARY KEY,
-      version bigint NOT NULL
-    )
-    SQL
   end
 end

--- a/src/avram/tasks/db/migrations_status.cr
+++ b/src/avram/tasks/db/migrations_status.cr
@@ -30,12 +30,7 @@ class Db::Migrations::Status < LuckyCli::Task
 
   private def migration_statuses
     migrations.map do |migration|
-      status = if migration.new.migrated?
-                 "Migrated".colorize(:green)
-               else
-                 "Pending".colorize(:yellow)
-               end
-
+      status = migration.new.migrated? ? "Migrated" : "Pending"
       [migration.name, status]
     end
   end

--- a/src/avram/tasks/db/migrations_status.cr
+++ b/src/avram/tasks/db/migrations_status.cr
@@ -17,7 +17,7 @@ class Db::Migrations::Status < LuckyCli::Task
   end
 
   private def ensure_migration_tracking_tables_exist
-    Avram::Migrator::Runner.new.setup_migration_tracking_tables
+    Avram::Migrator::Runner.setup_migration_tracking_tables
   end
 
   private def print_migration_statuses

--- a/src/avram/tasks/db/migrations_status.cr
+++ b/src/avram/tasks/db/migrations_status.cr
@@ -1,0 +1,42 @@
+require "shell-table"
+
+class Db::Migrations::Status < LuckyCli::Task
+  summary "Print the current status of migrations"
+
+  def call
+    if migrations.none?
+      puts "There are no migrations.".colorize(:green)
+    else
+      ensure_migration_tracking_tables_exist
+      print_migration_statuses
+    end
+  end
+
+  private def migrations
+    Avram::Migrator::Runner.migrations
+  end
+
+  private def ensure_migration_tracking_tables_exist
+    Avram::Migrator::Runner.new.setup_migration_tracking_tables
+  end
+
+  private def print_migration_statuses
+    puts ShellTable.new(
+      labels: ["Migration", "Status"],
+      label_color: :white,
+      rows: migration_statuses
+    )
+  end
+
+  private def migration_statuses
+    migrations.map do |migration|
+      status = if migration.new.migrated?
+                 "Migrated".colorize(:green)
+               else
+                 "Pending".colorize(:yellow)
+               end
+
+      [migration.name, status]
+    end
+  end
+end


### PR DESCRIPTION
### 👋 

This is my first attempt at a contribution to Lucky and pretty much my first time writing Crystal code, so any / all feedback is super appreciated.

I took at a stab at adding the `lucky db.migrations.status` task from https://github.com/luckyframework/avram/issues/126

A few things to note:
- I added the `shell-table` shard as a dependency to help format the output.
- The `shell-table` shard is pointing to a branch on the fork at luckyframework. I didn't have a good reason to do this other than that's the version lucky itself is using (https://github.com/luckyframework/lucky/blob/32db2b499227541ab43b5927bf88e1b95a3e53d8/shard.yml#L47-L49). Happy to update this.
- It doesn't look like there are existing tests for CLI tasks so I didn't add any, but please point me in the right direction if I'm mistaken here.

Example output:
<img width="479" alt="Screen Shot 2019-07-06 at 6 41 37 AM" src="https://user-images.githubusercontent.com/1279093/60756978-3ea0c300-9fb9-11e9-962b-215a6700142e.png">

Thanks!
