### PR TITLE
Fixing clone for distincts

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -705,6 +705,16 @@ describe Avram::Query do
         cloned_products.first.line_items.first.price.should_not be_nil
       end
     end
+
+    it "clones distinct queries" do
+      post = PostBox.create &.title("Jim and Pam").published_at(2.days.ago)
+      PostBox.create &.title("Jim and Pam").published_at(nil)
+
+      original_query = Post::BaseQuery.new.distinct_on(&.title).clone
+      new_query = original_query.published_at.is_nil
+
+      new_query.to_sql[0].should contain "DISTINCT ON"
+    end
   end
 
   describe "#between" do

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -707,9 +707,6 @@ describe Avram::Query do
     end
 
     it "clones distinct queries" do
-      post = PostBox.create &.title("Jim and Pam").published_at(2.days.ago)
-      PostBox.create &.title("Jim and Pam").published_at(nil)
-
       original_query = Post::BaseQuery.new.distinct_on(&.title).clone
       new_query = original_query.published_at.is_nil
 

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -1,6 +1,7 @@
 class Avram::QueryBuilder
   alias ColumnName = Symbol | String
   getter table
+  getter distinct_on : String | Symbol | Nil = nil
   @limit : Int32?
   @offset : Int32?
   @wheres = [] of Avram::Where::SqlClause
@@ -12,7 +13,6 @@ class Avram::QueryBuilder
   @prepared_statement_placeholder = 0
   @distinct : Bool = false
   @delete : Bool = false
-  @distinct_on : String | Symbol | Nil = nil
 
   def initialize(@table : Symbol)
   end
@@ -62,7 +62,7 @@ class Avram::QueryBuilder
     merge(query_to_merge)
     self.select(query_to_merge.selects)
     distinct if query_to_merge.distinct?
-    distinct_on(query_to_merge.raw_distinct_on.to_s) if query_to_merge.has_distinct_on?
+    distinct_on(query_to_merge.distinct_on.to_s) if query_to_merge.has_distinct_on?
     limit(query_to_merge.limit)
     offset(query_to_merge.offset)
   end
@@ -133,10 +133,6 @@ class Avram::QueryBuilder
 
   def has_distinct_on?
     !!@distinct_on
-  end
-
-  def raw_distinct_on
-    @distinct_on
   end
 
   def limit

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -48,6 +48,8 @@ class Avram::QueryBuilder
   def clone(query_to_merge : Avram::QueryBuilder)
     merge(query_to_merge)
     self.select(query_to_merge.selects)
+    distinct if query_to_merge.distinct?
+    distinct_on(query_to_merge.raw_distinct_on.to_s) if query_to_merge.has_distinct_on?
     limit(query_to_merge.limit)
     offset(query_to_merge.offset)
   end
@@ -112,8 +114,16 @@ class Avram::QueryBuilder
     self
   end
 
-  private def distinct?
-    @distinct || @distinct_on
+  def distinct?
+    @distinct || has_distinct_on?
+  end
+
+  def has_distinct_on?
+    !!@distinct_on
+  end
+
+  def raw_distinct_on
+    @distinct_on
   end
 
   def limit
@@ -239,7 +249,7 @@ class Avram::QueryBuilder
     String.build do |sql|
       sql << "SELECT "
       sql << "DISTINCT " if distinct?
-      sql << "ON (#{@distinct_on}) " if @distinct_on
+      sql << "ON (#{@distinct_on}) " if has_distinct_on?
       sql << @selections
       sql << " FROM "
       sql << table


### PR DESCRIPTION
Fixes #284

I had to take off the private and break out the methods so that way I had access to the distincts on the query being merged in. 
