### PR TITLE
Generate docs for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,16 @@ before_install:
   - script/setup
 script:
   - script/test
+  - script/docs
 notifications:
   email: false
 addons:
   postgresql: "9.4"
+deploy:
+  provider: pages
+  skip_cleanup: true
+  token: $GITHUB_TOKEN
+  project_name: avram
+  on:
+    branch: master
+  local_dir: docs

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ dependencies:
 require "avram"
 ```
 
+## Documenation
+[API (master)](https://luckyframework.github.io/avram/)
+
 ## Contributing
 
 1. Fork it ( https://github.com/luckyframework/avram/fork )

--- a/script/docs
+++ b/script/docs
@@ -1,0 +1,6 @@
+#!/bin/sh -eu
+
+COMPOSE="docker-compose run --rm app"
+
+printf "\ngenerating docs with 'crystal docs'\n\n"
+$COMPOSE crystal docs


### PR DESCRIPTION
## Purpose
Generates docs (`crystal docs`) for Travis CI
Continuation of: https://github.com/luckyframework/lucky/issues/988

## Description
On any commit into `master`, this will auto-deploy documentation generated from `crystal docs` on Github Pages.

**Travis CI config needs to be updated to include GITHUB_TOKEN environment variable**
The GITHUB_TOKEN, which is a [github personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line), only needs the `public_repo` scope.
