### PR TITLE
Improve callbacks and operation setup and validation 

### DIFF
--- a/spec/define_attribute_spec.cr
+++ b/spec/define_attribute_spec.cr
@@ -5,6 +5,7 @@ private class VirtualOperation < Post::SaveOperation
   attribute terms_of_service : Bool
   attribute best_kind_of_bear : String = "black bear"
   attribute default_is_false : Bool = false
+  before_save prepare
 
   def prepare
     password_confirmation.value = "reset"

--- a/spec/define_attribute_spec.cr
+++ b/spec/define_attribute_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-private class VirtualOperation < Post::SaveOperation
+private class Operation < Post::SaveOperation
   attribute password_confirmation : String
   attribute terms_of_service : Bool
   attribute best_kind_of_bear : String = "black bear"
@@ -88,12 +88,12 @@ describe "attribute in forms" do
   end
 
   it "sets named args for attributes, leaves other empty" do
-    VirtualOperation.create(title: "My Title", best_kind_of_bear: "brown bear") do |operation, post|
+    Operation.create(title: "My Title", best_kind_of_bear: "brown bear") do |operation, post|
       operation.best_kind_of_bear.value.should eq("brown bear")
       operation.terms_of_service.value.should be_nil
       post.should_not be_nil
 
-      VirtualOperation.update(post.not_nil!, best_kind_of_bear: "koala bear") do |operation, post|
+      Operation.update(post.not_nil!, best_kind_of_bear: "koala bear") do |operation, post|
         operation.best_kind_of_bear.value.should eq("koala bear")
       end
     end
@@ -101,5 +101,5 @@ describe "attribute in forms" do
 end
 
 private def operation(attrs = {} of String => String)
-  VirtualOperation.new(attrs)
+  Operation.new(attrs)
 end

--- a/spec/nested_save_operation_spec.cr
+++ b/spec/nested_save_operation_spec.cr
@@ -49,7 +49,7 @@ private class NestedParams
   end
 end
 
-describe "Avram::SaveOperation with nested form" do
+describe "Avram::SaveOperation with nested operation" do
   context "when not all forms are valid" do
     it "does not save either" do
       params = NestedParams.new business: {"name" => "Fubar"},
@@ -58,7 +58,7 @@ describe "Avram::SaveOperation with nested form" do
 
       SaveBusiness.create(params) do |operation, business|
         business.should be_nil
-        forms_saved?(operation, false)
+        operations_saved?(operation, false)
       end
 
       params = NestedParams.new business: {"name" => "Fubar"},
@@ -67,7 +67,7 @@ describe "Avram::SaveOperation with nested form" do
 
       SaveBusiness.create(params) do |operation, business|
         business.should be_nil
-        forms_saved?(operation, false)
+        operations_saved?(operation, false)
       end
 
       params = NestedParams.new business: {"name" => "Fubar"},
@@ -76,7 +76,7 @@ describe "Avram::SaveOperation with nested form" do
 
       SaveBusiness.create(params) do |operation, business|
         business.should be_nil
-        forms_saved?(operation, false)
+        operations_saved?(operation, false)
       end
     end
   end
@@ -88,7 +88,7 @@ describe "Avram::SaveOperation with nested form" do
         tax_id: {"number" => "123"}
 
       SaveBusiness.create(params) do |operation, business|
-        forms_saved?(operation, saved?: true)
+        operations_saved?(operation, saved?: true)
         operation.errors.keys.size.should eq 0
         operation.save_tax_id.errors.keys.size.should eq 0
         operation.save_email_address.errors.keys.size.should eq 0
@@ -100,7 +100,7 @@ describe "Avram::SaveOperation with nested form" do
   end
 end
 
-private def forms_saved?(operation, saved? : Bool)
+private def operations_saved?(operation, saved? : Bool)
   operation.saved?.should eq(saved?)
   operation.save_email_address.saved?.should eq(saved?)
   operation.save_tax_id.saved?.should eq(saved?)

--- a/spec/operation_needs_spec.cr
+++ b/spec/operation_needs_spec.cr
@@ -1,6 +1,8 @@
 require "./spec_helper"
 
 class Needs::SaveOperation < User::SaveOperation
+  before_save prepare
+
   def prepare
     setup_required_attributes
   end

