### PR TITLE
Fixing query with has_one 

### DIFF
--- a/spec/query_associations_spec.cr
+++ b/spec/query_associations_spec.cr
@@ -10,10 +10,18 @@ end
 class NamedSpaced::Organization < BaseModel
   table do
     has_many locations : Location
+    has_one president : Staff
   end
 end
 
 class NamedSpaced::Location < BaseModel
+  table do
+    column name : String
+    belongs_to organization : Organization
+  end
+end
+
+class NamedSpaced::Staff < BaseModel
   table do
     column name : String
     belongs_to organization : Organization
@@ -137,5 +145,8 @@ describe "Query associations" do
     orgs = NamedSpaced::Organization::BaseQuery.new
       .where_locations(NamedSpaced::Location::BaseQuery.new.name("Home"))
     orgs.to_sql[0].should contain "INNER JOIN"
+
+    staff = NamedSpaced::Staff::BaseQuery.new
+    staff.to_sql[0].should contain "named_spaced_staffs"
   end
 end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -757,4 +757,26 @@ describe Avram::Query do
       end
     end
   end
+
+  context "queries joining with has_one" do
+    describe "when you query from the belongs_to side" do
+      it "returns a record" do
+        line_item = LineItemBox.create &.name("Thing 1")
+        price = PriceBox.create &.in_cents(100).line_item_id(line_item.id)
+
+        query = PriceQuery.new.where_line_items(LineItemQuery.new.name("Thing 1"))
+        query.first.should eq price
+      end
+    end
+
+    describe "when you query from the has_one side" do
+      it "returns a record" do
+        line_item = LineItemBox.create &.name("Thing 1")
+        price = PriceBox.create &.in_cents(100).line_item_id(line_item.id)
+
+        query = LineItemQuery.new.where_price(PriceQuery.new.in_cents(100))
+        query.first.should eq line_item
+      end
+    end
+  end
 end

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -11,7 +11,7 @@ module Avram::Associations::HasOne
     {% end %}
 
     {% unless foreign_key %}
-      {% foreign_key = "#{@type.name.underscore}_id".id %}
+      {% foreign_key = "#{@type.name.underscore.split("::").last.id}_id".id %}
     {% end %}
 
     {% foreign_key = foreign_key.id %}

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -66,6 +66,15 @@ class Avram::BaseQueryTemplate
                   foreign_key: primary_key_name
                 )
               )
+            {% elsif assoc[:relationship_type] == :has_one %}
+              join(
+                Avram::Join::{{ join_type.id }}.new(
+                  from: @@table_name,
+                  to: :{{ assoc[:table_name] }},
+                  foreign_key: :{{ assoc[:foreign_key] }},
+                  primary_key: primary_key_name
+                )
+              )
             {% elsif assoc[:through] %}
               {{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
               __yield_where_{{ assoc[:through].id }} do |join_query|

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -70,7 +70,7 @@ class Avram::BaseQueryTemplate
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: @@table_name,
-                  to: :{{ assoc[:table_name] }},
+                  to: {{ assoc[:type] }}::TABLE_NAME,
                   foreign_key: :{{ assoc[:foreign_key] }},
                   primary_key: primary_key_name
                 )


### PR DESCRIPTION
Fixes #223

This fixes 2 main issues with the `has_one`:

* Using `has_one` when your model is namespaced
* Doing a join query with has_one from both sides of the association

