### PR TITLE
merge in orders for queries

### DIFF
--- a/spec/query_builder/merge_spec.cr
+++ b/spec/query_builder/merge_spec.cr
@@ -16,6 +16,16 @@ describe "Avram::QueryBuilder#merge" do
     query_1.statement.should eq "SELECT * FROM users INNER JOIN posts ON users.id = posts.user_id INNER JOIN tasks ON users.id = tasks.user_id WHERE age = $1 AND age = $2 AND name = 'Mary' AND name = 'Greg'"
     query_1.args.should eq ["42", "20"]
   end
+
+  it "merges orders" do
+    query_1 = new_query
+      .order_by(:id, :asc)
+    query_2 = new_query
+      .order_by(:name, :desc)
+
+    query_1.merge(query_2)
+    query_1.statement.should contain "ORDER BY id ASC, name DESC"
+  end
 end
 
 private def new_query

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -612,4 +612,11 @@ describe Avram::Query do
       ChainedQuery.new.select_count.should eq 0
     end
   end
+
+  describe "ordering" do
+    it "orders by a joined table" do
+      query = Post::BaseQuery.new.where_comments(Comment::BaseQuery.new.created_at.asc_order)
+      query.to_sql[0].should contain "ORDER BY comments.created_at ASC"
+    end
+  end
 end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -25,7 +25,7 @@ class Avram::QueryBuilder
     [statement] + args
   end
 
-  # Merges the wheres, raw wheres, and joins from the passed in query
+  # Merges the wheres, raw wheres, joins, and orders from the passed in query
   def merge(query_to_merge : Avram::QueryBuilder)
     query_to_merge.wheres.each do |where|
       where(where)
@@ -37,6 +37,12 @@ class Avram::QueryBuilder
 
     query_to_merge.joins.each do |join|
       join(join)
+    end
+
+    query_to_merge.orders.each do |direction, order_bys|
+      order_bys.each do |order|
+        order_by(order, direction)
+      end
     end
   end
 
@@ -134,6 +140,13 @@ class Avram::QueryBuilder
         "#{columns.join(" #{direction.to_s.upcase}, ")} #{direction.to_s.upcase}"
       end.reject(&.nil?).join(", ")
     end
+  end
+
+  def orders
+    {
+      asc:  @orders[:asc].uniq,
+      desc: @orders[:desc].uniq,
+    }
   end
 
   def select_count


### PR DESCRIPTION
Fixes #189 

This allows us to order on a column in a joined table:

```crystal
# ORDER BY comments.created_at ASC
Post::BaseQuery.new.where_comments(Comment::BaseQuery.new.created_at.asc_order)
```
