### PR TITLE
Fix macro string interpolation

### DIFF
--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -2,7 +2,7 @@ class Avram::SaveOperationTemplate
   macro setup(type, columns, table_name, primary_key_type, primary_key_name, *args, **named_args)
     class ::{{ type }}::BaseForm
       macro inherited
-        \{% raise "BaseForm has been renamed to SaveOperation. Please inherit from #{type}::SaveOperation." %}
+        \{% raise "BaseForm has been renamed to SaveOperation. Please inherit from {{ type }}::SaveOperation." %}
       end
     end
 


### PR DESCRIPTION
I ran into this when upgrading to lucky 0.17. Not yet having made the necessary changes switching forms to operations, I got the unwieldly
```
Error: undefined macro variable 'type'
```

This is due to mistakenly using normal string interpolation where we instead want the macro argument to be interpolated into the error message. This then shows the proper error message

```
Error: BaseForm has been renamed to SaveOperation. Please inherit from Post::SaveOperation.
```