### PR TITLE
[WIP] Extend ordering with null sorting

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -625,6 +625,18 @@ describe Avram::Query do
       query = Post::BaseQuery.new.where_comments(Comment::BaseQuery.new.created_at.asc_order)
       query.to_sql[0].should contain "ORDER BY comments.created_at ASC"
     end
+
+    it "orders nulls first" do
+      query = Post::BaseQuery.new.published_at.asc_order(:nulls_first)
+
+      query.to_sql[0].should contain "ORDER BY posts.published_at ASC NULLS FIRST"
+    end
+
+    it "orders nulls last" do
+      query = Post::BaseQuery.new.published_at.asc_order(:nulls_last)
+
+      query.to_sql[0].should contain "ORDER BY posts.published_at ASC NULLS LAST"
+    end
   end
 
   describe "cloning queries" do

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -2,17 +2,22 @@ class Avram::Criteria(T, V)
   property :rows, :column
   @negate_next_criteria : Bool
 
+  enum NullSorting
+    NullsFirst
+    NullsLast
+  end
+
   def initialize(@rows : T, @column : Symbol | String)
     @negate_next_criteria = false
   end
 
-  def desc_order : T
-    rows.query.order_by(column, :desc)
+  def desc_order(null_sorting : NullSorting? = nil) : T
+    rows.query.order_by(column, :desc, null_sorting)
     rows
   end
 
-  def asc_order : T
-    rows.query.order_by(column, :asc)
+  def asc_order(null_sorting : NullSorting? = nil) : T
+    rows.query.order_by(column, :asc, null_sorting)
     rows
   end
 

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -7,8 +7,8 @@ class Avram::QueryBuilder
   @raw_wheres = [] of Avram::Where::Raw
   @joins = [] of Avram::Join::SqlClause
   @orders = {
-    asc:  [] of Symbol | String,
-    desc: [] of Symbol | String,
+    asc:  [] of Tuple(ColumnName, Symbol?),
+    desc: [] of Tuple(ColumnName, Symbol?),
   }
   @selections : String = "*"
   @prepared_statement_placeholder = 0
@@ -17,6 +17,7 @@ class Avram::QueryBuilder
   @distinct_on : String | Symbol | Nil = nil
 
   VALID_DIRECTIONS = [:asc, :desc]
+  VALID_NULL_SORTING = [:nulls_first, :nulls_last]
 
   def initialize(@table : Symbol)
   end
@@ -135,9 +136,10 @@ class Avram::QueryBuilder
     self
   end
 
-  def order_by(column, direction : Symbol)
+  def order_by(column, direction : Symbol, null_sorting : Symbol? = nil)
     raise "Direction must be :asc or :desc, got #{direction}" unless VALID_DIRECTIONS.includes?(direction)
-    @orders[direction] << column
+    raise "NULL Sorting must be :nulls_first or :nulls_last, got #{null_sorting}" unless null_sorting && VALID_NULL_SORTING.includes?(null_sorting)
+    @orders[direction] << {column, null_sorting}
     self
   end
 


### PR DESCRIPTION
fixes #153

This adds the ability to order with `NULLS FIRST` or `NULLS LAST` by adding an argument to the `asc_order` and `desc_order` methods.

Something interesting I learned from postgres:
> By default, null values sort as if larger than any non-null value; that is, NULLS FIRST is the default for DESC order, and NULLS LAST otherwise.

I'm thinking maybe we use that and orders just always show the explicit null sorting....  