### PR TITLE
Update to crystal-db ~> 0.7.0 and Crystal 0.31.0

### DIFF
--- a/db/migrations/20190723233131_test_change_type.cr
+++ b/db/migrations/20190723233131_test_change_type.cr
@@ -17,7 +17,7 @@ class TestChangeType::V20190723233131 < Avram::Migrator::Migration::V1
   end
 
   def migrate
-    TempUserInt64::SaveOperation.create!(name: "foo", age: 0, joined_at: Time.now)
+    TempUserInt64::SaveOperation.create!(name: "foo", age: 0, joined_at: Time.utc)
 
     alter table_for(User) do
       change_type id : Int32

--- a/shard.yml
+++ b/shard.yml
@@ -19,10 +19,10 @@ dependencies:
     version: ~> 0.13
   db:
     github: crystal-lang/crystal-db
-    version: 0.6.0
+    version: ~> 0.7.0
   pg:
     github: will/crystal-pg
-    version: 0.18.0
+    version: ~> 0.19.0
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4

--- a/spec/type_extension_spec.cr
+++ b/spec/type_extension_spec.cr
@@ -48,7 +48,9 @@ describe "TypeExtensions" do
     opt = MenuOptionQuery.new.option_value(4).first
     opt.option_value.should eq 4_i16
 
-    opt = MenuOptionQuery.new.option_value(33000).first?
+    # Any Int32 value above Int16::MAX will cause a FailedCase
+    # that will fail in Avram::Type#parse!
+    opt = MenuOptionQuery.new.option_value(32767).first?
     opt.should eq nil
   end
 end

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -27,6 +27,8 @@ struct Int16
 
     def parse(value : Int32)
       SuccessfulCast(Int16).new value.to_i16
+    rescue OverflowError
+      FailedCast.new
     end
 
     def to_db(value : Int16)

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -21,6 +21,8 @@ struct Int32
       SuccessfulCast(Int32).new(value)
     end
 
+    # Isn't a `def parse(value : Int64)` missing?
+
     def parse(values : Array(Int32))
       SuccessfulCast(Array(Int32)).new values
     end

--- a/src/avram/pool_statement_logging.cr
+++ b/src/avram/pool_statement_logging.cr
@@ -5,14 +5,9 @@ module DB
       statement_with_retry &.exec
     end
 
-    def exec(*args) : ExecResult
-      log_query(args)
-      statement_with_retry &.exec(*args)
-    end
-
-    def exec(args : Array) : ExecResult
-      log_query(args)
-      statement_with_retry &.exec(args)
+    def exec(*args_, args : Array? = nil) : ExecResult
+      log_query(*args_, args: args)
+      statement_with_retry &.exec(*args_, args: args)
     end
 
     def query : ResultSet
@@ -20,24 +15,21 @@ module DB
       statement_with_retry &.query
     end
 
-    def query(*args) : ResultSet
-      log_query(args)
-      statement_with_retry &.query(*args)
+    def query(*args_, args : Array? = nil) : ResultSet
+      log_query(*args_, args: args)
+      statement_with_retry &.query(*args_, args: args)
     end
 
-    def query(args : Array) : ResultSet
-      log_query(args)
-      statement_with_retry &.query(args)
+    def scalar(*args_, args : Array? = nil)
+      log_query(*args_, args: args)
+      statement_with_retry &.scalar(*args_, args: args)
     end
 
-    def scalar(*args)
-      log_query(args)
-      statement_with_retry &.scalar(*args)
-    end
-
-    private def log_query(args = [] of String)
+    private def log_query(*args_, args : Array? = nil)
       Avram.settings.query_log_level.try do |level|
-        Avram.logger.log(level, {query: @query, args: args})
+        logging_args = EnumerableConcat.build(args_, args)
+        logging_args = logging_args.to_a if logging_args.is_a?(EnumerableConcat)
+        Avram.logger.log(level, {query: @query, args: logging_args})
       end
     end
   end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -74,7 +74,7 @@ class Avram::QueryBuilder
       else
         value.to_s
       end
-    end
+    end.to_a
   end
 
   private def set_sql_clause(params)

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -79,7 +79,7 @@ module Avram::Queryable(T)
   def delete : Int64
     query.delete
     database.run do |db|
-      db.exec(query.statement, query.args).rows_affected
+      db.exec(query.statement, args: query.args).rows_affected
     end
   end
 
@@ -174,7 +174,7 @@ module Avram::Queryable(T)
 
   private def exec_query
     database.run do |db|
-      db.query query.statement, query.args do |rs|
+      db.query query.statement, args: query.args do |rs|
         @@schema_class.from_rs(rs)
       end
     end
@@ -182,7 +182,7 @@ module Avram::Queryable(T)
 
   def exec_scalar
     database.run do |db|
-      db.scalar query.statement, query.args
+      db.scalar query.statement, args: query.args
     end
   end
 

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -349,7 +349,7 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
     self.created_at.value ||= Time.utc if responds_to?(:created_at)
     self.updated_at.value ||= Time.utc if responds_to?(:updated_at)
     @record = database.run do |db|
-      db.query insert_sql.statement, insert_sql.args do |rs|
+      db.query insert_sql.statement, args: insert_sql.args do |rs|
         @record = @@schema_class.from_rs(rs).first
       end
     end
@@ -358,7 +358,7 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
   private def update(id) : T
     self.updated_at.value = Time.utc if responds_to?(:updated_at)
     @record = database.run do |db|
-      db.query update_query(id).statement_for_update(changes), update_query(id).args_for_update(changes) do |rs|
+      db.query update_query(id).statement_for_update(changes), args: update_query(id).args_for_update(changes) do |rs|
         @record = @@schema_class.from_rs(rs).first
       end
     end


### PR DESCRIPTION
Commits are fairly descriptive on their intention.
Changes are compatible with Crystal 0.30.0 and 0.31.0
The `Handle overflow` commit point some smells here or there that might be worth checking.

Most of the changes regarding crystal-db 0.7.0 are due to https://github.com/crystal-lang/crystal-db/pull/110. 