--- a/spec/operation_spec.cr
+++ b/spec/operation_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-private class TestVirtualOperation < Avram::VirtualOperation
+private class TestOperation < Avram::Operation
   attribute name : String
   attribute age : Int32
 
@@ -9,7 +9,7 @@ private class TestVirtualOperation < Avram::VirtualOperation
   end
 end
 
-private class TestVirtualOperationWithMultipleValidations < Avram::VirtualOperation
+private class TestOperationWithMultipleValidations < Avram::Operation
   attribute name : String
   attribute age : Int32
 
@@ -33,15 +33,15 @@ private class CanUseSameVirtualAttributeTwiceInModelBackedSaveOperation < User::
   attribute password : String
 end
 
-private class CanUseSameVirtualAttributeTwiceInVirtualOperation < Avram::VirtualOperation
+private class CanUseSameVirtualAttributeTwiceInOperation < Avram::Operation
   attribute name : String
 end
 
-private class ParamKeySaveOperation < Avram::VirtualOperation
+private class ParamKeySaveOperation < Avram::Operation
   param_key :custom_param
 end
 
-describe Avram::VirtualOperation do
+describe Avram::Operation do
   it "has create/update args for non column attributes" do
     UserWithVirtual.create(password: "p@ssword") do |operation, _user|
       operation.password.value = "p@ssword"
@@ -54,7 +54,7 @@ describe Avram::VirtualOperation do
   end
 
   it "sets a param_key based on the underscored class name" do
-    TestVirtualOperation.param_key.should eq "test_virtual_operation"
+    TestOperation.param_key.should eq "test_operation"
   end
 
   it "allows overriding the param_key" do
@@ -62,44 +62,44 @@ describe Avram::VirtualOperation do
   end
 
   it "sets up initializers for params and no params" do
-    virtual_operation = TestVirtualOperation.new
-    virtual_operation.name.value.should be_nil
-    virtual_operation.name.value = "Megan"
-    virtual_operation.name.value.should eq("Megan")
+    operation = TestOperation.new
+    operation.name.value.should be_nil
+    operation.name.value = "Megan"
+    operation.name.value.should eq("Megan")
 
     params = Avram::Params.new({"name" => "Jordan"})
-    virtual_operation = TestVirtualOperation.new(params)
-    virtual_operation.name.value.should eq("Jordan")
+    operation = TestOperation.new(params)
+    operation.name.value.should eq("Jordan")
   end
 
   it "parses params" do
     params = Avram::Params.new({"age" => "45"})
-    virtual_operation = TestVirtualOperation.new(params)
-    virtual_operation.age.value.should eq 45
-    virtual_operation.age.errors.should eq [] of String
+    operation = TestOperation.new(params)
+    operation.age.value.should eq 45
+    operation.age.errors.should eq [] of String
 
     params = Avram::Params.new({"age" => "not an int"})
-    virtual_operation = TestVirtualOperation.new(params)
-    virtual_operation.age.value.should be_nil
-    virtual_operation.age.errors.should eq ["is invalid"]
+    operation = TestOperation.new(params)
+    operation.age.value.should be_nil
+    operation.age.errors.should eq ["is invalid"]
   end
 
   it "includes validations" do
     params = Avram::Params.new({"name" => ""})
-    virtual_operation = TestVirtualOperation.new(params)
-    virtual_operation.name.errors.should eq [] of String
-    virtual_operation.valid?.should be_true
+    operation = TestOperation.new(params)
+    operation.name.errors.should eq [] of String
+    operation.valid?.should be_true
 
-    virtual_operation.validate
+    operation.validate
 
-    virtual_operation.name.errors.should eq ["is required"]
-    virtual_operation.valid?.should be_false
+    operation.name.errors.should eq ["is required"]
+    operation.valid?.should be_false
   end
 
   describe "#errors" do
     it "includes errors for all attributes" do
       params = Avram::Params.new({"name" => "", "age" => "20"})
-      operation = TestVirtualOperationWithMultipleValidations.new(params)
+      operation = TestOperationWithMultipleValidations.new(params)
 
       operation.validate
 

