### PR TITLE
locking down 3rd party shards. 

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: avram
 version: 0.10.0
 
-crystal: 0.27.2
+crystal: 0.29.0
 
 targets:
   lucky.gen.migration:
@@ -13,14 +13,16 @@ authors:
 dependencies:
   blank:
     github: kostya/blank
+    version: 0.1.0
   lucky_cli:
     github: luckyframework/lucky_cli
     version: ~> 0.13
   db:
     github: crystal-lang/crystal-db
+    version: 0.5.1
   pg:
     github: will/crystal-pg
-    version: ~> 0.15
+    version: 0.16.1
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4


### PR DESCRIPTION
Part of https://github.com/luckyframework/lucky/issues/806

This PR locks down 3rd party shards to specific versions. When running `shards update`, there's potential (especially right after a new crystal version is released) that everything breaks. By locking these down, we ensure that our current version plays nicely together.

These current shard versions are what is specified in our `shard.lock` currently. So we know that these versions all play nice together. 