### PR TITLE
Adding support for Arrays

### DIFF
--- a/db/migrations/20180113081408_create_companies.cr
+++ b/db/migrations/20180113081408_create_companies.cr
@@ -4,7 +4,7 @@ class CreateCompanies::V20180113081408 < Avram::Migrator::Migration::V1
       primary_key id : Int64
       add_timestamps
       add sales : Int64
-      add earnings : Float
+      add earnings : Float64
     end
   end
 

--- a/db/migrations/20180802180357_test_defaults.cr
+++ b/db/migrations/20180802180357_test_defaults.cr
@@ -8,7 +8,7 @@ class TestDefaults::V20180802180357 < Avram::Migrator::Migration::V1
       add published_at : Time, default: 1.day.from_now
       add admin : Bool, default: false
       add age : Int32, default: 30
-      add money : Float, default: 3.5
+      add money : Float64, default: 3.5
     end
   end
 

--- a/db/migrations/20190712145900_create_buckets.cr
+++ b/db/migrations/20190712145900_create_buckets.cr
@@ -2,14 +2,14 @@ class CreateBuckets::V20190712145900 < Avram::Migrator::Migration::V1
   def migrate
     create table_for(Bucket) do
       primary_key id : Int64
-      #add bools : Array(Bool)
-      #add prices : Array(Float64)
-      #add small_numbers : Array(Int16)
-      #add numbers : Array(Int32)
-      #add big_numbers : Array(Int64)
+      add bools : Array(Bool)
+      add prices : Array(Float64)
+      add small_numbers : Array(Int16)
+      add numbers : Array(Int32)
+      add big_numbers : Array(Int64)
       add names : Array(String)
-      #add dates : Array(Time)
-      #add ids : Array(UUID)
+      add dates : Array(Time)
+      add ids : Array(UUID)
     end
   end
 

--- a/db/migrations/20190712145900_create_buckets.cr
+++ b/db/migrations/20190712145900_create_buckets.cr
@@ -1,0 +1,19 @@
+class CreateBuckets::V20190712145900 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(Bucket) do
+      primary_key id : Int64
+      add bools : Array(Bool)
+      add prices : Array(Float64)
+      add small_numbers : Array(Int16)
+      add numbers : Array(Int32)
+      add big_numbers : Array(Int64)
+      add names : Array(String)
+      add dates : Array(Time)
+      add ids : Array(UUID)
+    end
+  end
+
+  def rollback
+    drop :buckets
+  end
+end

--- a/db/migrations/20190712145900_create_buckets.cr
+++ b/db/migrations/20190712145900_create_buckets.cr
@@ -3,13 +3,13 @@ class CreateBuckets::V20190712145900 < Avram::Migrator::Migration::V1
     create table_for(Bucket) do
       primary_key id : Int64
       add bools : Array(Bool)
-      add prices : Array(Float64)
-      add small_numbers : Array(Int16)
-      add numbers : Array(Int32)
-      add big_numbers : Array(Int64)
-      add names : Array(String)
-      add dates : Array(Time)
-      add ids : Array(UUID)
+      #add prices : Array(Float64)
+      #add small_numbers : Array(Int16)
+      #add numbers : Array(Int32)
+      #add big_numbers : Array(Int64)
+      #add names : Array(String)
+      #add dates : Array(Time)
+      #add ids : Array(UUID)
     end
   end
 

--- a/db/migrations/20190712145900_create_buckets.cr
+++ b/db/migrations/20190712145900_create_buckets.cr
@@ -2,14 +2,13 @@ class CreateBuckets::V20190712145900 < Avram::Migrator::Migration::V1
   def migrate
     create table_for(Bucket) do
       primary_key id : Int64
+      add_timestamps
       add bools : Array(Bool)
       add prices : Array(Float64)
       add small_numbers : Array(Int16)
       add numbers : Array(Int32)
       add big_numbers : Array(Int64)
       add names : Array(String)
-      add dates : Array(Time)
-      add ids : Array(UUID)
     end
   end
 

--- a/db/migrations/20190712145900_create_buckets.cr
+++ b/db/migrations/20190712145900_create_buckets.cr
@@ -2,12 +2,12 @@ class CreateBuckets::V20190712145900 < Avram::Migrator::Migration::V1
   def migrate
     create table_for(Bucket) do
       primary_key id : Int64
-      add bools : Array(Bool)
+      #add bools : Array(Bool)
       #add prices : Array(Float64)
       #add small_numbers : Array(Int16)
       #add numbers : Array(Int32)
       #add big_numbers : Array(Int64)
-      #add names : Array(String)
+      add names : Array(String)
       #add dates : Array(Time)
       #add ids : Array(UUID)
     end

--- a/db/migrations/20190712145900_create_buckets.cr
+++ b/db/migrations/20190712145900_create_buckets.cr
@@ -4,7 +4,6 @@ class CreateBuckets::V20190712145900 < Avram::Migrator::Migration::V1
       primary_key id : Int64
       add_timestamps
       add bools : Array(Bool)
-      add prices : Array(Float64)
       add small_numbers : Array(Int16)
       add numbers : Array(Int32)
       add big_numbers : Array(Int64)

--- a/db/migrations/20190712145900_create_buckets_with_array_types.cr
+++ b/db/migrations/20190712145900_create_buckets_with_array_types.cr
@@ -1,4 +1,4 @@
-class CreateBuckets::V20190712145900 < Avram::Migrator::Migration::V1
+class CreateBucketsWithArrayTypes::V20190712145900 < Avram::Migrator::Migration::V1
   def migrate
     create table_for(Bucket) do
       primary_key id : Int64

--- a/spec/array_column_spec.cr
+++ b/spec/array_column_spec.cr
@@ -1,0 +1,18 @@
+require "./spec_helper"
+
+private class BucketQuery < Bucket::BaseQuery
+end
+
+describe "Array Columns" do
+  it "fails when passing a single value to an array query" do
+    bucket = BucketBox.new.numbers([1, 2, 3]).create
+    expect_raises(PQ::PQError) do
+      BucketQuery.new.numbers(1).select_count
+    end
+  end
+
+  it "returns no results when passing in a proper query that doesn't match" do
+    bucket = BucketBox.new.numbers([1, 2, 3]).create
+    BucketQuery.new.numbers([1]).select_count.should eq 0
+  end
+end

--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -15,6 +15,7 @@ describe Avram::Migrator::AlterTableStatement do
       add updated_at : Time, fill_existing_with: :now
       add future_time : Time, default: Time.local
       add new_id : UUID, default: UUID.new("46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0")
+      add numbers : Array(Int32), fill_existing_with: [1]
       remove :old_column
       remove_belongs_to :employee
     end
@@ -33,11 +34,12 @@ describe Avram::Migrator::AlterTableStatement do
       ADD updated_at timestamptz NOT NULL,
       ADD future_time timestamptz NOT NULL DEFAULT '#{Time.local.to_utc}',
       ADD new_id uuid NOT NULL DEFAULT '46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0',
+      ADD numbers int[] NOT NULL,
       DROP old_column,
       DROP employee_id
     SQL
 
-    built.statements.size.should eq 7
+    built.statements.size.should eq 9
     built.statements[1].should eq "CREATE UNIQUE INDEX users_age_index ON users USING btree (age);"
     built.statements[2].should eq "CREATE INDEX users_num_index ON users USING btree (num);"
     built.statements[3].should eq "UPDATE users SET email = 'noreply@lucky.com';"

--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -8,7 +8,7 @@ describe Avram::Migrator::AlterTableStatement do
       add nickname : String, fill_existing_with: :nothing
       add age : Int32, default: 1, unique: true
       add num : Int64, default: 1, index: true
-      add amount_paid : Float, default: 1.0, precision: 10, scale: 5
+      add amount_paid : Float64, default: 1.0, precision: 10, scale: 5
       add completed : Bool, default: false
       add meta : JSON::Any, default: JSON::Any.new({"default" => JSON::Any.new("value")})
       add joined_at : Time, default: :now