--- a/spec/save_operation_callbacks_spec.cr
+++ b/spec/save_operation_callbacks_spec.cr
@@ -80,7 +80,7 @@ describe "Avram::SaveOperation callbacks" do
 
   it "does not run after_commit if rolled back" do
     post = PostBox.create
-    operation = CallbacksSaveOperation.new(post)
+    operation = CallbacksSaveOperation.new(post, rollback: true)
     operation.callbacks_that_ran.should eq([] of String)
 
     operation.save

--- a/spec/save_operation_spec.cr
+++ b/spec/save_operation_spec.cr
@@ -2,6 +2,7 @@ require "./spec_helper"
 
 private class SaveUser < User::SaveOperation
   permit_columns :name, :nickname, :joined_at, :age
+  before_save prepare
 
   def prepare
     validate_required name, joined_at, age
@@ -16,6 +17,8 @@ private class SaveTask < Task::SaveOperation
 end
 
 private class ValidSaveOperationWithoutParams < Post::SaveOperation
+  before_save prepare
+
   def prepare
     title.value = "My Title"
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,8 +4,8 @@ require "./support/base_model"
 require "./support/**"
 require "../config/database"
 
-Db::Create.new.call
-Db::Migrate.new.call
+Db::Create.new(quiet: true).call
+Db::Migrate.new(quiet: true).call
 
 Spec.before_each do
   TestDatabase.truncate

--- a/spec/type_extension_spec.cr
+++ b/spec/type_extension_spec.cr
@@ -5,6 +5,7 @@ end
 
 class SaveCompany < Company::SaveOperation
   permit_columns :sales, :earnings
+  before_save prepare
 
   def prepare
     validate_required sales

--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -13,6 +13,7 @@ end
 
 class UniquenessWithDatabaseBackedSaveOperation < User::SaveOperation
   permit_columns name
+  before_save prepare
 
   def prepare
     validate_uniqueness_of name

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -1,61 +1,128 @@
 module Avram::Callbacks
-  macro before_save(method)
+  # Run the given method before saving or creating
+  #
+  # This runs before saving and before the database transaction is started.
+  # You can set defaults, validate, or perform any other setup necessary for
+  # saving.
+  #
+  # ```
+  # before_save run_validations
+  #
+  # private def run_validations
+  #   validate_required name, age
+  # end
+  # ```
+  macro before_save(method_name)
     def before_save
       {% if @type.methods.map(&.name).includes?(:before_save.id) %}
         previous_def
       {% end %}
 
-      {{ method.id }}
+      {{ method_name.id }}
     end
   end
 
-  macro after_save(method)
+  # Run the given block before saving or creating
+  #
+  # This runs before saving and before the database transaction is started.
+  # You can set defaults, validate, or perform any other setup necessary for
+  # saving.
+  #
+  # ```
+  # before_save do
+  #   validate_required name, age
+  # end
+  # ```
+  macro before_save
+    def before_save
+      {% if @type.methods.map(&.name).includes?(:before_save.id) %}
+        previous_def
+      {% end %}
+
+      {{ yield }}
+    end
+  end
+
+  # Run the given method after save, but before transaction is committed
+  #
+  # This is a great place to do other database saves because if something goes
+  # wrong the whole transaction would be rolled back.
+  #
+  # The newly saved record will be passed to the method.
+  #
+  # ```
+  # class SaveComment < Comment::SaveOperation
+  #   after_save touch_post
+  #
+  #   private def touch_post(comment : Comment)
+  #     SavePost.update!(comment.post!, updated_at: Time.utc)
+  #   end
+  # end
+  # ```
+  #
+  # > This is *not* a good place to do things like send messages, enqueue
+  # > background jobs, or charge payments. Since the transaction could be rolled
+  # > back the record may not be persisted to the database.
+  # > Instead use `after_commit`
+  macro after_save(method_name)
     def after_save(object)
       {% if @type.methods.map(&.name).includes?(:after_save.id) %}
         previous_def
       {% end %}
 
-      {{ method.id }}(object)
+      {{ method_name.id }}(object)
     end
   end
 
