### PR TITLE
Update for Crystal v0.30.0

### DIFF
--- a/spec/nested_save_operation_spec.cr
+++ b/spec/nested_save_operation_spec.cr
@@ -24,7 +24,7 @@ private class NestedParams
   def initialize(@business, @email_address, @tax_id)
   end
 
-  def nested?(key : String)
+  def nested?(key : String) : Hash(String, String)
     if key == "email_address"
       @email_address
     elsif key == "tax_id"
@@ -36,7 +36,7 @@ private class NestedParams
     end
   end
 
-  def nested(key : String)
+  def nested(key : String) : Hash(String, String)
     nested?(key)
   end
 

--- a/spec/support/base_model.cr
+++ b/spec/support/base_model.cr
@@ -1,5 +1,5 @@
 class BaseModel < Avram::Model
-  def self.database
+  def self.database : Avram::Database.class
     TestDatabase
   end
 end

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -3,7 +3,7 @@ class Avram::BaseQueryTemplate
     class ::{{ type }}::BaseQuery < Avram::Query
       include Avram::Queryable({{ type }})
 
-      def database
+      def database : Avram::Database.class
         {{ type }}.database
       end
 

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -61,7 +61,8 @@ abstract class Avram::Database
     settings.url
   end
 
-  protected def run
+  # :nodoc:
+  def run
     yield current_transaction.try(&.connection) || db
   end
 
@@ -81,7 +82,8 @@ abstract class Avram::Database
     raise Avram::Rollback.new
   end
 
-  protected def transaction : Bool
+  # :nodoc:
+  def transaction : Bool
     if current_transaction
       yield
     else

--- a/src/avram/join.cr
+++ b/src/avram/join.cr
@@ -38,25 +38,25 @@ module Avram::Join
   end
 
   class Inner < SqlClause
-    def join_type
+    def join_type : String
       "INNER"
     end
   end
 
   class Left < SqlClause
-    def join_type
+    def join_type : String
       "LEFT"
     end
   end
 
   class Right < SqlClause
-    def join_type
+    def join_type : String
       "RIGHT"
     end
   end
 
   class Full < SqlClause
-    def join_type
+    def join_type : String
       "FULL"
     end
   end

--- a/src/avram/migrator/columns/bool_column.cr
+++ b/src/avram/migrator/columns/bool_column.cr
@@ -7,7 +7,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       "boolean"
     end
   end

--- a/src/avram/migrator/columns/float_column.cr
+++ b/src/avram/migrator/columns/float_column.cr
@@ -14,7 +14,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       if precision && scale
         "decimal(#{precision},#{scale})"
       else

--- a/src/avram/migrator/columns/int16_column.cr
+++ b/src/avram/migrator/columns/int16_column.cr
@@ -7,7 +7,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       "smallint"
     end
   end

--- a/src/avram/migrator/columns/int32_column.cr
+++ b/src/avram/migrator/columns/int32_column.cr
@@ -7,7 +7,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       "int"
     end
   end

--- a/src/avram/migrator/columns/int64_column.cr
+++ b/src/avram/migrator/columns/int64_column.cr
@@ -7,7 +7,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       "bigint"
     end
   end

--- a/src/avram/migrator/columns/json_column.cr
+++ b/src/avram/migrator/columns/json_column.cr
@@ -7,7 +7,7 @@ module Avram::Migrator::Columns::JSON
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       "jsonb"
     end
 

--- a/src/avram/migrator/columns/string_column.cr
+++ b/src/avram/migrator/columns/string_column.cr
@@ -7,7 +7,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       "text"
     end
   end

--- a/src/avram/migrator/columns/time_column.cr
+++ b/src/avram/migrator/columns/time_column.cr
@@ -7,7 +7,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       "timestamptz"
     end
 

--- a/src/avram/migrator/columns/uuid_column.cr
+++ b/src/avram/migrator/columns/uuid_column.cr
@@ -7,7 +7,7 @@ module Avram::Migrator::Columns
     def initialize(@name, @nilable, @default)
     end
 
-    def column_type
+    def column_type : String
       "uuid"
     end
   end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -158,11 +158,13 @@ class Avram::Model
 
   macro setup_getters(columns, *args, **named_args)
     {% for column in columns %}
-      def {{column[:name]}}
-        {% if column[:type].is_a?(Generic) %}
-          {{column[:type].type_vars.first}}::Lucky.from_db! @{{column[:name]}}
+      {% db_type = column[:type].is_a?(Generic) ? column[:type].type_vars.first : column[:type] %}
+      def {{column[:name]}} : {% if column[:nilable] %}::Union({{db_type}}, ::Nil){% else %}{{column[:type]}}{% end %}
+        %from_db = {{ db_type }}::Lucky.from_db!(@{{column[:name]}})
+        {% if column[:nilable] %}
+          %from_db.as?({{db_type}})
         {% else %}