--- a/spec/migrator/create_table_statement_spec.cr
+++ b/spec/migrator/create_table_statement_spec.cr
@@ -102,7 +102,7 @@ describe Avram::Migrator::CreateTableStatement do
       joined_at timestamptz NOT NULL DEFAULT NOW(),
       future_time timestamptz NOT NULL DEFAULT '#{Time.local.to_utc}',
       friend_count smallint NOT NULL DEFAULT '1',
-      friends text[] NOT NULL DEFAULT {'Paul'});
+      friends text[] NOT NULL DEFAULT '["Paul"]');
     SQL
   end
 

--- a/spec/migrator/create_table_statement_spec.cr
+++ b/spec/migrator/create_table_statement_spec.cr
@@ -86,6 +86,7 @@ describe Avram::Migrator::CreateTableStatement do
       add joined_at : Time, default: :now
       add future_time : Time, default: Time.local
       add friend_count : Int16, default: 1
+      add friends : Array(String), default: ["Paul"]
     end
 
     built.statements.size.should eq 1
@@ -100,7 +101,8 @@ describe Avram::Migrator::CreateTableStatement do
       meta jsonb NOT NULL DEFAULT '{}',
       joined_at timestamptz NOT NULL DEFAULT NOW(),
       future_time timestamptz NOT NULL DEFAULT '#{Time.local.to_utc}',
-      friend_count smallint NOT NULL DEFAULT '1');
+      friend_count smallint NOT NULL DEFAULT '1',
+      friends text[] NOT NULL DEFAULT {'Paul'});
     SQL
   end
 

--- a/spec/migrator/create_table_statement_spec.cr
+++ b/spec/migrator/create_table_statement_spec.cr
@@ -19,7 +19,7 @@ describe Avram::Migrator::CreateTableStatement do
       add age : Int32
       add completed : Bool
       add joined_at : Time
-      add amount_paid : Float, precision: 10, scale: 2
+      add amount_paid : Float64, precision: 10, scale: 2
       add email : String?
       add meta : JSON::Any?
       add reference : UUID
@@ -80,7 +80,7 @@ describe Avram::Migrator::CreateTableStatement do
       add email : String?, default: "optional"
       add age : Int32, default: 1
       add num : Int64, default: 1
-      add amount_paid : Float, default: 1.0
+      add amount_paid : Float64, default: 1.0
       add completed : Bool, default: false
       add meta : JSON::Any, default: JSON::Any.new(Hash(String, JSON::Any).new)
       add joined_at : Time, default: :now

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -569,12 +569,14 @@ describe Avram::Query do
 
   context "when querying arrays" do
     describe "simple where query" do
-      bucket = BucketBox.new.names(["pumpkin", "zucchini"]).create
+      it "returns 1 result" do
+        bucket = BucketBox.new.names(["pumpkin", "zucchini"]).create
 
-      query = ArrayQuery.new.names(["pumpkin", "zucchini"])
-      query.to_sql.should eq ["SELECT buckets.id, buckets.created_at, buckets.updated_at, buckets.bools, buckets.prices, buckets.small_numbers, buckets.numbers, buckets.big_numbers, buckets.names FROM buckets WHERE buckets.names = $1", "{\"pumpkin\",\"zucchini\"}"]
-      result = query.first
-      result.should eq bucket
+        query = ArrayQuery.new.names(["pumpkin", "zucchini"])
+        query.to_sql.should eq ["SELECT buckets.id, buckets.created_at, buckets.updated_at, buckets.bools, buckets.small_numbers, buckets.numbers, buckets.big_numbers, buckets.names FROM buckets WHERE buckets.names = $1", "{\"pumpkin\",\"zucchini\"}"]
+        result = query.first
+        result.should eq bucket
+      end
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -20,6 +20,9 @@ class JSONQuery < Blob::BaseQuery
   end
 end
 
+class ArrayQuery < Bucket::BaseQuery
+end
+
 describe Avram::Query do
   it "can chain scope methods" do
     ChainedQuery.new.young.named("Paul")
@@ -561,6 +564,17 @@ describe Avram::Query do
           query3.first
         end
       end
+    end
+  end
+
+  context "when querying arrays" do
+    describe "simple where query" do
+      bucket = BucketBox.new.names(["pumpkin", "zucchini"]).create
+
+      query = ArrayQuery.new.names(["pumpkin", "zucchini"])
+      query.to_sql.should eq ["SELECT buckets.id, buckets.created_at, buckets.updated_at, buckets.bools, buckets.prices, buckets.small_numbers, buckets.numbers, buckets.big_numbers, buckets.names FROM buckets WHERE buckets.names = $1", "{\"pumpkin\",\"zucchini\"}"]
+      result = query.first
+      result.should eq bucket
     end
   end
 

--- a/spec/support/boxes/bucket_box.cr
+++ b/spec/support/boxes/bucket_box.cr
@@ -1,12 +1,12 @@
 class BucketBox < BaseBox
   def initialize
-    # bools [true, false]
-    # prices [39.99, 199.95]
-    # small_numbers [1_i16, 2_i16]
-    # numbers [100, 200]
-    # big_numbers [1000_i64, 2000_i64]
+    bools [true, false]
+    prices [39.99, 199.95]
+    small_numbers [1_i16, 2_i16]
+    numbers [100, 200]
+    big_numbers [1000_i64, 2000_i64]
     names ["Mario", "Luigi"]
-    # dates [Time.utc, Time.utc]
-    # ids [UUID.random, UUID.random]
+    dates [Time.utc, Time.utc]
+    ids [UUID.random, UUID.random]
   end
 end

--- a/spec/support/boxes/bucket_box.cr
+++ b/spec/support/boxes/bucket_box.cr
@@ -1,11 +1,11 @@
 class BucketBox < BaseBox
   def initialize
-    bools [true, false]
+    #bools [true, false]
     #prices [39.99, 199.95]
     #small_numbers [1_i16, 2_i16]
     #numbers [100, 200]
     #big_numbers [1000_i64, 2000_i64]
-    #names ["Mario", "Luigi"]
+    names ["Mario", "Luigi"]
     #dates [Time.utc, Time.utc]
     #ids [UUID.random, UUID.random]
   end

--- a/spec/support/boxes/bucket_box.cr
+++ b/spec/support/boxes/bucket_box.cr
@@ -6,7 +6,5 @@ class BucketBox < BaseBox
     numbers [100, 200]
     big_numbers [1000_i64, 2000_i64]
     names ["Mario", "Luigi"]
-    dates [Time.utc, Time.utc]
-    ids [UUID.random, UUID.random]
   end
 end

--- a/spec/support/boxes/bucket_box.cr
+++ b/spec/support/boxes/bucket_box.cr
@@ -1,12 +1,12 @@
 class BucketBox < BaseBox
   def initialize
     bools [true, false]
-    prices [39.99, 199.95]
-    small_numbers [1_i16, 2_i16]
-    numbers [100, 200]
-    big_numbers [1000_i64, 2000_i64]
-    names ["Mario", "Luigi"]
-    dates [Time.utc, Time.utc]
-    ids [UUID.random, UUID.random]
+    #prices [39.99, 199.95]
+    #small_numbers [1_i16, 2_i16]
+    #numbers [100, 200]
+    #big_numbers [1000_i64, 2000_i64]
+    #names ["Mario", "Luigi"]
+    #dates [Time.utc, Time.utc]
+    #ids [UUID.random, UUID.random]
   end
 end

--- a/spec/support/boxes/bucket_box.cr
+++ b/spec/support/boxes/bucket_box.cr
@@ -1,12 +1,12 @@
 class BucketBox < BaseBox
   def initialize
-    #bools [true, false]
-    #prices [39.99, 199.95]
-    #small_numbers [1_i16, 2_i16]
-    #numbers [100, 200]
-    #big_numbers [1000_i64, 2000_i64]
+    # bools [true, false]
+    # prices [39.99, 199.95]
+    # small_numbers [1_i16, 2_i16]
+    # numbers [100, 200]
+    # big_numbers [1000_i64, 2000_i64]
     names ["Mario", "Luigi"]
-    #dates [Time.utc, Time.utc]
-    #ids [UUID.random, UUID.random]
+    # dates [Time.utc, Time.utc]
+    # ids [UUID.random, UUID.random]
   end
 end

