### PR TITLE
[DO NOT MERGE] v0.12.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.31.1
+FROM crystallang/crystal:0.33.0
 WORKDIR /data
 
 # install base dependencies
@@ -6,7 +6,7 @@ RUN apt-get update && \
   apt-get install -y libgconf-2-4 curl libreadline-dev && \
   # postgres 11 installation
   curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-  echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" | tee /etc/apt/sources.list.d/postgres.list && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" | tee /etc/apt/sources.list.d/postgres.list && \
   apt-get update && \
   apt-get install -y postgresql-11 && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: avram
-version: 0.12.2
+version: 0.12.3
 
-crystal: 0.32.0
+crystal: 0.33.0
 
 targets:
   lucky.gen.migration:

--- a/src/avram/version.cr
+++ b/src/avram/version.cr
@@ -1,3 +1,3 @@
 module Avram
-  VERSION = "0.12.2"
+  VERSION = "0.12.3"
 end


### PR DESCRIPTION
Bump patch versions for some Crystal 0.33.0 support. Nothing has changed to affect this shard. This release is just 0.12.2 with these commits.