-          {{ column[:type] }}::Lucky.from_db! @{{column[:name]}}
+          %from_db.as({{column[:type]}})
         {% end %}
       end
     {% end %}

--- a/src/avram/params.cr
+++ b/src/avram/params.cr
@@ -15,11 +15,11 @@ class Avram::Params
     end
   end
 
-  def nested?(key)
+  def nested?(key) : Hash(String, String)
     @hash
   end
 
-  def nested(key)
+  def nested(key) : Hash(String, String)
     @hash
   end
 

--- a/src/avram/postgres_url.cr
+++ b/src/avram/postgres_url.cr
@@ -37,8 +37,8 @@ class Avram::PostgresURL
   end
 
   private def set_url_creds(io)
-    io << URI.escape(username) unless username.empty?
-    io << ":#{URI.escape(password)}" unless password.empty?
+    io << URI.encode_www_form(username) unless username.empty?
+    io << ":#{URI.encode_www_form(password)}" unless password.empty?
     io << "@" unless username.empty?
   end
 

--- a/src/avram/query.cr
+++ b/src/avram/query.cr
@@ -1,7 +1,7 @@
 require "./queryable"
 
 abstract class Avram::Query
-  abstract def database : Avram::Database
+  abstract def database : Avram::Database.class
 
   # runs a SQL `TRUNCATE` on the current table
   def self.truncate

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -26,7 +26,7 @@ module Avram::Where
   end
 
   class Null < NullSqlClause
-    def operator
+    def operator : String
       "IS"
     end
 
@@ -36,7 +36,7 @@ module Avram::Where
   end
 
   class NotNull < NullSqlClause
-    def operator
+    def operator : String
       "IS NOT"
     end
 
@@ -46,7 +46,7 @@ module Avram::Where
   end
 
   class Equal < SqlClause
-    def operator
+    def operator : String
       "="
     end
 
@@ -56,7 +56,7 @@ module Avram::Where
   end
 
   class NotEqual < SqlClause
-    def operator
+    def operator : String
       "!="
     end
 
@@ -66,7 +66,7 @@ module Avram::Where
   end
 
   class GreaterThan < SqlClause
-    def operator
+    def operator : String
       ">"
     end
 
@@ -76,7 +76,7 @@ module Avram::Where
   end
 
   class GreaterThanOrEqualTo < SqlClause
-    def operator
+    def operator : String
       ">="
     end
 
@@ -86,7 +86,7 @@ module Avram::Where
   end
 
   class LessThan < SqlClause
-    def operator
+    def operator : String
       "<"
     end
 
@@ -96,7 +96,7 @@ module Avram::Where
   end
 
   class LessThanOrEqualTo < SqlClause
-    def operator
+    def operator : String
       "<="
     end
 
@@ -106,7 +106,7 @@ module Avram::Where
   end
 
   class Like < SqlClause
-    def operator
+    def operator : String
       "LIKE"
     end
 
@@ -116,7 +116,7 @@ module Avram::Where
   end
 
   class Ilike < SqlClause
-    def operator
+    def operator : String
       "ILIKE"
     end
 
@@ -126,7 +126,7 @@ module Avram::Where
   end
 
   class NotLike < SqlClause
-    def operator
+    def operator : String
       "NOT LIKE"
     end
 
@@ -136,7 +136,7 @@ module Avram::Where
   end
 
   class NotIlike < SqlClause
-    def operator
+    def operator : String
       "NOT ILIKE"
     end
 
@@ -146,7 +146,7 @@ module Avram::Where
   end
 
   class In < SqlClause
-    def operator
+    def operator : String
       "= ANY"
     end
 
@@ -160,7 +160,7 @@ module Avram::Where
   end
 
   class NotIn < SqlClause
-    def operator
+    def operator : String
       "!= ALL"
     end
 


### PR DESCRIPTION
Hi, this is a partial update to Crystal 0.30.0

I am a bit lost in the metamodel of avram regarding the last two commits where I am trying to make the "Add column getter return type" commit work. I didn't follow all the type information of column, attributes, etc. Probably I am missing something obvious. Any clue?

Since the return types will be required and `Authentic::PasswordAuthenticatable#encrypted_password` has return type I was trying to set the return types for every column.

Note: Some dependencies need to be updated also, my `bcardiff/use-fork` branch has those overrided.