--- a/spec/support/boxes/bucket_box.cr
+++ b/spec/support/boxes/bucket_box.cr
@@ -1,7 +1,6 @@
 class BucketBox < BaseBox
   def initialize
     bools [true, false]
-    prices [39.99, 199.95]
     small_numbers [1_i16, 2_i16]
     numbers [100, 200]
     big_numbers [1000_i64, 2000_i64]

--- a/spec/support/boxes/bucket_box.cr
+++ b/spec/support/boxes/bucket_box.cr
@@ -1,0 +1,12 @@
+class BucketBox < BaseBox
+  def initialize
+    bools [true, false]
+    prices [39.99, 199.95]
+    small_numbers [1_i16, 2_i16]
+    numbers [100, 200]
+    big_numbers [1000_i64, 2000_i64]
+    names ["Mario", "Luigi"]
+    dates [Time.utc, Time.utc]
+    ids [UUID.random, UUID.random]
+  end
+end

--- a/spec/support/bucket.cr
+++ b/spec/support/bucket.cr
@@ -1,11 +1,11 @@
 class Bucket < BaseModel
   table do
-    column bools : Array(Bool)
+    #column bools : Array(Bool)
     #column prices : Array(Float64)
     #column small_numbers : Array(Int16)
     #column numbers : Array(Int32)
     #column big_numbers : Array(Int64)
-    #column names : Array(String)
+    column names : Array(String)
     #column dates : Array(Time)
     #column ids : Array(UUID)
   end

--- a/spec/support/bucket.cr
+++ b/spec/support/bucket.cr
@@ -1,12 +1,12 @@
 class Bucket < BaseModel
   table do
-    #column bools : Array(Bool)
-    #column prices : Array(Float64)
-    #column small_numbers : Array(Int16)
-    #column numbers : Array(Int32)
-    #column big_numbers : Array(Int64)
+    # column bools : Array(Bool)
+    # column prices : Array(Float64)
+    # column small_numbers : Array(Int16)
+    # column numbers : Array(Int32)
+    # column big_numbers : Array(Int64)
     column names : Array(String)
-    #column dates : Array(Time)
-    #column ids : Array(UUID)
+    # column dates : Array(Time)
+    # column ids : Array(UUID)
   end
 end

--- a/spec/support/bucket.cr
+++ b/spec/support/bucket.cr
@@ -1,7 +1,6 @@
 class Bucket < BaseModel
   table do
     column bools : Array(Bool)
-    column prices : Array(Float64)
     column small_numbers : Array(Int16)
     column numbers : Array(Int32)
     column big_numbers : Array(Int64)

--- a/spec/support/bucket.cr
+++ b/spec/support/bucket.cr
@@ -1,0 +1,12 @@
+class Bucket < BaseModel
+  table do
+    column bools : Array(Bool)
+    column prices : Array(Float64)
+    column small_numbers : Array(Int16)
+    column numbers : Array(Int32)
+    column big_numbers : Array(Int64)
+    column names : Array(String)
+    column dates : Array(Time)
+    column ids : Array(UUID)
+  end
+end

--- a/spec/support/bucket.cr
+++ b/spec/support/bucket.cr
@@ -1,12 +1,12 @@
 class Bucket < BaseModel
   table do
-    # column bools : Array(Bool)
-    # column prices : Array(Float64)
-    # column small_numbers : Array(Int16)
-    # column numbers : Array(Int32)
-    # column big_numbers : Array(Int64)
+    column bools : Array(Bool)
+    column prices : Array(Float64)
+    column small_numbers : Array(Int16)
+    column numbers : Array(Int32)
+    column big_numbers : Array(Int64)
     column names : Array(String)
-    # column dates : Array(Time)
-    # column ids : Array(UUID)
+    column dates : Array(Time)
+    column ids : Array(UUID)
   end
 end

--- a/spec/support/bucket.cr
+++ b/spec/support/bucket.cr
@@ -1,12 +1,12 @@
 class Bucket < BaseModel
   table do
     column bools : Array(Bool)
-    column prices : Array(Float64)
-    column small_numbers : Array(Int16)
-    column numbers : Array(Int32)
-    column big_numbers : Array(Int64)
-    column names : Array(String)
-    column dates : Array(Time)
-    column ids : Array(UUID)
+    #column prices : Array(Float64)
+    #column small_numbers : Array(Int16)
+    #column numbers : Array(Int32)
+    #column big_numbers : Array(Int64)
+    #column names : Array(String)
+    #column dates : Array(Time)
+    #column ids : Array(UUID)
   end
 end

--- a/spec/support/bucket.cr
+++ b/spec/support/bucket.cr
@@ -6,7 +6,5 @@ class Bucket < BaseModel
     column numbers : Array(Int32)
     column big_numbers : Array(Int64)
     column names : Array(String)
-    column dates : Array(Time)
-    column ids : Array(UUID)
   end
 end

--- a/spec/type_extensions/array_spec.cr
+++ b/spec/type_extensions/array_spec.cr
@@ -1,0 +1,39 @@
+require "../spec_helper"
+
+describe "Array" do
+  it "parses Array(Bool) from Array(String)" do
+    result = Bool::Lucky.parse(["true"])
+    result.value.should eq([true])
+  end
+
+  it "parses Array(String)" do
+    result = String::Lucky.parse(["test"])
+    result.value.should eq(["test"])
+  end
+
+  it "parses Array(Int32) from Array(String)" do
+    result = Int32::Lucky.parse(["10"])
+    result.value.should eq([10])
+  end
+
+  it "parses Array(Int16) from Array(String)" do
+    result = Int16::Lucky.parse(["1"])
+    result.value.should eq([1_i16])
+  end
+
+  it "parses Array(Int64) from Array(String)" do
+    result = Int64::Lucky.parse(["1000"])
+    result.value.should eq([1000_i64])
+  end
+
+  it "parses Array(UUID) from Array(String)" do
+    result = UUID::Lucky.parse(["f51a73d5-bb75-465a-8f8b-d213658dfc63"])
+    result.value.should eq([UUID.new("f51a73d5-bb75-465a-8f8b-d213658dfc63")])
+  end
+
+  it "parses Array(Time) from Array(String)" do
+    result = Time::Lucky.parse(["2019-07-16 14:42:12"])
+    time = Time.parse_utc("2019-07-16 14:42:12", "%Y-%m-%d %H:%M:%S")
+    result.value.should eq([time])
+  end
+end

--- a/spec/type_extensions/array_spec.cr
+++ b/spec/type_extensions/array_spec.cr
@@ -25,15 +25,4 @@ describe "Array" do
     result = Int64::Lucky.parse(["1000"])
     result.value.should eq([1000_i64])
   end
-
-  it "parses Array(UUID) from Array(String)" do
-    result = UUID::Lucky.parse(["f51a73d5-bb75-465a-8f8b-d213658dfc63"])
-    result.value.should eq([UUID.new("f51a73d5-bb75-465a-8f8b-d213658dfc63")])
-  end
-
-  it "parses Array(Time) from Array(String)" do
-    result = Time::Lucky.parse(["2019-07-16 14:42:12"])
-    time = Time.parse_utc("2019-07-16 14:42:12", "%Y-%m-%d %H:%M:%S")
-    result.value.should eq([time])
-  end
 end

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -35,6 +35,7 @@ class Avram::BaseQueryTemplate
         end
 
         {% if column[:type].is_a?(Generic) %}
+          # Checking Array type
           generate_criteria_method(BaseQuery, {{ column[:name] }}, {{ column[:type].type_vars.first }})
 
           macro inherited

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -25,7 +25,7 @@ class Avram::BaseQueryTemplate
       macro generate_criteria_method(query_class, name, type)
         def \{{ name }}
           column_name = "#{@@table_name}.\{{ name }}"
-          \{{ type }}::Lucky::Criteria(\{{ query_class }}, \{{ type }}).new(self, "#{@@table_name}.\{{ name }}")
+          \{{ type }}::Lucky::Criteria(\{{ query_class }}, \{{ type }}).new(self, column_name)
         end
       end
 