-  macro before_create(method)
-    def before_create
-      {% if @type.methods.map(&.name).includes?(:before_create.id) %}
+  # Run the given method after save and after successful transaction commit
+  #
+  # The newly saved record will be passed to the method.
+  #
+  # ```
+  # class SaveComment < Comment::SaveOperation
+  #   after_commit notify_post_author
+  #
+  #   private def notify_post_author(comment : Comment)
+  #     NewCommentNotificationEmail.new(comment, to: comment.author!).deliver_now
+  #   end
+  # end
+  # ```
+  #
+  macro after_commit(method_name)
+    def after_commit(object)
+      {% if @type.methods.map(&.name).includes?(:after_commit.id) %}
         previous_def
       {% end %}
 
-      {{ method.id }}
+      {{ method_name.id }}(object)
     end
   end
 
-  macro after_create(method)
-    def after_create(object)
-      {% if @type.methods.map(&.name).includes?(:after_create.id) %}
-        previous_def
-      {% end %}
+  {% for callbacks_without_block in [:after_save, :after_commit] %}
+    # :nodoc:
+    macro {{ callbacks_without_block.id }}
+      \{% raise <<-ERROR
+        '#{callbacks_without_block.id}' does not accept a block. Instead give it a method name  to run.
 
-      {{ method.id }}(object)
+        Example:
+
+            #{callbacks_without_block.id} run_something
+        ERROR
+      %}
+      # Will never be called but must be there so that the macro accepts a block
+      \{{ yield }}
     end
-  end
+  {% end %}
 
-  macro before_update(method)
-    def before_update
-      {% if @type.methods.map(&.name).includes?(:before_update.id) %}
-        previous_def
-      {% end %}
-
-      {{ method.id }}
+  {% for removed_callback in [:create, :update] %}
+    # :nodoc:
+    macro after_{{ removed_callback.id }}(method_name)
+      \{% raise "'after_#{removed_callback}' has been removed" %}
     end
-  end
 
-  macro after_update(method)
-    def after_update(object)
-      {% if @type.methods.map(&.name).includes?(:after_update.id) %}
-        previous_def
-      {% end %}
-
-      {{ method.id }}(object)
+    # :nodoc:
+    macro before_{{ removed_callback.id }}(method_name)
+      \{% raise "'before_#{removed_callback.id}' has been removed" %}
     end
-  end
+  {% end %}
 end

--- a/src/avram/database_validations.cr
+++ b/src/avram/database_validations.cr
@@ -1,0 +1,41 @@
+require "./validations/**"
+
+module Avram::DatabaseValidations
+  private def validate_uniqueness_of(
+    attribute : Avram::Attribute,
+    query : Avram::Criteria,
+    message : String = "is already taken"
+  )
+    attribute.value.try do |value|
+      if query.eq(value).first?
+        attribute.add_error message
+      end
+    end
+  end
+
+  private def validate_uniqueness_of(
+    attribute : Avram::Attribute,
+    message : String = "is already taken"
+  )
+    attribute.value.try do |value|
+      if build_validation_query(attribute.name, attribute.value).first?
+        attribute.add_error message
+      end
+    end
+  end
+
+  # Must be included in the macro to get access to the generic T class
+  # in forms that save to the database.
+  #
+  # Operations will also have access to this, but will fail if you try to use
+  # if because there is no T (model class).
+  macro included
+    private def build_validation_query(column_name, value) : T::BaseQuery
+      query = T::BaseQuery.new.where(column_name, value)
+      record.try(&.id).try do |id|
+        query = query.id.not.eq(id)
+      end
+      query
+    end
+  end
+end

--- a/src/avram/nested_save_operation.cr
+++ b/src/avram/nested_save_operation.cr
@@ -8,7 +8,7 @@ module Avram::NestedSaveOperation
       @_{{ name }} ||= {{ type }}.new(params)
     end
 
-    after_create save_nested_{{ name }}
+    after_save save_nested_{{ name }}
 
     def save_nested_{{ name }}(record)
       {{ name }}.{{ @type.constant(:FOREIGN_KEY).id }}.value = record.id

--- a/src/avram/nested_save_operation.cr
+++ b/src/avram/nested_save_operation.cr
@@ -29,7 +29,7 @@ module Avram::NestedSaveOperation
 
   def mark_nested_save_operations_as_failed
     nested_save_operations.each do |f|
-      f.mark_as_failed
+      f.as(Avram::MarkAsFailed).mark_as_failed
     end
   end
 

