### PR TITLE
Adds new to_prepared_sql method 

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -757,4 +757,17 @@ describe Avram::Query do
       end
     end
   end
+
+  describe "#to_prepared_sql" do
+    it "returns the full SQL with args combined" do
+      query = Bucket::BaseQuery.new.names(["Larry", "Moe", "Curly"]).numbers([1, 2, 3])
+      query.to_prepared_sql.should eq(%{SELECT buckets.id, buckets.created_at, buckets.updated_at, buckets.bools, buckets.small_numbers, buckets.numbers, buckets.big_numbers, buckets.names FROM buckets WHERE buckets.names = {"Larry","Moe","Curly"} AND buckets.numbers = {1,2,3}})
+
+      query = Blob::BaseQuery.new.doc(JSON::Any.new({"properties" => JSON::Any.new("sold")}))
+      query.to_prepared_sql.should eq(%{SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc FROM blobs WHERE blobs.doc = {"properties":"sold"}})
+
+      query = UserQuery.new.name.in(["Don", "Juan"]).age.gt(30)
+      query.to_prepared_sql.should eq(%{SELECT #{User::COLUMN_SQL} FROM users WHERE users.name = ANY ({"Don","Juan"}) AND users.age > 30})
+    end
+  end
 end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -24,11 +24,11 @@ class Avram::QueryBuilder
   # Prepares the SQL statement by combining the `args` and `statement`
   # in to a single `String`
   def to_prepared_sql : String
-    params = args.map { |arg| String.new(PQ::Param.encode(arg).slice) }
+    params = args.map { |arg| "'#{String.new(PQ::Param.encode(arg).slice)}'" }
     i = 0
     sql = statement
-    sql.scan(/\$\d/) do |match|
-      sql = sql.gsub(match[0], params[i])
+    sql.scan(/\$\d+/) do |match|
+      sql = sql.sub(match[0], params[i])
       i += 1
     end
     sql

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -21,6 +21,19 @@ class Avram::QueryBuilder
     [statement] + args
   end
 
+  # Prepares the SQL statement by combining the `args` and `statement`
+  # in to a single `String`
+  def to_prepared_sql : String
+    params = args.map { |arg| String.new(PQ::Param.encode(arg).slice) }
+    i = 0
+    sql = statement
+    sql.scan(/\$\d/) do |match|
+      sql = sql.gsub(match[0], params[i])
+      i += 1
+    end
+    sql
+  end
+
   # Merges the wheres, raw wheres, joins, and orders from the passed in query
   def merge(query_to_merge : Avram::QueryBuilder)
     query_to_merge.wheres.each do |where|

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -197,4 +197,8 @@ module Avram::Queryable(T)
   def to_sql
     query.to_sql
   end
+
+  def to_prepared_sql
+    query.to_prepared_sql
+  end
 end


### PR DESCRIPTION
Fixes #239

This adds a new `to_prepared_sql` method to query objects. When debugging, or logging, you might use `to_sql` which returns an array where the first element is the SQL string, and the second is an array of the WHERE args. In some cases when debugging, you may want to copy this SQL and run it directly in psql to see the result. With larger and more complex SQL (especially with arrays and json), this becomes very difficult. You have to know what a postgres json or array object looks like, and how to manually convert it.

This new `to_prepared_sql` method takes your args, converts them to PG, then injects them in to the SQL string so you have a straight copy/paste string that can be run directly in postgres.