### PR TITLE
Adding new delete_all query method to remove records based on query

### DIFF
--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -6,6 +6,18 @@ describe "Avram::QueryBuilder" do
     new_query.args.should eq [] of String
   end
 
+  it "deletes all" do
+    new_query.delete.statement.should eq "DELETE FROM users"
+  end
+
+  it "deletes where" do
+    query = new_query
+      .where(Avram::Where::Equal.new(:age, "42"))
+      .delete
+    query.statement.should eq "DELETE FROM users WHERE age = $1"
+    query.args.should eq ["42"]
+  end
+
   it "can be limited" do
     query = new_query.limit(1)
     query.statement.should eq "SELECT * FROM users LIMIT 1"

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -590,19 +590,20 @@ describe Avram::Query do
   end
 
   describe "delete_all" do
-    it "uses the glove" do
+    it "deletes user records that are young" do
       UserBox.new.name("Tony").age(48).create
       UserBox.new.name("Peter").age(15).create
       UserBox.new.name("Bruce").age(49).create
       UserBox.new.name("Wanda").age(17).create
 
       ChainedQuery.new.select_count.should eq 4
+      # use the glove to remove half of them
       result = ChainedQuery.new.young.delete_all
       result.should eq 2
       ChainedQuery.new.select_count.should eq 2
     end
 
-    it "finishes what it started" do
+    it "delete all records since no where clause is specified" do
       UserBox.new.name("Steve").age(90).create
       UserBox.new.name("Nick").age(66).create
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -588,4 +588,27 @@ describe Avram::Query do
       UserQuery.new.select_count.should eq 0
     end
   end
+
+  describe "delete_all" do
+    it "uses the glove" do
+      UserBox.new.name("Tony").age(48).create
+      UserBox.new.name("Peter").age(15).create
+      UserBox.new.name("Bruce").age(49).create
+      UserBox.new.name("Wanda").age(17).create
+
+      ChainedQuery.new.select_count.should eq 4
+      result = ChainedQuery.new.young.delete_all
+      result.should eq 2
+      ChainedQuery.new.select_count.should eq 2
+    end
+
+    it "finishes what it started" do
+      UserBox.new.name("Steve").age(90).create
+      UserBox.new.name("Nick").age(66).create
+
+      result = ChainedQuery.new.delete_all
+      result.should eq 2
+      ChainedQuery.new.select_count.should eq 0
+    end
+  end
 end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -598,7 +598,7 @@ describe Avram::Query do
 
       ChainedQuery.new.select_count.should eq 4
       # use the glove to remove half of them
-      result = ChainedQuery.new.young.delete_all
+      result = ChainedQuery.new.young.delete
       result.should eq 2
       ChainedQuery.new.select_count.should eq 2
     end
@@ -607,7 +607,7 @@ describe Avram::Query do
       UserBox.new.name("Steve").age(90).create
       UserBox.new.name("Nick").age(66).create
 
-      result = ChainedQuery.new.delete_all
+      result = ChainedQuery.new.delete
       result.should eq 2
       ChainedQuery.new.select_count.should eq 0
     end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -14,6 +14,7 @@ class Avram::QueryBuilder
   @selections : String = "*"
   @prepared_statement_placeholder = 0
   @distinct : Bool = false
+  @delete : Bool = false
   @distinct_on : String | Symbol | Nil = nil
 
   VALID_DIRECTIONS = [:asc, :desc]
@@ -26,7 +27,7 @@ class Avram::QueryBuilder
   end
 
   def statement
-    join_sql [select_sql] + sql_condition_clauses
+    join_sql [@delete ? delete_sql : select_sql] + sql_condition_clauses
   end
 
   def statement_for_update(params)
@@ -68,6 +69,11 @@ class Avram::QueryBuilder
 
   private def sql_condition_clauses
     [joins_sql, wheres_sql, order_sql, limit_sql, offset_sql]
+  end
+
+  def delete
+    @delete = true
+    self
   end
 
   def distinct
@@ -246,5 +252,9 @@ class Avram::QueryBuilder
   private def next_prepared_statement_placeholder
     @prepared_statement_placeholder += 1
     "$#{@prepared_statement_placeholder}"
+  end
+
+  private def delete_sql
+    "DELETE FROM #{table}"
   end
 end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -55,11 +55,10 @@ module Avram::Queryable(T)
     self
   end
 
-  # returns the number of records removed as `Int64`.
-  # This will run a `DELETE FROM` on the current table
-  # with any `WHERE` queries specified. If none are provided,
-  # it will delete all records from the table.
+  # Delete the records using the query's where clauses,
+  # or all the records if no wheres are added.
   #
+  # returns the number of records removed as `Int64`.
   # ```
   # # DELETE FROM users WHERE age < 21
   # UserQuery.new.age.lt(21).delete

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -64,7 +64,7 @@ module Avram::Queryable(T)
   # # DELETE FROM users WHERE age < 21
   # UserQuery.new.age.lt(21).delete_all
   # ```
-  def delete_all : Int64
+  def delete : Int64
     query.delete
     database.run do |db|
       db.exec(query.statement, query.args).rows_affected

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -62,7 +62,7 @@ module Avram::Queryable(T)
   #
   # ```
   # # DELETE FROM users WHERE age < 21
-  # UserQuery.new.age.lt(21).delete_all
+  # UserQuery.new.age.lt(21).delete
   # ```
   def delete : Int64
     query.delete

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -55,6 +55,13 @@ module Avram::Queryable(T)
     self
   end
 
+  def delete_all : Int64
+    query.delete
+    database.run do |db|
+      db.exec(query.statement, query.args).rows_affected
+    end
+  end
+
   def join(join_clause : Avram::Join::SqlClause)
     query.join(join_clause)
     self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -55,6 +55,15 @@ module Avram::Queryable(T)
     self
   end
 
+  # returns the number of records removed as `Int64`.
+  # This will run a `DELETE FROM` on the current table
+  # with any `WHERE` queries specified. If none are provided,
+  # it will delete all records from the table.
+  #
+  # ```
+  # # DELETE FROM users WHERE age < 21
+  # UserQuery.new.age.lt(21).delete_all
+  # ```
   def delete_all : Int64
     query.delete
     database.run do |db|


### PR DESCRIPTION
Fixes #111 

Based on how rails works, when you run the `delete_all` method, it'll return an integer, so it's going to be the last thing you run in your query. You can chain all your wheres like normal though.