### PR TITLE
Add boolean getter for boolean columns.

### DIFF
--- a/db/migrations/20170127143149_create_users.cr
+++ b/db/migrations/20170127143149_create_users.cr
@@ -8,6 +8,7 @@ class CreateUsers::V20170127143149 < Avram::Migrator::Migration::V1
       add age : Int32
       add joined_at : Time
       add average_score : Float64?
+      add available_for_hire : Bool?
     end
   end
 

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -45,7 +45,8 @@ describe Avram::Model do
       created_at: now,
       updated_at: now,
       nickname: "nick",
-      average_score: nil
+      average_score: nil,
+      available_for_hire: nil
 
     user.name.should eq "Name"
     user.age.should eq 24
@@ -53,6 +54,8 @@ describe Avram::Model do
     user.updated_at.should eq now
     user.created_at.should eq now
     user.nickname.should eq "nick"
+    user.available_for_hire.should be_nil
+    user.available_for_hire?.should be_false
   end
 
   it "can be used for params" do
@@ -65,7 +68,8 @@ describe Avram::Model do
       created_at: now,
       updated_at: now,
       nickname: "nick",
-      average_score: nil
+      average_score: nil,
+      available_for_hire: nil
 
     user.to_param.should eq "123"
   end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -795,9 +795,10 @@ describe Avram::Query do
         .joined_at.lt(an_hour)
         .average_score.gt(1.2)
         .average_score.lt(4.9)
+        .available_for_hire(true)
         .created_at(a_day)
 
-      query.to_prepared_sql.should eq(%{SELECT users.id, users.created_at, users.updated_at, users.name, users.age, users.nickname, users.joined_at, users.average_score FROM users WHERE users.name = 'Don' AND users.age > '21' AND users.age < '99' AND users.nickname ILIKE 'j%' AND users.nickname ILIKE '%y' AND users.joined_at > '#{a_week}' AND users.joined_at < '#{an_hour}' AND users.average_score > '1.2' AND users.average_score < '4.9' AND users.created_at = '#{a_day}'})
+      query.to_prepared_sql.should eq(%{SELECT users.id, users.created_at, users.updated_at, users.name, users.age, users.nickname, users.joined_at, users.average_score, users.available_for_hire FROM users WHERE users.name = 'Don' AND users.age > '21' AND users.age < '99' AND users.nickname ILIKE 'j%' AND users.nickname ILIKE '%y' AND users.joined_at > '#{a_week}' AND users.joined_at < '#{an_hour}' AND users.average_score > '1.2' AND users.average_score < '4.9' AND users.available_for_hire = 'true' AND users.created_at = '#{a_day}'})
     end
   end
 

--- a/spec/support/boxes/user_box.cr
+++ b/spec/support/boxes/user_box.cr
@@ -14,7 +14,8 @@ class UserBox < BaseBox
       age: 18,
       name: "Paul Smith",
       nickname: nil,
-      average_score: nil
+      average_score: nil,
+      available_for_hire: nil
     )
   end
 end

--- a/spec/support/user.cr
+++ b/spec/support/user.cr
@@ -1,5 +1,5 @@
 class User < BaseModel
-  COLUMN_SQL = "users.id, users.created_at, users.updated_at, users.name, users.age, users.nickname, users.joined_at, users.average_score"
+  COLUMN_SQL = "users.id, users.created_at, users.updated_at, users.name, users.age, users.nickname, users.joined_at, users.average_score, users.available_for_hire"
 
   table do
     column name : String
@@ -7,6 +7,7 @@ class User < BaseModel
     column nickname : String?
     column joined_at : Time
     column average_score : Float64?
+    column available_for_hire : Bool?
     has_one sign_in_credential : SignInCredential?
   end
 end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -183,6 +183,11 @@ abstract class Avram::Model
           %from_db.as({{column[:type]}})
         {% end %}
       end
+      {% if column[:type].id == Bool.id %}
+      def {{column[:name]}}? : Bool
+        !!{{column[:name]}}
+      end
+      {% end %}
     {% end %}
   end
 


### PR DESCRIPTION
As discussed in #288, this PR adds the `method_name?` variant for boolean columns, and includes a boolean column in the specs as well.