--- a/src/avram/operation.cr
+++ b/src/avram/operation.cr
@@ -1,14 +1,16 @@
+require "./validations"
+require "./save_operation_errors"
 require "./define_attribute"
 require "./save_operation_errors"
 require "./param_key_override"
 
 class Avram::VirtualForm
   macro inherited
-    {% raise "Avram::VirtualForm has been renamed to Avram::VirtualOperation. Please inherit from Avram::VirtualOperation." %}
+    {% raise "Avram::VirtualForm has been renamed to Avram::Operation. Please inherit from Avram::Operation." %}
   end
 end
 
-class Avram::VirtualOperation
+class Avram::Operation
   include Avram::DefineAttribute
   include Avram::Validations
   include Avram::SaveOperationErrors

--- a/src/avram/param_key_override.cr
+++ b/src/avram/param_key_override.cr
@@ -1,6 +1,13 @@
 module Avram::ParamKeyOverride
   macro included
-    # Override the param key used for this operation
+    define_param_key_override
+
+    macro inherited
+      define_param_key_override
+    end
+  end
+
+  macro define_param_key_override
     macro param_key(key)
       def self.param_key
         \{{ key.id.stringify }}

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -48,6 +48,7 @@ abstract class Avram::SaveOperation(T)
     T.name.underscore
   end
 
