### PR TITLE
updating SaveOperation callbacks to also call the super callbacks

### DIFF
--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -16,6 +16,8 @@ module Avram::Callbacks
     def before_save
       {% if @type.methods.map(&.name).includes?(:before_save.id) %}
         previous_def
+      {% else %}
+        super
       {% end %}
 
       {{ method_name.id }}
@@ -37,6 +39,8 @@ module Avram::Callbacks
     def before_save
       {% if @type.methods.map(&.name).includes?(:before_save.id) %}
         previous_def
+      {% else %}
+        super
       {% end %}
 
       {{ yield }}
@@ -68,6 +72,8 @@ module Avram::Callbacks
     def after_save(object)
       {% if @type.methods.map(&.name).includes?(:after_save.id) %}
         previous_def
+      {% else %}
+        super
       {% end %}
 
       {{ method_name.id }}(object)
@@ -92,6 +98,8 @@ module Avram::Callbacks
     def after_commit(object)
       {% if @type.methods.map(&.name).includes?(:after_commit.id) %}
         previous_def
+      {% else %}
+        super
       {% end %}
 
       {{ method_name.id }}(object)

--- a/src/avram/operation.cr
+++ b/src/avram/operation.cr
@@ -1,5 +1,4 @@
 require "./validations"
-require "./save_operation_errors"
 require "./define_attribute"
 require "./save_operation_errors"
 require "./param_key_override"

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -175,6 +175,10 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
   # required validation, then returns `true` if all attributes are valid.
   def valid? : Bool
     before_save
+
+    # These validations must be ran after all `before_save` callbacks have completed
+    # in the case that someone has set a required field in a `before_save`. If we run
+    # this in a `before_save` ourselves, the ordering would cause this to be ran first.
     validate_required *required_attributes
     attributes.all? &.valid?
   end

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -171,9 +171,11 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
     end
   end
 
-  # Runs `before_save` steps and returns `true` if all attributes are valid.
+  # Runs `before_save` steps,
+  # required validation, then returns `true` if all attributes are valid.
   def valid? : Bool
     before_save
+    validate_required *required_attributes
     attributes.all? &.valid?
   end
 
@@ -262,26 +264,6 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
       value.not_nil!.class.adapter.to_db(value.as({{ column[:type] }}))
     end
     {% end %}
-  end
-
-  macro finished
-    # After all before_save callbacks run, make sure non-nilable column attributes
-    # are there.
-    #
-    # This must run after the other before_* callbacks otherwise it might mark
-    # a field as missing and then later another callback sets the field.
-    #
-    # For example:
-    #
-    #   before_save { email.value = "default@example.com" }
-    #
-    # If we had already validate 'email' it would say 'email is missing' when
-    # in reality We set it in another callback.
-    before_save validate_non_nilable_column_attributes
-
-    def validate_non_nilable_column_attributes
-      validate_required *required_attributes
-    end
   end
 
   def save : Bool


### PR DESCRIPTION
Fixes #265
Fixes #258 
Supersedes #261 

Since `previous_def` doesn't bubble up, we add in a call to `super` when no other methods are there. This will bubble up and catches the built-in validation callbacks, and setting the id for UUID primary key.
