### PR TITLE
add_belongs_to uses bigint in AlterTable statements

### DIFF
--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -76,10 +76,10 @@ describe Avram::Migrator::AlterTableStatement do
 
       built.statements.first.should eq <<-SQL
       ALTER TABLE comments
-        ADD user_id int NOT NULL REFERENCES users ON DELETE CASCADE,
-        ADD post_id int REFERENCES posts ON DELETE RESTRICT,
-        ADD category_label_id int NOT NULL REFERENCES custom_table ON DELETE SET NULL,
-        ADD employee_id int NOT NULL REFERENCES users ON DELETE CASCADE,
+        ADD user_id bigint NOT NULL REFERENCES users ON DELETE CASCADE,
+        ADD post_id bigint REFERENCES posts ON DELETE RESTRICT,
+        ADD category_label_id bigint NOT NULL REFERENCES custom_table ON DELETE SET NULL,
+        ADD employee_id bigint NOT NULL REFERENCES users ON DELETE CASCADE,
         ADD line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE
       SQL
 

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -71,7 +71,7 @@ class Avram::Migrator::AlterTableStatement
   end
 
   # Adds a references column and index given a model class and references option.
-  macro add_belongs_to(type_declaration, on_delete, references = nil, foreign_key_type = Int32)
+  macro add_belongs_to(type_declaration, on_delete, references = nil, foreign_key_type = Int64)
     {% unless type_declaration.is_a?(TypeDeclaration) %}
       {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
     {% end %}


### PR DESCRIPTION
In #121 we changed our primary keys from `Int32` to `Int64` but I believe we forgot to update the alter table migration statements to use Int64 as the default primary key type. This causes errors like:

```
PG::ResultSet#read returned a Int32. A (Int64 | Nil) was expected. (Exception)
```
or the very similar
```
PG::ResultSet#read returned a Int32. A Int64 was expected. (Exception)
```