### PR TITLE
Small dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 FROM crystallang/crystal:0.31.1
+WORKDIR /data
 
+# install base dependencies
 RUN apt-get update && \
-  apt-get install -y libgconf-2-4 build-essential curl libreadline-dev libevent-dev libssl-dev libxml2-dev libyaml-dev libgmp-dev git wget
+  apt-get install -y libgconf-2-4 curl libreadline-dev && \
+  # postgres 11 installation
+  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" | tee /etc/apt/sources.list.d/postgres.list && \
+  apt-get update && \
+  apt-get install -y postgresql-11 && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Lucky cli
 RUN git clone https://github.com/luckyframework/lucky_cli --branch v0.17.0 --depth 1 /usr/local/lucky_cli && \
@@ -9,15 +17,4 @@ RUN git clone https://github.com/luckyframework/lucky_cli --branch v0.17.0 --dep
   shards install && \
   crystal build src/lucky.cr -o /usr/local/bin/lucky
 
-# Install updated pg client
-RUN touch /etc/apt/sources.list.d/pgdg.list
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get update && apt-get install -y postgresql-11
-
-# Cleanup leftovers
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN mkdir /data
-WORKDIR /data
-ADD . /data
+COPY . /data


### PR DESCRIPTION
1. Docker layers once created are immutable.    Clean up, therefore, must happen in the same layer. 
2. ADD is for archives, though semantically works like COPY, it's the wrong tool.  

This PR fixes both of those plus moves stuff around. Avoid invalidating the cache as long as possible.

Closes #272 