@@ -34,11 +34,19 @@ class Avram::BaseQueryTemplate
           {{ column[:name] }}.eq(value)
         end
 
-        generate_criteria_method(BaseQuery, {{ column[:name] }}, {{ column[:type] }})
+        {% if column[:type].is_a?(Generic) %}
+          generate_criteria_method(BaseQuery, {{ column[:name] }}, {{ column[:type].type_vars.first }})
 
-        macro inherited
-          generate_criteria_method(\{{ @type.name }}, {{ column[:name] }}, {{ column[:type] }})
-        end
+          macro inherited
+            generate_criteria_method(\{{ @type.name }}, {{ column[:name] }}, {{ column[:type].type_vars.first }})
+          end
+        {% else %}
+          generate_criteria_method(BaseQuery, {{ column[:name] }}, {{ column[:type] }})
+
+          macro inherited
+            generate_criteria_method(\{{ @type.name }}, {{ column[:name] }}, {{ column[:type] }})
+          end
+        {% end %}
       {% end %}
 
       {% for assoc in associations %}

--- a/src/avram/blank_extensions.cr
+++ b/src/avram/blank_extensions.cr
@@ -1,3 +1,9 @@
+struct Bool
+  def blank?
+    false
+  end
+end
+
 struct Time
   def blank?
     nil?
@@ -37,5 +43,17 @@ end
 struct JSON::Any
   def blank?
     nil?
+  end
+end
+
+struct UUID
+  def blank?
+    false
+  end
+end
+
+class Array(T)
+  def blank?
+    empty?
   end
 end

--- a/src/avram/charms/array_extensions.cr
+++ b/src/avram/charms/array_extensions.cr
@@ -1,0 +1,8 @@
+class Array(T)
+
+  # Proxy to the `T`'s adapter so we can call methods like
+  # `Array(String).adapter.to_db(["test"])`
+  def self.adapter
+    T::Lucky
+  end
+end

--- a/src/avram/charms/array_extensions.cr
+++ b/src/avram/charms/array_extensions.cr
@@ -1,5 +1,4 @@
 class Array(T)
-
   # Proxy to the `T`'s adapter so we can call methods like
   # `Array(String).adapter.to_db(["test"])`
   def self.adapter

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -7,7 +7,7 @@ struct Bool
     alias ColumnType = Bool
     include Avram::Type
 
-    def self.parse(value : String)
+    def parse(value : String)
       if %w(true 1).includes? value
         SuccessfulCast(Bool).new true
       elsif %w(false 0).includes? value
@@ -17,11 +17,20 @@ struct Bool
       end
     end
 
-    def self.parse(value : Bool)
+    def parse(value : Bool)
       SuccessfulCast(Bool).new value
     end
 
-    def self.to_db(value : Bool)
+    def parse(values : Array(Bool))
+      SuccessfulCast(Array(Bool)).new values
+    end
+
+    def parse(values : Array(String))
+      values = values.map {|value| parse(value).value }.as(Array(Bool))
+      parse(values)
+    end
+
+    def to_db(value : Bool)
       value.to_s
     end
 

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -25,11 +25,6 @@ struct Bool
       SuccessfulCast(Array(Bool)).new values
     end
 
-    def parse(values : Array(String))
-      values = values.map {|value| parse(value).value }.as(Array(Bool))
-      parse(values)
-    end
-
     def to_db(value : Bool)
       value.to_s
     end

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -1,6 +1,6 @@
 struct Bool
-  def blank?
-    false
+  def self.adapter
+    Lucky
   end
 
   module Lucky
@@ -27,6 +27,10 @@ struct Bool
 
     def to_db(value : Bool)
       value.to_s
+    end
+
+    def to_db(values : Array(Bool))
+      PQ::Param.encode_array(values)
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -29,11 +29,6 @@ struct Float64
       FailedCast.new
     end
 
-    def parse(values : Array(String))
-      values = values.map {|value| parse(value).value }.as(Array(Float64))
-      parse(values)
-    end
-
     def parse(value : Int32)
       SuccessfulCast(Float64).new value.to_f64
     end

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -1,4 +1,8 @@
 struct Float64
+  def self.adapter
+    Lucky
+  end
+
   module Lucky
     alias ColumnType = Float64
     include Avram::Type
@@ -39,6 +43,10 @@ struct Float64
 
     def to_db(value : Float64)
       value.to_s
+    end
+
+    def to_db(values : Array(Float64))
+      PQ::Param.encode_array(values)
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -3,37 +3,46 @@ struct Float64
     alias ColumnType = Float64
     include Avram::Type
 
-    def self.from_db!(value : Float64)
+    def from_db!(value : Float64)
       value
     end
 
-    def self.from_db!(value : PG::Numeric)
+    def from_db!(value : PG::Numeric)
       value.to_f
     end
 
-    def self.parse(value : Float64)
+    def parse(value : Float64)
       SuccessfulCast(Float64).new(value)
     end
 
-    def self.parse(value : PG::Numeric)
+    def parse(values : Array(Float64))
+      SuccessfulCast(Array(Float64)).new values
+    end
+
+    def parse(value : PG::Numeric)
       SuccessfulCast(Float64).new(value.to_f)
     end
 
-    def self.parse(value : String)
+    def parse(value : String)
       SuccessfulCast(Float64).new value.to_f64
     rescue ArgumentError
       FailedCast.new
     end
 
-    def self.parse(value : Int32)
+    def parse(values : Array(String))
+      values = values.map {|value| parse(value).value }.as(Array(Float64))
+      parse(values)
+    end
+
+    def parse(value : Int32)
       SuccessfulCast(Float64).new value.to_f64
     end
 
-    def self.parse(value : Int64)
+    def parse(value : Int64)
       SuccessfulCast(Float64).new value.to_f64
     end
 
-    def self.to_db(value : Float64)
+    def to_db(value : Float64)
       value.to_s
     end
 

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -1,4 +1,8 @@
 struct Int16
+  def self.adapter
+    Lucky
+  end
+
   module Lucky
     alias ColumnType = Int16
     include Avram::Type
@@ -27,6 +31,10 @@ struct Int16
 
     def to_db(value : Int16)
       value.to_s
+    end
+
+    def to_db(values : Array(Int16))
+      PQ::Param.encode_array(values)
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -21,11 +21,6 @@ struct Int16
       FailedCast.new
     end
 
-    def parse(values : Array(String))
-      values = values.map {|value| parse(value).value }.as(Array(Int16))
-      parse(values)
-    end
-
     def parse(value : Int32)
       SuccessfulCast(Int16).new value.to_i16
     end

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -3,25 +3,34 @@ struct Int16
     alias ColumnType = Int16
     include Avram::Type
 
-    def self.from_db!(value : Int16)
+    def from_db!(value : Int16)
       value
     end
 
-    def self.parse(value : Int16)
+    def parse(value : Int16)
       SuccessfulCast(Int16).new(value)
     end
 
-    def self.parse(value : String)
+    def parse(values : Array(Int16))
+      SuccessfulCast(Array(Int16)).new values
+    end
+
+    def parse(value : String)
       SuccessfulCast(Int16).new value.to_i16
     rescue ArgumentError
       FailedCast.new
     end
 
-    def self.parse(value : Int32)
+    def parse(values : Array(String))
+      values = values.map {|value| parse(value).value }.as(Array(Int16))
+      parse(values)
+    end
+
+    def parse(value : Int32)
       SuccessfulCast(Int16).new value.to_i16
     end
 
-    def self.to_db(value : Int16)
+    def to_db(value : Int16)
       value.to_s
     end
 

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -13,11 +13,6 @@ struct Int32
       FailedCast.new
     end
 
-    def parse(values : Array(String))
-      values = values.map {|value| parse(value).value }.as(Array(Int32))
-      parse(values)
-    end
-
     def parse(value : Int32)
       SuccessfulCast(Int32).new(value)
     end

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -1,4 +1,8 @@
 struct Int32
+  def self.adapter
+    Lucky
+  end
+
   module Lucky
     alias ColumnType = Int32
     include Avram::Type
