### PR TITLE
Bug: TypeCastError when aggregate function returns NULL

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -355,6 +355,14 @@ describe Avram::Query do
       max = UserQuery.new.age.lte(2).age.select_max
       max.should eq 2
     end
+
+    it "works when there are no matching records" do
+      UserBox.create &.age(2)
+      UserBox.create &.age(1)
+      UserBox.create &.age(3)
+      max = UserQuery.new.age.gt(3).age.select_max
+      max.should eq nil
+    end
   end
 
   describe "#select_average" do


### PR DESCRIPTION
If an aggregate function like `select_max` is called but there are no rows to aggregate, the query returns no rows, which results in Avram causing a `TypeCastError`.

This PR adds a test demonstrating the problem. The full error from the test is:

```
       cast from Nil to Int32 failed, at /data/src/avram/criteria.cr:110:5:110 (TypeCastError)
         from src/avram/criteria.cr:110:5 in 'select_max'
         from spec/query_spec.cr:363:7 in '->'
         from /usr/share/crystal/src/spec/example.cr:255:3 in 'run'
         from /usr/share/crystal/src/spec/context.cr:211:23 in 'run'
         from /usr/share/crystal/src/spec/context.cr:211:23 in 'run'
         from /usr/share/crystal/src/spec/context.cr:42:23 in 'run'
         from /usr/share/crystal/src/spec/dsl.cr:235:7 in '->'
         from /usr/share/crystal/src/kernel.cr:255:3 in 'run'
         from /usr/share/crystal/src/crystal/main.cr:47:5 in 'main'
         from /usr/share/crystal/src/crystal/main.cr:106:3 in 'main'
         from __libc_start_main
         from _start
         from ???
```

I encountered this with a query that attempts to get the date of the most recently edit row, however it's possible that sometimes no rows in the source table match the other clauses in the query, resulting in this error. For now I'm catching `TypeCastError` and returning a default value. I imagine the solution is to make the return value of the aggregate functions nilable.