### PR TITLE
Allow overriding backup database via BACKUP_DATABASE_URL

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -17,7 +17,7 @@ class SampleBackupDatabase < Avram::Database
 end
 
 SampleBackupDatabase.configure do |settings|
-  settings.url = Avram::PostgresURL.build(
+  settings.url = ENV["BACKUP_DATABASE_URL"]? || Avram::PostgresURL.build(
     hostname: "db",
     database: "sample_backup",
     username: "lucky",


### PR DESCRIPTION
Some specs access to another database that can't be overridden as the main DB.