@@ -23,6 +27,10 @@ struct Int32
 
     def to_db(value : Int32)
       value.to_s
+    end
+
+    def to_db(values : Array(Int32))
+      PQ::Param.encode_array(values)
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -3,21 +3,30 @@ struct Int32
     alias ColumnType = Int32
     include Avram::Type
 
-    def self.from_db!(value : Int32)
+    def from_db!(value : Int32)
       value
     end
 
-    def self.parse(value : String)
+    def parse(value : String)
       SuccessfulCast(Int32).new value.to_i
     rescue ArgumentError
       FailedCast.new
     end
 
-    def self.parse(value : Int32)
+    def parse(values : Array(String))
+      values = values.map {|value| parse(value).value }.as(Array(Int32))
+      parse(values)
+    end
+
+    def parse(value : Int32)
       SuccessfulCast(Int32).new(value)
     end
 
-    def self.to_db(value : Int32)
+    def parse(values : Array(Int32))
+      SuccessfulCast(Array(Int32)).new values
+    end
+
+    def to_db(value : Int32)
       value.to_s
     end
 

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -3,25 +3,34 @@ struct Int64
     alias ColumnType = Int64
     include Avram::Type
 
-    def self.from_db!(value : Int64)
+    def from_db!(value : Int64)
       value
     end
 
-    def self.parse(value : Int64)
+    def parse(value : Int64)
       SuccessfulCast(Int64).new(value)
     end
 
-    def self.parse(value : String)
+    def parse(values : Array(Int64))
+      SuccessfulCast(Array(Int64)).new values
+    end
+
+    def parse(value : String)
       SuccessfulCast(Int64).new value.to_i64
     rescue ArgumentError
       FailedCast.new
     end
 
-    def self.parse(value : Int32)
+    def parse(values : Array(String))
+      values = values.map {|value| parse(value).value }.as(Array(Int64))
+      parse(values)
+    end
+
+    def parse(value : Int32)
       SuccessfulCast(Int64).new value.to_i64
     end
 
-    def self.to_db(value : Int64)
+    def to_db(value : Int64)
       value.to_s
     end
 

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -21,11 +21,6 @@ struct Int64
       FailedCast.new
     end
 
-    def parse(values : Array(String))
-      values = values.map {|value| parse(value).value }.as(Array(Int64))
-      parse(values)
-    end
-
     def parse(value : Int32)
       SuccessfulCast(Int64).new value.to_i64
     end

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -1,4 +1,8 @@
 struct Int64
+  def self.adapter
+    Lucky
+  end
+
   module Lucky
     alias ColumnType = Int64
     include Avram::Type
@@ -27,6 +31,10 @@ struct Int64
 
     def to_db(value : Int64)
       value.to_s
+    end
+
+    def to_db(values : Array(Int64))
+      PQ::Param.encode_array(values)
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -3,19 +3,19 @@ struct JSON::Any
     alias ColumnType = JSON::Any
     include Avram::Type
 
-    def self.from_db!(value : JSON::Any)
+    def from_db!(value : JSON::Any)
       value
     end
 
-    def self.parse(value : JSON::Any)
+    def parse(value : JSON::Any)
       SuccessfulCast(JSON::Any).new value
     end
 
-    def self.parse(value)
+    def parse(value)
       SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
     end
 
-    def self.to_db(value)
+    def to_db(value)
       value.to_json
     end
 

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -1,4 +1,8 @@
 struct JSON::Any
+  def self.adapter
+    Lucky
+  end
+
   module Lucky
     alias ColumnType = JSON::Any
     include Avram::Type

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -1,4 +1,8 @@
 class String
+  def self.adapter
+    Lucky
+  end
+
   module Lucky
     alias ColumnType = String
     include Avram::Type
@@ -13,6 +17,10 @@ class String
 
     def to_db(value : String)
       value
+    end
+
+    def to_db(values : Array(String))
+      PQ::Param.encode_array(values)
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -7,6 +7,10 @@ class String
       SuccessfulCast(String).new(value)
     end
 
+    def parse(values : Array(String))
+      SuccessfulCast(Array(String)).new(values)
+    end
+
     def to_db(value : String)
       value
     end

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -14,17 +14,22 @@ struct Time
       Time::Format::ISO_8601_TIME,
     ]
 
-    def self.from_db!(value : Time)
+    def from_db!(value : Time)
       value
     end
 
-    def self.parse(value : String) : SuccessfulCast(Time) | FailedCast
+    def parse(value : String) : SuccessfulCast(Time) | FailedCast
       # Prefer user defined string formats
       try_parsing_with_string_formats(value) ||
         # Then try default formats
         try_parsing_with_default_formatters(value) ||
         # Fail if none of them work
         FailedCast.new
+    end
+
+    def parse(values : Array(String))
+      values = values.map {|value| parse(value).value }.as(Array(Time))
+      parse(values)
     end
 
     def self.try_parsing_with_default_formatters(value : String)
@@ -51,11 +56,15 @@ struct Time
       end
     end
 
-    def self.parse(value : Time)
+    def parse(value : Time)
       SuccessfulCast(Time).new value
     end
 
-    def self.to_db(value : Time)
+    def parse(values : Array(Time))
+      SuccessfulCast(Array(Time)).new values
+    end
+
+    def to_db(value : Time)
       value.to_s
     end
 

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -1,4 +1,8 @@
 struct Time
+  def self.adapter
+    Lucky
+  end
+
   module Lucky
     alias ColumnType = Time
     include Avram::Type

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -27,11 +27,6 @@ struct Time
         FailedCast.new
     end
 
-    def parse(values : Array(String))
-      values = values.map {|value| parse(value).value }.as(Array(Time))
-      parse(values)
-    end
-
     def self.try_parsing_with_default_formatters(value : String)
       TIME_FORMATS.find do |format|
         begin

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -11,10 +11,19 @@ struct UUID
       SuccessfulCast(UUID).new(value)
     end
 
+    def parse(values : Array(UUID))
+      SuccessfulCast(Array(UUID)).new values
+    end
+
     def parse(value : String)
       SuccessfulCast(UUID).new(UUID.new(value))
     rescue
       FailedCast.new
+    end
+
+    def parse(values : Array(String))
+      values = values.map {|value| parse(value).value }.as(Array(UUID))
+      parse(values)
     end
 
     def to_db(value : UUID)

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -21,11 +21,6 @@ struct UUID
       FailedCast.new
     end
 
-    def parse(values : Array(String))
-      values = values.map {|value| parse(value).value }.as(Array(UUID))
-      parse(values)
-    end
-
     def to_db(value : UUID)
       value.to_s
     end

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -1,6 +1,6 @@
 struct UUID
-  def blank?
-    false
+  def self.adapter
+    Lucky
   end
 
   module Lucky

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -83,9 +83,15 @@ class Avram::Migrator::AlterTableStatement
     {% if type_declaration.type.is_a?(Union) %}
       {% type = type_declaration.type.types.first %}
       {% nilable = true %}
+      {% array = false %}
+    {% elsif type_declaration.type.is_a?(Generic) %}
+      {% type = type_declaration.type.type_vars.first %}
+      {% nilable = false %}
+      {% array = true %}
     {% else %}
       {% type = type_declaration.type %}
       {% nilable = false %}
+      {% array = false %}
     {% end %}
 
     {% if !nilable && default == nil && fill_existing_with == nil %}
@@ -112,6 +118,9 @@ class Avram::Migrator::AlterTableStatement
       default: {{ default }},
       {{ **type_options }}
     )
+    {% if array %}
+    .array!
+    {% end %}
     .build_add_statement_for_alter
 
     {% if fill_existing_with && fill_existing_with != :nothing %}

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -63,7 +63,7 @@ class Avram::Migrator::AlterTableStatement
     {% foreign_key_name = type_declaration.var + "_id" %}
     %table_name = {{ references }} || Wordsmith::Inflector.pluralize({{ underscored_class }})
 
