### PR TITLE
Allow nil on size and inclusion validations.

### DIFF
--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -199,20 +199,23 @@ describe Avram::Validations do
   describe "validate_inclusion_of" do
     it "validates" do
       allowed_name = attribute("Jamie")
-      Avram::Validations.validate_inclusion_of allowed_name, in: ["Jamie"]
+      Avram::Validations.validate_inclusion_of(allowed_name, in: ["Jamie"])
       allowed_name.valid?.should be_true
 
       forbidden_name = attribute("123123123")
-      Avram::Validations.validate_inclusion_of forbidden_name, in: ["Jamie"]
+      Avram::Validations.validate_inclusion_of(forbidden_name, in: ["Jamie"])
       forbidden_name.errors.should eq(["is invalid"])
     end
 
     it "can allow nil" do
       nil_name = attribute(nil)
-      Avram::Validations.validate_inclusion_of nil_name, in: ["Jamie"], allow_nil: true
+      Avram::Validations.validate_inclusion_of(nil_name, in: ["Jamie"], allow_nil: true)
       nil_name.valid?.should be_true
 
-      Avram::Validations.validate_inclusion_of nil_name, in: ["Jamie"]
+      Avram::Validations.validate_inclusion_of(nil_name, in: ["Jamie"], allow_nil: false)
+      nil_name.valid?.should be_false
+
+      Avram::Validations.validate_inclusion_of(nil_name, in: ["Jamie"])
       nil_name.valid?.should be_false
     end
   end

--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -206,6 +206,15 @@ describe Avram::Validations do
       Avram::Validations.validate_inclusion_of forbidden_name, in: ["Jamie"]
       forbidden_name.errors.should eq(["is invalid"])
     end
+
+    it "can be allowed to be nil" do
+      nil_name = attribute(nil)
+      Avram::Validations.validate_inclusion_of nil_name, in: ["Jamie"], allow_nil: true
+      nil_name.valid?.should be_true
+
+      Avram::Validations.validate_inclusion_of nil_name, in: ["Jamie"]
+      nil_name.valid?.should be_false
+    end
   end
 
   describe "validate_size_of" do
@@ -218,9 +227,9 @@ describe Avram::Validations do
       Avram::Validations.validate_size_of(too_short_attribute, min: 2)
       too_short_attribute.errors.should eq(["is too short"])
 
-      too_long_attribute = attribute("P")
-      Avram::Validations.validate_size_of(too_long_attribute, min: 2)
-      too_long_attribute.errors.should eq(["is too short"])
+      too_long_attribute = attribute("Supercalifragilisticexpialidocious")
+      Avram::Validations.validate_size_of(too_long_attribute, max: 32)
+      too_long_attribute.errors.should eq(["is too long"])
 
       just_right_attribute = attribute("Goldilocks")
       Avram::Validations.validate_size_of(just_right_attribute, is: 10)
@@ -232,6 +241,21 @@ describe Avram::Validations do
       expect_raises(Avram::ImpossibleValidation) do
         Avram::Validations.validate_size_of does_not_matter, min: 4, max: 1
       end
+    end
+
+    it "can be allowed to be nil" do
+      just_nil = attribute(nil)
+      Avram::Validations.validate_size_of(just_nil, is: 10, allow_nil: true)
+      just_nil.valid?.should be_true
+
+      Avram::Validations.validate_size_of(just_nil, min: 1, max: 2, allow_nil: true)
+      just_nil.valid?.should be_true
+
+      Avram::Validations.validate_size_of(just_nil, is: 10)
+      just_nil.valid?.should be_false
+
+      Avram::Validations.validate_size_of(just_nil, min: 1, max: 2)
+      just_nil.valid?.should be_false
     end
   end
 end

--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -207,7 +207,7 @@ describe Avram::Validations do
       forbidden_name.errors.should eq(["is invalid"])
     end
 
-    it "can be allowed to be nil" do
+    it "can allow nil" do
       nil_name = attribute(nil)
       Avram::Validations.validate_inclusion_of nil_name, in: ["Jamie"], allow_nil: true
       nil_name.valid?.should be_true

--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -243,7 +243,7 @@ describe Avram::Validations do
       end
     end
 
-    it "can be allowed to be nil" do
+    it "can allow nil" do
       just_nil = attribute(nil)
       Avram::Validations.validate_size_of(just_nil, is: 10, allow_nil: true)
       just_nil.valid?.should be_true

--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -208,7 +208,8 @@ describe Avram::Validations do
     end
 
     it "can allow nil" do
-      nil_name = attribute(nil)
+      nil_name = Avram::Attribute(String?).new(value: nil, param: nil, param_key: "fake", name: :fake)
+
       Avram::Validations.validate_inclusion_of(nil_name, in: ["Jamie"], allow_nil: true)
       nil_name.valid?.should be_true
 

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -103,7 +103,7 @@ module Avram::Validations
     end
   end
 