+  # :nodoc:
   def log_failed_save
     Avram.logger.warn({
       failed_to_save:    self.class.name.to_s,
@@ -61,6 +62,7 @@ abstract class Avram::SaveOperation(T)
     end.join(". ")
   end
 
+  # :nodoc:
   def self.save(*args, **named_args, &block)
     {% raise <<-ERROR
       SaveOperations do not have a 'save' method.
@@ -74,6 +76,7 @@ abstract class Avram::SaveOperation(T)
     %}
   end
 
+  # :nodoc:
   macro add_column_attributes(primary_key_type, attributes)
     {% for attribute in attributes %}
       {% COLUMN_ATTRIBUTES << attribute %}
@@ -153,14 +156,6 @@ abstract class Avram::SaveOperation(T)
         {% end %}
       )
     end
-
-    def after_prepare
-      validate_required *required_attributes
-
-      {% if primary_key_type.id == UUID.id %}
-        id.value ||= UUID.random()
-      {% end %}
-    end
   end
 
   private def ensure_paramable(params)
@@ -171,22 +166,23 @@ abstract class Avram::SaveOperation(T)
     end
   end
 
+  # Runs `before_save` steps and returns `true` if all attributes are valid.
   def valid? : Bool
-    prepare
-    after_prepare
+    before_save
     attributes.all? &.valid?
   end
 
-  abstract def after_prepare
-
+  # Returns true if the operation has run and saved the record successfully
   def saved?
     save_status == SaveStatus::Saved
   end
 
+  # Return true if the operation has run and the record failed to save
   def save_failed?
     save_status == SaveStatus::SaveFailed
   end
 
+  # :nodoc:
   macro fillable(*args)
     {% raise "'fillable' has been renamed to 'permit_columns'" %}
   end
@@ -261,40 +257,50 @@ abstract class Avram::SaveOperation(T)
     end
   end
 
+  macro finished
+    # After all before_save callbacks run, make sure non-nilable column attributes
+    # are there.
+    #
+    # This must run after the other before_* callbacks otherwise it might mark
+    # a field as missing and then later another callback sets the field.
+    #
+    # For example:
+    #
+    #   before_save { email.value = "default@example.com" }
+    #
+    # If we had already validate 'email' it would say 'email is missing' when
+    # in reality We set it in another callback.
+    before_save validate_non_nilable_column_attributes
+
+    def validate_non_nilable_column_attributes
+      validate_required *required_attributes
+    end
+  end
+
   def save : Bool
-    if perform_save
+    if valid? && changes.any?
+      transaction_committed = database.transaction do
+        insert_or_update
+        saved_record = record.not_nil!
+        after_save(saved_record)
+        true
+      end
+
+      if transaction_committed
+        saved_record = record.not_nil!
+        after_commit(saved_record)
+        self.save_status = SaveStatus::Saved
+        true
+      else
+        mark_as_failed
+        false
+      end
+    elsif valid? && changes.empty?
       self.save_status = SaveStatus::Saved
       true
     else
       mark_as_failed
       false
-    end
-  end
-
-  private def perform_save : Bool
-    if valid? && changes.any?
-      database.transaction do
-        is_update = persisted?
-        before_save
-        if is_update
-          before_update
-        else
-          before_create
-        end
-
-        insert_or_update
-        saved_record = record.not_nil!
-        after_save(saved_record)
-
-        if is_update
-          after_update(saved_record)
-        else
-          after_create(saved_record)
-        end
-        true
-      end
-    else
-      valid? && changes.empty?
     end
   end
 
@@ -326,26 +332,15 @@ abstract class Avram::SaveOperation(T)
     @record.try &.id
   end
 
-  # Default callbacks
-  def prepare; end
-
-  def after_prepare; end
-
   def before_save; end
 
   def after_save(_record : T); end
 
-  def before_create; end
-
-  def after_create(_record : T); end
-
-  def before_update; end
-
-  def after_update(_record : T); end
+  def after_commit(_record : T); end
 
   private def insert : T
     self.created_at.value ||= Time.utc if responds_to?(:created_at)
-    self.updated_at.value ||= Time.utc if responds_to?(:created_at)
+    self.updated_at.value ||= Time.utc if responds_to?(:updated_at)
     @record = database.run do |db|
       db.query insert_sql.statement, insert_sql.args do |rs|
         @record = @@schema_class.from_rs(rs).first

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -1,22 +1,19 @@
-require "./validations"
+require "./operation"
+require "./database_validations"
 require "./callbacks"
 require "./nested_save_operation"
 require "./needy_initializer_and_save_methods"
 require "./define_attribute"
 require "./mark_as_failed"
 require "./param_key_override"
-require "./save_operation_errors"
 require "./inherit_column_attributes"
 
-abstract class Avram::SaveOperation(T)
-  include Avram::Validations
+abstract class Avram::SaveOperation(T) < Avram::Operation
   include Avram::NeedyInitializerAndSaveMethods
-  include Avram::DefineAttribute
   include Avram::Callbacks
+  include Avram::DatabaseValidations
   include Avram::NestedSaveOperation
   include Avram::MarkAsFailed
-  include Avram::SaveOperationErrors
-  include Avram::ParamKeyOverride
   include Avram::InheritColumnAttributes
 
   enum SaveStatus
@@ -25,10 +22,10 @@ abstract class Avram::SaveOperation(T)
     Unperformed
   end
 
+  @save_status = SaveStatus::Unperformed
+
   macro inherited
     @valid : Bool = true
-    @save_status = SaveStatus::Unperformed
-
     @@permitted_param_keys = [] of String
     @@schema_class = T
   end

--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -7,6 +7,14 @@ class Avram::SaveOperationTemplate
     end
 
     class ::{{ type }}::SaveOperation < Avram::SaveOperation({{ type }})
+      {% if primary_key_type.id == UUID.id %}
+        before_save set_uuid
+
+        def set_uuid
+          id.value ||= UUID.random()
+        end
+      {% end %}
+
       def database
         {{ type }}.database
       end

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -75,7 +75,7 @@ module Avram::Validations
   # Must be included in the macro to get access to the generic T class
   # in forms that save to the database.
   #
-  # VirtualOperations will also have access to this, but will fail if you try to use
+  # Operations will also have access to this, but will fail if you try to use
   # if because there is no T (model class).
   macro included
     private def build_validation_query(column_name, value) : T::BaseQuery


### PR DESCRIPTION
- [x]  Needs to accept a block in callbacks too. 
- [x] call `before_save` in `valid?`
- [x] add specs to ensure after commit runs after the transaction 
- [x] add docs for callbacks. Explain when they run. Whether inside a transaction, etc. 
- [x] document `valid?`. Explain that it runs `before_save` callbacks but doesn’t save
- [x] Rename `VirtualOperation` to `Operation`

## Do later

This requires more work, refactoring, and possible extracting to another shard for `LuckyOperation` or something. Can be figured out later

- [ ] add abstract `run` method to operations. And yield the operation and the result
- [ ] change SaveOperation to use `run` under the hood