-    rows << ::Avram::Migrator::Columns::{{ foreign_key_type }}Column.new(
+    rows << ::Avram::Migrator::Columns::{{ foreign_key_type }}Column({{ foreign_key_type }}).new(
       name: {{ foreign_key_name.stringify }},
       nilable: {{ optional }},
       default: nil
@@ -112,7 +112,9 @@ class Avram::Migrator::AlterTableStatement
       {% type_declaration.raise "Cannot use both 'default' and 'fill_existing_with' arguments" %}
     {% end %}
 
-    rows << Avram::Migrator::Columns::{{ type }}Column.new(
+    rows << Avram::Migrator::Columns::{{ type }}Column(
+    {% if array %}Array({% end %}{{ type }}{% if array %}){% end %}
+    ).new(
       name: {{ type_declaration.var.stringify }},
       nilable: {{ nilable }},
       default: {{ default }},

--- a/src/avram/migrator/columns/base.cr
+++ b/src/avram/migrator/columns/base.cr
@@ -27,6 +27,7 @@ abstract class Avram::Migrator::Columns::Base
 
   def array!
     @array = true
+    self
   end
 
   def build_add_statement_for_alter : String

--- a/src/avram/migrator/columns/base.cr
+++ b/src/avram/migrator/columns/base.cr
@@ -4,7 +4,7 @@ abstract class Avram::Migrator::Columns::Base
 
   macro inherited
     @name : String
-    @array : Bool = false
+    @array : Bool?
     @nilable : Bool?
     @references : String?
     @on_delete : Symbol?
@@ -23,6 +23,10 @@ abstract class Avram::Migrator::Columns::Base
 
   def set_references(@references, @on_delete)
     {% raise "When setting a reference you must set the reference table and the 'on_delete' option." %}
+  end
+
+  def array!
+    @array = true
   end
 
   def build_add_statement_for_alter : String

--- a/src/avram/migrator/columns/base.cr
+++ b/src/avram/migrator/columns/base.cr
@@ -4,6 +4,7 @@ abstract class Avram::Migrator::Columns::Base
 
   macro inherited
     @name : String
+    @array : Bool = false
     @nilable : Bool?
     @references : String?
     @on_delete : Symbol?
@@ -32,11 +33,15 @@ abstract class Avram::Migrator::Columns::Base
     "  " + build_add_statement
   end
 
+  def as_array_type : String
+    @array ? "[]" : ""
+  end
+
   private def build_add_statement : String
     String.build do |row|
       row << name.to_s
       row << " "
-      row << column_type
+      row << column_type + as_array_type
       row << null_fragment
       row << default_fragment unless default.nil?
       row << references_fragment unless references.nil?

--- a/src/avram/migrator/columns/bool_column.cr
+++ b/src/avram/migrator/columns/bool_column.cr
@@ -2,7 +2,7 @@ require "./base"
 
 module Avram::Migrator::Columns
   class BoolColumn < Base
-    @default : Bool? = nil
+    @default : Array(Bool) | Bool | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/bool_column.cr
+++ b/src/avram/migrator/columns/bool_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class BoolColumn < Base
     @default : Bool? = nil
 
-    def initialize(@name, @nilable, @default, @array)
+    def initialize(@name, @nilable, @default)
     end
 
     def column_type

--- a/src/avram/migrator/columns/bool_column.cr
+++ b/src/avram/migrator/columns/bool_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class BoolColumn < Base
     @default : Bool? = nil
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @array)
     end
 
     def column_type

--- a/src/avram/migrator/columns/bool_column.cr
+++ b/src/avram/migrator/columns/bool_column.cr
@@ -1,8 +1,8 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class BoolColumn < Base
-    @default : Array(Bool) | Bool | Nil = nil
+  class BoolColumn(T) < Base
+    @default : T | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/float_column.cr
+++ b/src/avram/migrator/columns/float_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class FloatColumn < Base
     private getter precision, scale
 
-    @default : Float64 | Float32 | Nil = nil
+    @default : Array(Float64) | Float64 | Float32 | Nil = nil
     @precision : Int32?
     @scale : Int32?
 

--- a/src/avram/migrator/columns/float_column.cr
+++ b/src/avram/migrator/columns/float_column.cr
@@ -1,10 +1,10 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class FloatColumn < Base
+  class FloatColumn(T) < Base
     private getter precision, scale
 
-    @default : Array(Float64) | Float64 | Float32 | Nil = nil
+    @default : T | Float32 | Nil = nil
     @precision : Int32?
     @scale : Int32?
 
@@ -23,9 +23,9 @@ module Avram::Migrator::Columns
     end
   end
 
-  class Float32Column < FloatColumn
+  class Float32Column(T) < FloatColumn(T)
   end
 
-  class Float64Column < FloatColumn
+  class Float64Column(T) < FloatColumn(T)
   end
 end

--- a/src/avram/migrator/columns/float_column.cr
+++ b/src/avram/migrator/columns/float_column.cr
@@ -11,7 +11,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default, @precision, @scale)
     end
 
-    def initialize(@name, @nilable, @default, @array)
+    def initialize(@name, @nilable, @default)
     end
 
     def column_type

--- a/src/avram/migrator/columns/float_column.cr
+++ b/src/avram/migrator/columns/float_column.cr
@@ -1,7 +1,7 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class FloatColumn(T) < Base
+  abstract class FloatColumn(T) < Base
     private getter precision, scale
 
     @default : T | Float32 | Nil = nil

--- a/src/avram/migrator/columns/float_column.cr
+++ b/src/avram/migrator/columns/float_column.cr
@@ -11,7 +11,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default, @precision, @scale)
     end
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @array)
     end
 
     def column_type

--- a/src/avram/migrator/columns/int16_column.cr
+++ b/src/avram/migrator/columns/int16_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class Int16Column < Base
     @default : Int16 | Int32 | Nil = nil
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @array)
     end
 
     def column_type

--- a/src/avram/migrator/columns/int16_column.cr
+++ b/src/avram/migrator/columns/int16_column.cr
@@ -2,7 +2,7 @@ require "./base"
 
 module Avram::Migrator::Columns
   class Int16Column < Base
-    @default : Int16 | Int32 | Nil = nil
+    @default : Array(Int16) | Int16 | Int32 | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/int16_column.cr
+++ b/src/avram/migrator/columns/int16_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class Int16Column < Base
     @default : Int16 | Int32 | Nil = nil
 
-    def initialize(@name, @nilable, @default, @array)
+    def initialize(@name, @nilable, @default)
     end
 
     def column_type

--- a/src/avram/migrator/columns/int16_column.cr
+++ b/src/avram/migrator/columns/int16_column.cr
@@ -1,8 +1,8 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class Int16Column < Base
-    @default : Array(Int16) | Int16 | Int32 | Nil = nil
+  class Int16Column(T) < Base
+    @default : T | Int32 | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/int32_column.cr
+++ b/src/avram/migrator/columns/int32_column.cr
@@ -1,8 +1,8 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class Int32Column < Base
-    @default : Array(Int32) | Int32 | Nil = nil
+  class Int32Column(T) < Base
+    @default : T | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/int32_column.cr
+++ b/src/avram/migrator/columns/int32_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class Int32Column < Base
     @default : Int32? = nil
 
-    def initialize(@name, @nilable, @default, @array)
+    def initialize(@name, @nilable, @default)
     end
 
     def column_type

--- a/src/avram/migrator/columns/int32_column.cr
+++ b/src/avram/migrator/columns/int32_column.cr
@@ -2,7 +2,7 @@ require "./base"
 
 module Avram::Migrator::Columns
   class Int32Column < Base
-    @default : Int32? = nil
+    @default : Array(Int32) | Int32 | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/int32_column.cr
+++ b/src/avram/migrator/columns/int32_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class Int32Column < Base
     @default : Int32? = nil
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @array)
     end
 
     def column_type

--- a/src/avram/migrator/columns/int64_column.cr
+++ b/src/avram/migrator/columns/int64_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class Int64Column < Base
     @default : Int64 | Int32 | Nil = nil
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @array)
     end
 
     def column_type

