### PR TITLE
Add in GROUP BY querying

### DIFF
--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -288,6 +288,26 @@ describe Avram::QueryBuilder do
 
       query.statement.should eq "SELECT * FROM users GROUP BY name"
     end
+
+    it "groups by multiple columns" do
+      query = Avram::QueryBuilder
+        .new(table: :users)
+        .group_by(:age)
+        .group_by(:average_score)
+      query.statement.should eq "SELECT * FROM users GROUP BY age, average_score"
+    end
+
+    it "groups in the proper order with other query parts" do
+      query = Avram::QueryBuilder
+        .new(table: :users)
+        .where(Avram::Where::Equal.new(:name, "Paul"))
+        .order_by(Avram::OrderBy.new(:name, :desc))
+        .group_by(:age)
+        .group_by(:average_score)
+        .limit(10)
+      query.statement.should eq "SELECT * FROM users WHERE name = $1 GROUP BY age, average_score ORDER BY name DESC LIMIT 10"
+      query.args.should eq ["Paul"]
+    end
   end
 end
 

--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -262,6 +262,33 @@ describe Avram::QueryBuilder do
       old_query.statement.should eq "SELECT users.name, users.age FROM users INNER JOIN posts ON users.id = posts.user_id WHERE name = $1 ORDER BY id ASC LIMIT 1 OFFSET 2"
     end
   end
+
+  describe "grouped?" do
+    it "returns true when there's a grouping" do
+      query = Avram::QueryBuilder
+        .new(table: :users)
+        .group_by(:id)
+
+      query.grouped?.should eq true
+    end
+
+    it "returns false when there's no groups" do
+      query = Avram::QueryBuilder
+        .new(table: :users)
+
+      query.grouped?.should eq false
+    end
+  end
+
+  describe "group_by" do
+    it "groups by a column" do
+      query = Avram::QueryBuilder
+        .new(table: :users)
+        .group_by(:name)
+
+      query.statement.should eq "SELECT * FROM users GROUP BY name"
+    end
+  end
 end
 
 private def new_query

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -746,14 +746,10 @@ describe Avram::Query do
 
       users = UserQuery.new.group(&.age).group(&.id)
       users.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users GROUP BY users.age, users.id"
-      users.map(&.name).should contain "Dwight"
+      users.map(&.name).should eq ["Dwight", "Michael", "Jim"]
     end
 
     it "raises an error when grouped incorrectly" do
-      user = UserBox.create &.age(25).name("Erin")
-      user = UserBox.create &.age(25).name("Angela")
-      user = UserBox.create &.age(21).name("Pam")
-
       users = UserQuery.new.group(&.age)
 
       expect_raises(PQ::PQError, /column "users\.id" must appear in the GROUP BY/) do

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -130,6 +130,11 @@ class Avram::Criteria(T, V)
     rows.query.distinct_on(column)
   end
 
+  # :nodoc:
+  def __group : Avram::QueryBuilder
+    rows.query.group_by(column)
+  end
+
   private def add_clause(sql_clause) : T
     sql_clause = build_sql_clause(sql_clause)
     rows.query.where(sql_clause)

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -10,6 +10,7 @@ class Avram::QueryBuilder
     asc:  [] of Symbol | String,
     desc: [] of Symbol | String,
   }
+  @groups = [] of ColumnName
   @selections : String = "*"
   @prepared_statement_placeholder = 0
   @distinct : Bool = false
@@ -43,6 +44,10 @@ class Avram::QueryBuilder
       order_bys.each do |order|
         order_by(order, direction)
       end
+    end
+
+    query_to_merge.groups.each do |group|
+      group_by(group)
     end
   end
 
@@ -96,7 +101,7 @@ class Avram::QueryBuilder
   end
 
   private def sql_condition_clauses
-    [joins_sql, wheres_sql, order_sql, limit_sql, offset_sql]
+    [joins_sql, wheres_sql, group_sql, order_sql, limit_sql, offset_sql]
   end
 
   def delete
@@ -167,6 +172,25 @@ class Avram::QueryBuilder
       asc:  @orders[:asc].uniq,
       desc: @orders[:desc].uniq,
     }
+  end
+
+  def group_by(column : ColumnName)
+    @groups << column
+    self
+  end
+
+  def group_sql
+    if grouped?
+      "GROUP BY " + groups.join(", ")
+    end
+  end
+
+  def groups
+    @groups
+  end
+
+  def grouped?
+    @groups.any?
   end
 
   def select_count

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -106,6 +106,12 @@ module Avram::Queryable(T)
     raise "#{e.message}. Accepted values are: :asc, :desc"
   end
 
+  def group(&block) : self
+    criteria = yield self
+    criteria.__group
+    self
+  end
+
   def none : self
     query.where(Avram::Where::Equal.new("1", "0"))
     self


### PR DESCRIPTION
Fixes #193 

* [x] - Low level group_by SQL generation
* [x] - High level Query access to low level group
* [x] - type-safe group_by access
* [ ] - A simple way to get counts from a group like rails `User.group(:status).count #=> {"active" => 100, "inactive" => 4}`

We have `select_count` currently, but maybe that needs to become aware if there's some grouping? 

