### PR TITLE
Add compile-time error to catch use of before in SaveOperation.

### DIFF
--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -134,7 +134,7 @@ module Avram::Callbacks
 
       Try this...
 
-        ▸ before_save #{ callback_method.id }
+        ▸ before_save #{callback_method.id}
 
       ERROR
     %}

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -127,14 +127,14 @@ module Avram::Callbacks
   {% end %}
 
   # :nodoc:
-  macro before(unused)
+  macro before(callback_method)
     {% raise <<-ERROR
 
       'before' is not a valid SaveOperation callback.
 
       Try this...
 
-        ▸ before_save #{ unused.id }
+        ▸ before_save #{ callback_method.id }
 
       ERROR
     %}

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -125,4 +125,18 @@ module Avram::Callbacks
       \{% raise "'before_#{removed_callback.id}' has been removed" %}
     end
   {% end %}
+
+  # :nodoc:
+  macro before(unused)
+    {% raise <<-ERROR
+
+      'before' is not a valid SaveOperation callback.
+
+      Try this...
+
+        ▸ before_save #{ unused.id }
+
+      ERROR
+    %}
+  end
 end


### PR DESCRIPTION
Fixes #235 

<img width="600" alt="Screen Shot 2019-09-17 at 2 58 54 PM" src="https://user-images.githubusercontent.com/2391/65082813-b5fcb680-d95b-11e9-8bc5-9c1c000cba2d.png">