-  # Validates that the attribute value is in a list of allowed values
+  # Validates that nil is allowed with a list of values
   #
   # ```
   # validate_inclusion_of state, in: ["NY", "MA"], allow_nil: true

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -94,12 +94,13 @@ module Avram::Validations
   #
   # This will mark `state` as invalid unless the value is `"NY"`, or `"MA"`.
   def validate_inclusion_of(
-    attribute : Avram::Attribute(T),
+    attribute : Avram::Attribute,
     in allowed_values : Enumerable(T),
-    message : Avram::Attribute::ErrorMessage = "is invalid"
+    message : Avram::Attribute::ErrorMessage = "is invalid",
+    allow_nil : Bool = false
   ) forall T
-    if !allowed_values.includes? attribute.value
-      attribute.add_error message
+    unless allowed_values.includes? attribute.value
+      attribute.add_error message unless allow_nil && attribute.value.nil?
     end
   end
 
@@ -108,9 +109,15 @@ module Avram::Validations
   # ```
   # validate_size_of api_key, is: 32
   # ```
-  def validate_size_of(attribute : Avram::Attribute, *, is exact_size, message : Avram::Attribute::ErrorMessage = "is invalid")
+  def validate_size_of(
+    attribute : Avram::Attribute,
+    *,
+    is exact_size,
+    message : Avram::Attribute::ErrorMessage = "is invalid",
+    allow_nil : Bool = false
+  )
     if attribute.value.to_s.size != exact_size
-      attribute.add_error message
+      attribute.add_error message unless allow_nil && attribute.value.nil?
     end
   end
 
@@ -120,19 +127,28 @@ module Avram::Validations
   # validate_size_of age, min: 18, max: 100
   # validate_size_of account_balance, min: 500
   # ```
-  def validate_size_of(attribute : Avram::Attribute, min = nil, max = nil)
+  def validate_size_of(
+    attribute : Avram::Attribute,
+    min = nil,
+    max = nil,
+    allow_nil : Bool = false
+  )
     if !min.nil? && !max.nil? && min > max
-      raise ImpossibleValidation.new(attribute: attribute.name, message: "size greater than #{min} but less than #{max}")
+      raise ImpossibleValidation.new(
+        attribute: attribute.name,
+        message: "size greater than #{min} but less than #{max}")
     end
 
-    size = attribute.value.to_s.size
+    unless allow_nil && attribute.value.nil?
+      size = attribute.value.to_s.size
 
-    if !min.nil? && size < min
-      attribute.add_error "is too short"
-    end
+      if !min.nil? && size < min
+        attribute.add_error "is too short"
+      end
 
-    if !max.nil? && size > max
-      attribute.add_error "is too long"
+      if !max.nil? && size > max
+        attribute.add_error "is too long"
+      end
     end
   end
 

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -94,13 +94,30 @@ module Avram::Validations
   #
   # This will mark `state` as invalid unless the value is `"NY"`, or `"MA"`.
   def validate_inclusion_of(
-    attribute : Avram::Attribute,
+    attribute : Avram::Attribute(T),
     in allowed_values : Enumerable(T),
-    message : Avram::Attribute::ErrorMessage = "is invalid",
-    allow_nil : Bool = false
+    message : Avram::Attribute::ErrorMessage = "is invalid"
   ) forall T
     unless allowed_values.includes? attribute.value
-      attribute.add_error message unless allow_nil && attribute.value.nil?
+      attribute.add_error message
+    end
+  end
+
+  # Validates that the attribute value is in a list of allowed values
+  #
+  # ```
+  # validate_inclusion_of state, in: ["NY", "MA"], allow_nil: true
+  # ```
+  #
+  # This will mark `state` as invalid unless the value is `nil`, `"NY"` or `"MA"`.
+  def validate_inclusion_of(
+    attribute : Avram::Attribute(Nil),
+    in allowed_values : Enumerable,
+    message : Avram::Attribute::ErrorMessage = "is invalid",
+    allow_nil : Bool = false
+  )
+    unless allow_nil && attribute.value.nil?
+      attribute.add_error message
     end
   end
 

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -96,28 +96,11 @@ module Avram::Validations
   def validate_inclusion_of(
     attribute : Avram::Attribute(T),
     in allowed_values : Enumerable(T),
-    message : Avram::Attribute::ErrorMessage = "is invalid"
-  ) forall T
-    unless allowed_values.includes? attribute.value
-      attribute.add_error message
-    end
-  end
-
-  # Validates that nil is allowed with a list of values
-  #
-  # ```
-  # validate_inclusion_of state, in: ["NY", "MA"], allow_nil: true
-  # ```
-  #
-  # This will mark `state` as invalid unless the value is `nil`, `"NY"` or `"MA"`.
-  def validate_inclusion_of(
-    attribute : Avram::Attribute(Nil),
-    in allowed_values : Enumerable,
     message : Avram::Attribute::ErrorMessage = "is invalid",
     allow_nil : Bool = false
-  )
-    unless allow_nil && attribute.value.nil?
-      attribute.add_error message
+  ) forall T
+    unless allowed_values.includes? attribute.value
+      attribute.add_error message unless allow_nil && attribute.value.nil?
     end
   end
 


### PR DESCRIPTION
As suggested in #293, this PR adds an `allow_nil` option for `validate_size_of` and `validate_inclusion_of`.