--- a/src/avram/migrator/columns/int64_column.cr
+++ b/src/avram/migrator/columns/int64_column.cr
@@ -1,8 +1,8 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class Int64Column < Base
-    @default : Array(Int64) | Int64 | Int32 | Nil = nil
+  class Int64Column(T) < Base
+    @default : T | Int32 | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/int64_column.cr
+++ b/src/avram/migrator/columns/int64_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class Int64Column < Base
     @default : Int64 | Int32 | Nil = nil
 
-    def initialize(@name, @nilable, @default, @array)
+    def initialize(@name, @nilable, @default)
     end
 
     def column_type

--- a/src/avram/migrator/columns/int64_column.cr
+++ b/src/avram/migrator/columns/int64_column.cr
@@ -2,7 +2,7 @@ require "./base"
 
 module Avram::Migrator::Columns
   class Int64Column < Base
-    @default : Int64 | Int32 | Nil = nil
+    @default : Array(Int64) | Int64 | Int32 | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/json_column.cr
+++ b/src/avram/migrator/columns/json_column.cr
@@ -1,7 +1,7 @@
 require "./base"
 
 module Avram::Migrator::Columns::JSON
-  class AnyColumn < Base
+  class AnyColumn(T) < Base
     @default : ::JSON::Any? = nil
 
     def initialize(@name, @nilable, @default)

--- a/src/avram/migrator/columns/string_column.cr
+++ b/src/avram/migrator/columns/string_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class StringColumn < Base
     @default : String? = nil
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @array)
     end
 
     def column_type

--- a/src/avram/migrator/columns/string_column.cr
+++ b/src/avram/migrator/columns/string_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class StringColumn < Base
     @default : String? = nil
 
-    def initialize(@name, @nilable, @default, @array)
+    def initialize(@name, @nilable, @default)
     end
 
     def column_type

--- a/src/avram/migrator/columns/string_column.cr
+++ b/src/avram/migrator/columns/string_column.cr
@@ -1,8 +1,8 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class StringColumn < Base
-    @default : Array(String) | String | Nil = nil
+  class StringColumn(T) < Base
+    @default : T | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/string_column.cr
+++ b/src/avram/migrator/columns/string_column.cr
@@ -2,7 +2,7 @@ require "./base"
 
 module Avram::Migrator::Columns
   class StringColumn < Base
-    @default : String? = nil
+    @default : (Array(String) | String | Nil) = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/string_column.cr
+++ b/src/avram/migrator/columns/string_column.cr
@@ -2,7 +2,7 @@ require "./base"
 
 module Avram::Migrator::Columns
   class StringColumn < Base
-    @default : (Array(String) | String | Nil) = nil
+    @default : Array(String) | String | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/time_column.cr
+++ b/src/avram/migrator/columns/time_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class TimeColumn < Base
     @default : Time | Symbol | Nil = nil
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @array)
     end
 
     def column_type

--- a/src/avram/migrator/columns/time_column.cr
+++ b/src/avram/migrator/columns/time_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class TimeColumn < Base
     @default : Time | Symbol | Nil = nil
 
-    def initialize(@name, @nilable, @default, @array)
+    def initialize(@name, @nilable, @default)
     end
 
     def column_type

--- a/src/avram/migrator/columns/time_column.cr
+++ b/src/avram/migrator/columns/time_column.cr
@@ -2,7 +2,7 @@ require "./base"
 
 module Avram::Migrator::Columns
   class TimeColumn < Base
-    @default : Time | Symbol | Nil = nil
+    @default : Array(Time) | Time | Symbol | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/time_column.cr
+++ b/src/avram/migrator/columns/time_column.cr
@@ -1,8 +1,8 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class TimeColumn < Base
-    @default : Array(Time) | Time | Symbol | Nil = nil
+  class TimeColumn(T) < Base
+    @default : T | Symbol | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/uuid_column.cr
+++ b/src/avram/migrator/columns/uuid_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class UUIDColumn < Base
     @default : UUID? = nil
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @array)
     end
 
     def column_type

--- a/src/avram/migrator/columns/uuid_column.cr
+++ b/src/avram/migrator/columns/uuid_column.cr
@@ -4,7 +4,7 @@ module Avram::Migrator::Columns
   class UUIDColumn < Base
     @default : UUID? = nil
 
-    def initialize(@name, @nilable, @default, @array)
+    def initialize(@name, @nilable, @default)
     end
 
     def column_type

--- a/src/avram/migrator/columns/uuid_column.cr
+++ b/src/avram/migrator/columns/uuid_column.cr
@@ -2,7 +2,7 @@ require "./base"
 
 module Avram::Migrator::Columns
   class UUIDColumn < Base
-    @default : UUID? = nil
+    @default : Array(UUID) | UUID | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/columns/uuid_column.cr
+++ b/src/avram/migrator/columns/uuid_column.cr
@@ -1,8 +1,8 @@
 require "./base"
 
 module Avram::Migrator::Columns
-  class UUIDColumn < Base
-    @default : Array(UUID) | UUID | Nil = nil
+  class UUIDColumn(T) < Base
+    @default : T | Nil = nil
 
     def initialize(@name, @nilable, @default)
     end

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -80,7 +80,7 @@ class Avram::Migrator::CreateTableStatement
       {% nilable = true %}
       {% array = false %}
     {% elsif type_declaration.type.is_a?(Generic) %}
-      {% type = type_declaraion.type_vars.first %}
+      {% type = type_declaraion.type.type_vars.first %}
       {% nilable = false %}
       {% array = true %}
     {% else %}
@@ -92,10 +92,12 @@ class Avram::Migrator::CreateTableStatement
     rows << Avram::Migrator::Columns::{{ type }}Column.new(
       name: {{ type_declaration.var.stringify }},
       nilable: {{ nilable }},
-      default: {{ default }},
-      array: {{ array }}
+      default: {{ default }}
       {{ **type_options }}
     )
+    {% if array %}
+    .array!
+    {% end %}
     .build_add_statement_for_create
 
     {% if index || unique %}

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -78,15 +78,22 @@ class Avram::Migrator::CreateTableStatement
     {% if type_declaration.type.is_a?(Union) %}
       {% type = type_declaration.type.types.first %}
       {% nilable = true %}
+      {% array = false %}
+    {% elsif type_declaration.type.is_a?(Generic) %}
+      {% type = type_declaraion.type_vars.first %}
+      {% nilable = false %}
+      {% array = true %}
     {% else %}
       {% type = type_declaration.type %}
       {% nilable = false %}
+      {% array = false %}
     {% end %}
 
     rows << Avram::Migrator::Columns::{{ type }}Column.new(
       name: {{ type_declaration.var.stringify }},
       nilable: {{ nilable }},
       default: {{ default }},
+      array: {{ array }}
       {{ **type_options }}
     )
     .build_add_statement_for_create

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -89,7 +89,9 @@ class Avram::Migrator::CreateTableStatement
       {% array = false %}
     {% end %}
 
