### PR TITLE
Allow record deletion when primary key is UUID

### DIFF
--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -133,6 +133,15 @@ describe Avram::Model do
       item = LineItemQuery.new.first
       item.id.to_s.should match(uuid_regexp)
     end
+
+    it "can be deleted" do
+      LineItemBox.create
+
+      item = LineItemQuery.new.first
+      item.delete
+
+      LineItem::BaseQuery.all.size.should eq 0
+    end
   end
 
   it "can infer the table name when omitted" do

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -115,8 +115,16 @@ abstract class Avram::Model
 
   def delete
     self.class.database.run do |db|
-      db.exec "DELETE FROM #{@@table_name} WHERE #{primary_key_name} = #{id}"
+      db.exec "DELETE FROM #{@@table_name} WHERE #{primary_key_name} = #{escape_primary_key(id)}"
     end
+  end
+
+  private def escape_primary_key(id : Int64 | Int32 | Int16)
+    id
+  end
+
+  private def escape_primary_key(id : UUID)
+    PG::EscapeHelper.escape_literal(id.to_s)
   end
 
   macro setup_table_name(table_name, *args, **named_args)


### PR DESCRIPTION
Avram supports Int64 | Int32 | Int16 | UUID as primary keys. Current implementation does not escape UUID (as it's basically a string), this causes an exception.

This pull request fixes that issue.