### PR TITLE
adding a reset_limit and reset_offset. 

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -757,4 +757,18 @@ describe Avram::Query do
       end
     end
   end
+
+  describe "#reset_limit" do
+    it "resets the limit to nil so we can use aggregate functions again" do
+      users = UserQuery.new.limit(10)
+      users.reset_limit.select_count.should eq 0
+    end
+  end
+
+  describe "#reset_offset" do
+    it "resets the offset to nil so we can use aggregate functions again" do
+      users = UserQuery.new.offset(10)
+      users.reset_offset.select_count.should eq 0
+    end
+  end
 end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -759,16 +759,18 @@ describe Avram::Query do
   end
 
   describe "#reset_limit" do
-    it "resets the limit to nil so we can use aggregate functions again" do
+    it "resets the limit to nil" do
       users = UserQuery.new.limit(10)
-      users.reset_limit.select_count.should eq 0
+      users.query.limit.should eq 10
+      users.reset_limit.query.limit.should eq nil
     end
   end
 
   describe "#reset_offset" do
-    it "resets the offset to nil so we can use aggregate functions again" do
+    it "resets the offset to nil" do
       users = UserQuery.new.offset(10)
-      users.reset_offset.select_count.should eq 0
+      users.query.offset.should eq 10
+      users.reset_offset.query.offset.should eq nil
     end
   end
 end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -120,8 +120,7 @@ class Avram::QueryBuilder
     @limit
   end
 
-  def limit(amount)
-    @limit = amount
+  def limit(@limit)
     self
   end
 

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -62,6 +62,16 @@ module Avram::Queryable(T)
     self
   end
 
+  def reset_limit : self
+    query.limit(nil)
+    self
+  end
+
+  def reset_offset : self
+    query.offset(nil)
+    self
+  end
+
   def distinct_on(&block) : self
     criteria = yield self
     criteria.__distinct_on


### PR DESCRIPTION
Fixes #248

This adds `reset_limit` and `reset_offset` which can be combined to make your own `reset_pagination` if you need. This is useful for when you have a paginated collection, but you need to get a total count without the limit and offset. 