-    rows << Avram::Migrator::Columns::{{ type }}Column.new(
+    rows << Avram::Migrator::Columns::{{ type }}Column(
+    {% if array %}Array({% end %}{{ type }}{% if array %}){% end %}
+    ).new(
       name: {{ type_declaration.var.stringify }},
       nilable: {{ nilable }},
       default: {{ default }},
@@ -121,7 +123,7 @@ class Avram::Migrator::CreateTableStatement
     {% foreign_key_name = type_declaration.var + "_id" %}
     %table_name = {{ references }} || Wordsmith::Inflector.pluralize({{ underscored_class }})
 
-    rows << Avram::Migrator::Columns::{{ foreign_key_type }}Column.new(
+    rows << Avram::Migrator::Columns::{{ foreign_key_type }}Column({{ foreign_key_type }}).new(
       name: {{ foreign_key_name.stringify }},
       nilable: {{ optional }},
       default: nil,

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -80,7 +80,7 @@ class Avram::Migrator::CreateTableStatement
       {% nilable = true %}
       {% array = false %}
     {% elsif type_declaration.type.is_a?(Generic) %}
-      {% type = type_declaraion.type.type_vars.first %}
+      {% type = type_declaration.type.type_vars.first %}
       {% nilable = false %}
       {% array = true %}
     {% else %}
@@ -92,7 +92,7 @@ class Avram::Migrator::CreateTableStatement
     rows << Avram::Migrator::Columns::{{ type }}Column.new(
       name: {{ type_declaration.var.stringify }},
       nilable: {{ nilable }},
-      default: {{ default }}
+      default: {{ default }},
       {{ **type_options }}
     )
     {% if array %}

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -149,7 +149,7 @@ class Avram::Model
         {{column[:name]}}: {
           {% if column[:type].id == Float64.id %}
             type: PG::Numeric,
-            convertor: Float64Convertor,
+            convertor: Float64Converter,
           {% else %}
             {% if column[:type].is_a?(Generic) %}
             type: {{column[:type]}},

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -151,7 +151,11 @@ class Avram::Model
             type: PG::Numeric,
             convertor: Float64Convertor,
           {% else %}
+            {% if column[:type].is_a?(Generic) %}
+            type: {{column[:type]}},
+            {% else %}
             type: {{column[:type]}}::Lucky::ColumnType,
+            {% end %}
           {% end %}
           nilable: {{column[:nilable]}},
         },
@@ -168,7 +172,11 @@ class Avram::Model
   macro setup_getters(columns, *args, **named_args)
     {% for column in columns %}
       def {{column[:name]}}
-        {{ column[:type] }}::Lucky.from_db! @{{column[:name]}}
+        {% if column[:type].is_a?(Generic) %}
+          {{column[:type].type_vars.first}}::Lucky.from_db! @{{column[:name]}}, array: true
+        {% else %}
+          {{ column[:type] }}::Lucky.from_db! @{{column[:name]}}
+        {% end %}
       end
     {% end %}
   end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -173,7 +173,7 @@ class Avram::Model
     {% for column in columns %}
       def {{column[:name]}}
         {% if column[:type].is_a?(Generic) %}
-          {{column[:type].type_vars.first}}::Lucky.from_db! @{{column[:name]}}, array: true
+          {{column[:type].type_vars.first}}::Lucky.from_db! @{{column[:name]}}
         {% else %}
           {{ column[:type] }}::Lucky.from_db! @{{column[:name]}}
         {% end %}

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -265,14 +265,11 @@ abstract class Avram::SaveOperation(T)
     nil
   end
 
-  private def cast_value(value : Object)
-    case value
-    when JSON::Any
-      value.to_json
-    else
-      value.to_s
-    end
+  {% for attribute in COLUMN_ATTRIBUTES %}
+  private def cast_value(value : {{ attribute[:type] }})
+    value.not_nil!.class.adapter.to_db(value.as({{ attribute[:type] }}))
   end
+  {% end %}
 
   def save : Bool
     if perform_save

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -82,7 +82,16 @@ abstract class Avram::SaveOperation(T)
     private def extract_changes_from_params
       permitted_params.each do |key, value|
         {% for attribute in attributes %}
-          set_{{ attribute[:name] }}_from_param value if key == {{ attribute[:name].stringify }}
+          set_{{ attribute[:name] }}_from_param(
+          {% if attribute[:type].is_a?(Generic) %}
+            # THIS IS A HACK.
+            # Need to figure out what `value` is, and how we can make it
+            # an array
+            [value]
+          {% else %}
+            value
+          {% end %}
+          ) if key == {{ attribute[:name].stringify }}
         {% end %}
       end
     end

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -261,15 +261,17 @@ abstract class Avram::SaveOperation(T)
     _changes
   end
 
-  private def cast_value(value : Nil)
-    nil
-  end
+  macro add_cast_value_methods(columns)
+    private def cast_value(value : Nil)
+      nil
+    end
 
-  {% for attribute in COLUMN_ATTRIBUTES %}
-  private def cast_value(value : {{ attribute[:type] }})
-    value.not_nil!.class.adapter.to_db(value.as({{ attribute[:type] }}))
+    {% for column in columns %}
+    private def cast_value(value : {{ column[:type] }})
+      value.not_nil!.class.adapter.to_db(value.as({{ column[:type] }}))
+    end
+    {% end %}
   end
-  {% end %}
 
   def save : Bool
     if perform_save

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -123,7 +123,11 @@ abstract class Avram::SaveOperation(T)
       end
 
       def set_{{ attribute[:name] }}_from_param(_value)
-        parse_result = {{ attribute[:type] }}::Lucky.parse(_value)
+        {% if attribute[:type].is_a?(Generic) %}
+          parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse(_value)
+        {% else %}
+          parse_result = {{ attribute[:type] }}::Lucky.parse(_value)
+        {% end %}
         if parse_result.is_a? Avram::Type::SuccessfulCast
           {{ attribute[:name] }}.value = parse_result.value
         else

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -129,7 +129,7 @@ abstract class Avram::SaveOperation(T)
           parse_result = {{ attribute[:type] }}::Lucky.parse(_value)
         {% end %}
         if parse_result.is_a? Avram::Type::SuccessfulCast
-          {{ attribute[:name] }}.value = parse_result.value
+          {{ attribute[:name] }}.value = parse_result.value.as({{ attribute[:type] }})
         else
           {{ attribute[:name] }}.add_error "is invalid"
         end

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -82,16 +82,7 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
     private def extract_changes_from_params
       permitted_params.each do |key, value|
         {% for attribute in attributes %}
-          set_{{ attribute[:name] }}_from_param(
-          {% if attribute[:type].is_a?(Generic) %}
-            # THIS IS A HACK.
-            # Need to figure out what `value` is, and how we can make it
-            # an array
-            [value]
-          {% else %}
-            value
-          {% end %}
-          ) if key == {{ attribute[:name].stringify }}
+          set_{{ attribute[:name] }}_from_param(value) if key == {{ attribute[:name].stringify }}
         {% end %}
       end
     end
@@ -133,7 +124,11 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
 
       def set_{{ attribute[:name] }}_from_param(_value)
         {% if attribute[:type].is_a?(Generic) %}
-          parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse(_value)
+          # HACK:
+          # We have to pass an array her, but what's `_value`?
+          # If `_value` is `"true"`, then we pass `["true"]` which can be parsed, but
+          # what if we need to pass in multiple values? I don't know that params handles that currently
+          parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse([_value])
         {% else %}
           parse_result = {{ attribute[:type] }}::Lucky.parse(_value)
         {% end %}

--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -24,6 +24,7 @@ class Avram::SaveOperationTemplate
       end
 
       add_column_attributes({{ primary_key_type }}, {{ columns }})
+      add_cast_value_methods({{ columns }})
     end
   end
 end

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -11,6 +11,18 @@ module Avram::Type
     SuccessfulCast(Nil).new(nil)
   end
 
+  def parse(values : Array(String))
+    values = values.map do |value|
+      parsed_result = parse(value)
+      if parsed_result.is_a? Avram::Type::SuccessfulCast
+        parsed_result.value
+      else
+        nil
+      end
+    end.compact.as(Array)
+    parse(values)
+  end
+
   def parse!(value)
     parse(value).as(SuccessfulCast).value
   end

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -12,15 +12,13 @@ module Avram::Type
   end
 
   def parse(values : Array(String))
-    values = values.map do |value|
-      parsed_result = parse(value)
-      if parsed_result.is_a? Avram::Type::SuccessfulCast
-        parsed_result.value
-      else
-        nil
-      end
-    end.compact.as(Array)
-    parse(values)
+    casts = values.map { |value| parse(value) }
+    if casts.all?(&.is_a?(SuccessfulCast))
+      values = casts.map { |c| c.as(SuccessfulCast).value }
+      parse(values)
+    else
+      FailedCast.new
+    end
   end
 
   def parse!(value)
@@ -44,5 +42,8 @@ module Avram::Type
   end
 
   class FailedCast
+    def value
+      nil
+    end
   end
 end


### PR DESCRIPTION
fixes #147 
This PR adds support for postgres Arrays so you can define columns like

```crystal
column things : Array(String)
```

Some things to note: 

Crystal doesn't currently support nested constants in generics [ref](https://forum.crystal-lang.org/t/using-generic-with-inner-constants/953). This means that with the current code, we get macros generating things like `Array(String)::Lucky::ColumnType` which is a syntax error. 

