### PR TITLE
Allow for spaces in pwd output in precompile_tasks

### DIFF
--- a/script/precompile_tasks
+++ b/script/precompile_tasks
@@ -8,5 +8,5 @@ set -e
 if [ "$LUCKY_ENV" != "production" ] && [ -z "$CI" ] && [ -z "$SKIP_LUCKY_TASK_PRECOMPILATION" ]; then
     shards build && \
     mkdir -p ../../bin && \
-    cp -r $(pwd)/bin $(pwd)/../..
+    cp -r "$(pwd)/bin" "$(pwd)/../.."
 fi


### PR DESCRIPTION
`script/precompile_tasks` was failing if Avram was installed as a dependency of a project whose path contains a space, such as a subdirectory of an iCloud Drive folder (which is usually `/Users/$USER/Library/Mobile Documents/com~apple~CloudDocs/`), since the shell was treating the space as a separator. This commit tells the shell to avoid treating spaces in the current directory's path as an argument separator.