### PR TITLE
Empty array default fix

### DIFF
--- a/spec/migrator/create_table_statement_spec.cr
+++ b/spec/migrator/create_table_statement_spec.cr
@@ -87,6 +87,7 @@ describe Avram::Migrator::CreateTableStatement do
       add future_time : Time, default: Time.local
       add friend_count : Int16, default: 1
       add friends : Array(String), default: ["Paul"]
+      add problems : Array(String), default: [] of String
     end
 
     built.statements.size.should eq 1
@@ -102,7 +103,8 @@ describe Avram::Migrator::CreateTableStatement do
       joined_at timestamptz NOT NULL DEFAULT NOW(),
       future_time timestamptz NOT NULL DEFAULT '#{Time.local.to_utc}',
       friend_count smallint NOT NULL DEFAULT '1',
-      friends text[] NOT NULL DEFAULT '["Paul"]');
+      friends text[] NOT NULL DEFAULT '{"Paul"}',
+      problems text[] NOT NULL DEFAULT '{}');
     SQL
   end
 

--- a/src/avram/migrator/columns/base.cr
+++ b/src/avram/migrator/columns/base.cr
@@ -67,6 +67,10 @@ abstract class Avram::Migrator::Columns::Base
     escape_literal(value.to_s)
   end
 
+  def self.prepare_value_for_database(value : Array)
+    escape_literal(PQ::Param.encode_array(value))
+  end
+
   def self.escape_literal(value)
     PG::EscapeHelper.escape_literal(value)
   end


### PR DESCRIPTION
This fixes an issue with supplying an empty array as a default.
It also fixes the formatting of of the array to match what postgres expects.