### PR TITLE
Ensure polymorphic belongs to are nilable

### DIFF
--- a/spec/polymorphic_spec.cr
+++ b/spec/polymorphic_spec.cr
@@ -116,8 +116,4 @@ describe "polymorphic belongs to" do
       event.optional_eventable!.should be_nil
     end
   end
-
-  # They must be nullable since only one can be filled in at a time.
-  # And remind to make migration optional too
-  pending "ensure defined polymorphic associations are nullable"
 end


### PR DESCRIPTION
Closes #178

<img width="1056" alt="Screen Shot 2019-07-31 at 12 01 42 AM" src="https://user-images.githubusercontent.com/22394/62182939-65d38180-b326-11e9-8444-21fbb7abef98.png">

It also has this underneath:

<img width="376" alt="Screen Shot 2019-07-31 at 12 02 05 AM" src="https://user-images.githubusercontent.com/22394/62182953-6ff58000-b326-11e9-88fb-06227d04b86b.png">

Which indicates which type needs  to be nil. This error is a bit tricky now with Crystal 0.29 but in 0.30 it  will be  just the macro line that has the issue, which means this should be pretty easy to find in the printed error message