### PR TITLE
update Box.create_pair to now return an array of the instance. 

### DIFF
--- a/spec/box_spec.cr
+++ b/spec/box_spec.cr
@@ -1,19 +1,37 @@
 require "./spec_helper"
 
-describe "Sequences" do
-  it "increases a value every time it's called" do
-    BaseBox::SEQUENCES["name"] = 0
+describe Avram::Box do
+  describe "Sequences" do
+    it "increases a value every time it's called" do
+      BaseBox::SEQUENCES["name"] = 0
 
-    tag1 = TagBox.create
-    tag2 = TagBox.create
+      tag1 = TagBox.create
+      tag2 = TagBox.create
 
-    tag1.name.should eq("name-1")
-    tag2.name.should eq("name-2")
+      tag1.name.should eq("name-1")
+      tag2.name.should eq("name-2")
+    end
+
+    it "can be overridden" do
+      tag = TagBox.create(&.name("not-a-sequence"))
+
+      tag.name.should eq("not-a-sequence")
+    end
   end
 
-  it "can be overridden" do
-    tag = TagBox.create(&.name("not-a-sequence"))
+  describe "create_pair" do
+    it "creates 2 tags" do
+      tags = TagBox.create_pair
+      tags.size.should eq 2
+      tags.class.name.should eq "Array(Tag)"
+    end
 
-    tag.name.should eq("not-a-sequence")
+    it "yields the block to both boxes" do
+      tags = TagBox.create_pair do |box|
+        box.name(box.sequence("new-tag"))
+      end
+      tags.first.name.should eq "new-tag-1"
+      tags.last.name.should eq "new-tag-2"
+    end
   end
 end

--- a/spec/box_spec.cr
+++ b/spec/box_spec.cr
@@ -27,6 +27,14 @@ describe Avram::Box do
     end
 
     it "yields the block to both boxes" do
+      users = UserBox.create_pair do |box|
+        box.age(30)
+      end
+      users.first.age.should eq 30
+      users.last.age.should eq 30
+    end
+
+    it "works with sequences" do
       tags = TagBox.create_pair do |box|
         box.name(box.sequence("new-tag"))
       end

--- a/src/avram/box.cr
+++ b/src/avram/box.cr
@@ -46,12 +46,11 @@ abstract class Avram::Box
   # tags.size    # => 2
   # ```
   def self.create_pair
-    [1, 2].map do |n|
-      new.create
-    end
+    create_pair { |box| box }
   end
 
   # Similar to `create_pair`, but accepts a block which yields the box instance.
+  #
   # Both boxes receive the same argument values.
   #
   # Usage:

--- a/src/avram/box.cr
+++ b/src/avram/box.cr
@@ -36,8 +36,36 @@ abstract class Avram::Box
     operation.save!
   end
 
+  # Returns an array with 2 instances of the model from the Box.
+  #
+  # Usage:
+  #
+  # ```crystal
+  # tags = TagBox.create_pair
+  # typeof(tags) # => Array(Tag)
+  # tags.size    # => 2
+  # ```
   def self.create_pair
-    2.times { new.create }
+    [1, 2].map do |n|
+      new.create
+    end
+  end
+
+  # Similar to `create_pair`, but accepts a block which yields the box instance.
+  # Both boxes receive the same argument values.
+  #
+  # Usage:
+  #
+  # ```crystal
+  # TagBox.create_pair do |box|
+  #   # set both boxes name to "test"
+  #   box.name("test")
+  # end
+  # ```
+  def self.create_pair
+    [1, 2].map do |n|
+      self.create { |box| yield(box) }
+    end
   end
 
   # Returns a value with a number to use for unique values.


### PR DESCRIPTION
Fixes #199

Also added method overload for accepting a block. 

Before this PR, using `Box.create_pair` always returned `nil`, and there was no way to customize the boxes being created. Now it returns `[model, model]`. You can also pass a block in to customize it:

```crystal
users = UserBox.create_pair do |user_box|
  user_box.name(user_box.sequence("Jeremy"))
end

users.first.name #=> Jeremy-1
users.last.name #=> Jeremy-2
```

