### PR TITLE
Make querying associations more explicit

### DIFF
--- a/spec/query_associations_spec.cr
+++ b/spec/query_associations_spec.cr
@@ -1,5 +1,12 @@
 require "./spec_helper"
 
+# Ensure it works with inherited query classes
+class CommentQuery < Comment::BaseQuery
+  def body_eq(value)
+    body.eq(value)
+  end
+end
+
 describe "Query associations" do
   it "can query associations" do
     post_with_matching_comment = PostBox.create
@@ -16,10 +23,12 @@ describe "Query associations" do
       .post_id(post_without_matching_comment.id)
       .create
 
-    posts = Post::BaseQuery.new.join_comments.where_comments(&.body.eq("matching"))
+    posts = Post::BaseQuery.new
+      .where_comments(CommentQuery.new.body_eq("matching"))
     posts.results.should eq([post_with_matching_comment])
 
-    posts = Post::BaseQuery.new.join_comments.where_comments(&.body("matching"))
+    posts = Post::BaseQuery.new
+      .where_comments(Comment::BaseQuery.new.body("matching"))
     posts.results.should eq([post_with_matching_comment])
   end
 
@@ -38,7 +47,9 @@ describe "Query associations" do
       .post_id(post_without_matching_comment.id)
       .create
 
-    posts = Post::BaseQuery.new.inner_join_comments.where_comments(&.body.eq("matching"))
+    posts = Post::BaseQuery.new
+      .inner_join_comments
+      .where_comments(Comment::BaseQuery.new.body.eq("matching"), auto_inner_join: false)
     posts.to_sql[0].should contain "INNER JOIN"
     posts.results.should eq([post_with_matching_comment])
   end
@@ -58,7 +69,9 @@ describe "Query associations" do
       .post_id(post_without_matching_comment.id)
       .create
 
-    posts = Post::BaseQuery.new.left_join_comments.where_comments(&.body.eq("matching"))
+    posts = Post::BaseQuery.new
+      .left_join_comments
+      .where_comments(Comment::BaseQuery.new.body.eq("matching"), auto_inner_join: false)
     posts.to_sql[0].should contain "LEFT JOIN"
     posts.results.should eq([post_with_matching_comment])
   end
@@ -78,7 +91,9 @@ describe "Query associations" do
       .post_id(post_without_matching_comment.id)
       .create
 
-    posts = Post::BaseQuery.new.right_join_comments.where_comments(&.body.eq("matching"))
+    posts = Post::BaseQuery.new
+      .right_join_comments
+      .where_comments(Comment::BaseQuery.new.body.eq("matching"), auto_inner_join: false)
     posts.to_sql[0].should contain "RIGHT JOIN"
     posts.results.should eq([post_with_matching_comment])
   end
@@ -98,7 +113,9 @@ describe "Query associations" do
       .post_id(post_without_matching_comment.id)
       .create
 
-    posts = Post::BaseQuery.new.full_join_comments.where_comments(&.body.eq("matching"))
+    posts = Post::BaseQuery.new
+      .full_join_comments
+      .where_comments(Comment::BaseQuery.new.body.eq("matching"), auto_inner_join: false)
     posts.to_sql[0].should contain "FULL JOIN"
     posts.results.should eq([post_with_matching_comment])
   end

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -37,7 +37,7 @@ module Avram::Associations::HasMany
             all_{{ assoc_name }} = preload_query
               .dup
               .join_{{ through.id }}
-              .where_{{ through.id }} do |through_query|
+              .__yield_where_{{ through.id }} do |through_query|
                 through_query.{{ foreign_key.id }}.in(ids)
               end
               .preload_{{ through.id }}
@@ -90,7 +90,7 @@ module Avram::Associations::HasMany
         {{ model }}::BaseQuery
           .new
           .join_{{ through.id }}
-          .where_{{ through.id }} do |through_query|
+          .__yield_where_{{ through.id }} do |through_query|
             through_query.{{ foreign_key.id }}(id)
           end
           .preload_{{ through.id }}


### PR DESCRIPTION
Closes #171

Another issue has been opened for ensuring joins and wheres are unique before generating a statement https://github.com/luckyframework/avram/issues/175. That should make this a lot more reliable