### PR TITLE
add ability to clone a query. 

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -626,4 +626,40 @@ describe Avram::Query do
       query.to_sql[0].should contain "ORDER BY comments.created_at ASC"
     end
   end
+
+  describe "cloning queries" do
+    it "leaves the original query unaffected" do
+      original_query = ChainedQuery.new.young
+      new_query = original_query.clone.named("bruce wayne").joined_at.asc_order
+
+      original_query.to_sql.size.should eq 2
+      new_query.to_sql.size.should eq 3
+      new_query.to_sql[0].should contain "ORDER BY users.joined_at"
+      original_query.to_sql[0].should_not contain "ORDER BY"
+    end
+
+    it "returns separate results than the original query" do
+      UserBox.new.name("Purcell").age(22).create
+      UserBox.new.name("Purcell").age(84).create
+      UserBox.new.name("Griffiths").age(55).create
+      UserBox.new.name("Griffiths").age(75).create
+
+      original_query = ChainedQuery.new.named("Purcell")
+      new_query = original_query.clone.age.gt(30)
+
+      original_query.select_count.should eq 2
+      new_query.select_count.should eq 1
+    end
+
+    it "clones joined queries" do
+      post = PostBox.new.create
+      CommentBox.new.post_id(post.id).create
+
+      original_query = Post::BaseQuery.new.where_comments(Comment::BaseQuery.new.created_at.asc_order)
+      new_query = original_query.clone.select_count
+
+      original_query.first.should_not eq nil
+      new_query.should eq 1
+    end
+  end
 end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -44,6 +44,13 @@ module Avram::Queryable(T)
       .select(@@schema_class.column_names)
   end
 
+  def clone : self
+    original_query = query
+    instance = self.class.new
+    instance.query.merge(original_query)
+    instance
+  end
+
   def distinct : self
     query.distinct
     self


### PR DESCRIPTION
Fixes #208

This adds a `clone` method to queries so you can do things like fork a query and not have it mutate the original query.

```crystal
original_query = UserQuery.new.admin(true)
new_query = original_query.clone.last_name.desc_order

original_query # does not order by last name
```

I first called this method `dup` because that made most sense, but it seems there's already a `dup` method available that doesn't really work how you'd think. 