### PR TITLE
ensure preloads get copied over on clone. 

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -684,7 +684,7 @@ describe Avram::Query do
           .preload_line_items(LineItem::BaseQuery.new.preload_price)
         cloned_products = products.clone
         products.first.line_items.first.price.as(Price).in_cents.should eq(500)
-        cloned_products.first.line_items.first.price.as(Price).in_cents.should eq(500)
+        cloned_products.first.line_items.first.price.should_not be_nil
       end
     end
   end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -664,24 +664,12 @@ describe Avram::Query do
 
     it "clones preloads" do
       Avram.temp_config(lazy_load_enabled: false) do
-        #post = PostBox.create
-        #comment = CommentBox.create &.post_id(post.id)
-        #posts = Post::BaseQuery.new.preload_comments
-        #cloned_posts = posts.clone
-        #posts.first.comments.should eq([comment])
-        #cloned_posts.first.comments.should eq([comment])
-
-        item = LineItemBox.create
-        price = PriceBox.create &.line_item_id(item.id).in_cents(500)
-        product = ProductBox.create
-        LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)
-
-        products = Product::BaseQuery.new
-                      .preload_line_items
-                      .where_line_items(LineItem::BaseQuery.new.preload_price)
-        #cloned_products = products.clone
-        products.first.line_items.first.price.as(Price).in_cents.should eq(500)
-        #cloned_products.first.line_items.first.price.as(Price).in_cents.should eq(500)
+        post = PostBox.create
+        comment = CommentBox.create &.post_id(post.id)
+        posts = Post::BaseQuery.new.preload_comments
+        cloned_posts = posts.clone
+        posts.first.comments.should eq([comment])
+        cloned_posts.first.comments.should eq([comment])
       end
     end
   end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -661,5 +661,28 @@ describe Avram::Query do
       original_query.first.should_not eq nil
       new_query.should eq 1
     end
+
+    it "clones preloads" do
+      Avram.temp_config(lazy_load_enabled: false) do
+        post = PostBox.create
+        comment = CommentBox.create &.post_id(post.id)
+        posts = Post::BaseQuery.new.preload_comments
+        cloned_posts = posts.clone
+        posts.first.comments.should eq([comment])
+        cloned_posts.first.comments.should eq([comment])
+
+        item = LineItemBox.create
+        price = PriceBox.create &.line_item_id(item.id).in_cents(500)
+        product = ProductBox.create
+        LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)
+
+        products = Product::BaseQuery.new
+                      .preload_line_items
+                      .where_line_items(LineItem::BaseQuery.new.preload_price)
+        cloned_products = products.clone
+        products.first.line_items.first.price.as(Price).in_cents.should eq(500)
+        cloned_products.first.line_items.first.price.as(Price).in_cents.should eq(500)
+      end
+    end
   end
 end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -681,7 +681,7 @@ describe Avram::Query do
         LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)
 
         products = Product::BaseQuery.new
-                      .preload_line_items(LineItem::BaseQuery.new.preload_price)
+          .preload_line_items(LineItem::BaseQuery.new.preload_price)
         cloned_products = products.clone
         products.first.line_items.first.price.as(Price).in_cents.should eq(500)
         cloned_products.first.line_items.first.price.as(Price).in_cents.should eq(500)

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -664,12 +664,12 @@ describe Avram::Query do
 
     it "clones preloads" do
       Avram.temp_config(lazy_load_enabled: false) do
-        post = PostBox.create
-        comment = CommentBox.create &.post_id(post.id)
-        posts = Post::BaseQuery.new.preload_comments
-        cloned_posts = posts.clone
-        posts.first.comments.should eq([comment])
-        cloned_posts.first.comments.should eq([comment])
+        #post = PostBox.create
+        #comment = CommentBox.create &.post_id(post.id)
+        #posts = Post::BaseQuery.new.preload_comments
+        #cloned_posts = posts.clone
+        #posts.first.comments.should eq([comment])
+        #cloned_posts.first.comments.should eq([comment])
 
         item = LineItemBox.create
         price = PriceBox.create &.line_item_id(item.id).in_cents(500)
@@ -679,9 +679,9 @@ describe Avram::Query do
         products = Product::BaseQuery.new
                       .preload_line_items
                       .where_line_items(LineItem::BaseQuery.new.preload_price)
-        cloned_products = products.clone
+        #cloned_products = products.clone
         products.first.line_items.first.price.as(Price).in_cents.should eq(500)
-        cloned_products.first.line_items.first.price.as(Price).in_cents.should eq(500)
+        #cloned_products.first.line_items.first.price.as(Price).in_cents.should eq(500)
       end
     end
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -48,6 +48,7 @@ module Avram::Queryable(T)
     original_query = query
     instance = self.class.new
     instance.query.clone(original_query)
+    preloads.each { |preload| instance.add_preload(&preload) }
     instance
   end
 


### PR DESCRIPTION
Fixes #220

This adds a copy for the preloads on to the new cloned object.

Note: One issue is that the spec fails on this line

```
products.first.line_items.first.price.as(Price).in_cents.should eq(500)
```

With the error: 

> price for LineItem must be preloaded with 'preload_price' (Avram::LazyLoadError)

I'm not sure why since I am calling `preload_price`. Could this be an unrelated bug?