### PR TITLE
This adds an extra before_save to SaveOperation subclasses

### DIFF
--- a/spec/save_operation_spec.cr
+++ b/spec/save_operation_spec.cr
@@ -32,6 +32,11 @@ end
 
 private class SaveLineItem < LineItem::SaveOperation
   permit_columns :name
+  before_save prepare
+
+  def prepare
+    1
+  end
 end
 
 private class ValueColumnModel < BaseModel

--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -8,12 +8,20 @@ class Avram::SaveOperationTemplate
 
     class ::{{ type }}::SaveOperation < Avram::SaveOperation({{ type }})
       {% if primary_key_type.id == UUID.id %}
-        before_save set_uuid
-
-        def set_uuid
-          id.value ||= UUID.random()
-        end
+        # `before_save` calls `previous_def` which will not
+        # run this call on subclasses.
+        before_save set_primary_key_uuid
       {% end %}
+
+      macro inherited
+        {% if primary_key_type.id == UUID.id %}
+          before_save set_primary_key_uuid
+        {% end %}
+      end
+
+      def set_primary_key_uuid
+        id.value ||= UUID.random()
+      end
 
       def database
         {{ type }}.database


### PR DESCRIPTION
Fixes #258

The main issue is that `before_save` calls `previous_def` which doesn't bubble up in crystal. So a SaveOperation with no additional `before_save` callbacks ran just fine. Once you added one to the subclass, then the parent's callback was never ran. 

I also renamed the method. If someone wanted to generate a UUID other than v4, they could technically override this method with a different UUID generation.