### PR TITLE
Fix Criteria#select_sum

### DIFF
--- a/db/migrations/20170127143149_create_users.cr
+++ b/db/migrations/20170127143149_create_users.cr
@@ -6,6 +6,7 @@ class CreateUsers::V20170127143149 < Avram::Migrator::Migration::V1
       add name : String
       add nickname : String?
       add age : Int32
+      add year_born : Int16?
       add joined_at : Time
       add average_score : Float64?
       add available_for_hire : Bool?

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -41,6 +41,7 @@ describe Avram::Model do
     user = User.new id: 123_i64,
       name: "Name",
       age: 24,
+      year_born: 1990_i16,
       joined_at: now,
       created_at: now,
       updated_at: now,
@@ -50,6 +51,7 @@ describe Avram::Model do
 
     user.name.should eq "Name"
     user.age.should eq 24
+    user.year_born.should eq 1990_i16
     user.joined_at.should eq now
     user.updated_at.should eq now
     user.created_at.should eq now
@@ -64,6 +66,7 @@ describe Avram::Model do
     user = User.new id: 123_i64,
       name: "Name",
       age: 24,
+      year_born: 1990_i16,
       joined_at: now,
       created_at: now,
       updated_at: now,

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -393,8 +393,15 @@ describe Avram::Query do
     end
 
     it "returns nil if there are no records" do
-      queried_sum = UserQuery.new.age.select_sum
-      queried_sum.should be_nil
+      query_sum = UserQuery.new.age.select_sum
+      query_sum.should be_nil
+    end
+  end
+
+  describe "#select_sum! for Int32 column" do
+    it "returns 0 if there are no records" do
+      query_sum = UserQuery.new.age.select_sum!
+      query_sum.should eq 0_i64
     end
   end
 
@@ -416,8 +423,15 @@ describe Avram::Query do
     end
 
     it "returns nil if there are no records" do
-      queried_sum = UserQuery.new.id.select_sum
-      queried_sum.should be_nil
+      query_sum = UserQuery.new.id.select_sum
+      query_sum.should be_nil
+    end
+  end
+
+  describe "#select_sum! for Int64 column" do
+    it "returns 0 if there are no records" do
+      query_sum = UserQuery.new.id.select_sum!
+      query_sum.should eq 0_i64
     end
   end
 
@@ -432,8 +446,8 @@ describe Avram::Query do
 
     it "works with chained where clauses" do
       years = [1990_i16, 1995_i16]
-      out_of_range = 2000_i16
       sum = years.sum
+      out_of_range = 2000_i16
       years.each { |year| UserBox.create &.year_born(year) }
       UserBox.create &.year_born(out_of_range)
       query_sum = UserQuery.new.year_born.lt(2000).year_born.select_sum
@@ -441,8 +455,46 @@ describe Avram::Query do
     end
 
     it "returns nil if there are no records" do
-      queried_sum = UserQuery.new.year_born.select_sum
-      queried_sum.should be_nil
+      query_sum = UserQuery.new.year_born.select_sum
+      query_sum.should be_nil
+    end
+  end
+
+  describe "#select_sum! for Int16 column" do
+    it "returns 0 if there are no records" do
+      query_sum = UserQuery.new.year_born.select_sum!
+      query_sum.should eq 0_i64
+    end
+  end
+
+  describe "#select_sum for Float64 column" do
+    it "returns the sum" do
+      scores = [100.4, 123.22]
+      sum = scores.sum
+      scores.each { |score| UserBox.create &.average_score(score) }
+      query_sum = UserQuery.new.average_score.select_sum
+      query_sum.should eq sum
+    end
+
+    it "works with chained where clauses" do
+      scores = [100.4, 123.22]
+      sum = scores.sum
+      out_of_range = 200
+      scores.each { |score| UserBox.create &.average_score(score) }
+      query_sum = UserQuery.new.average_score.lt(out_of_range).average_score.select_sum
+      query_sum.should eq sum
+    end
+
+    it "returns nil if there are no records" do
+      query_sum = UserQuery.new.id.select_sum
+      query_sum.should be_nil
+    end
+  end
+
+  describe "#select_sum! for Float64 column" do
+    it "returns 0 if there are no records" do
+      query_sum = UserQuery.new.id.select_sum!
+      query_sum.should eq 0_i64
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -375,7 +375,7 @@ describe Avram::Query do
     end
   end
 
-  describe "#select_sum" do
+  describe "#select_sum for Int32 column" do
     it "returns the sum" do
       UserBox.create &.age(2)
       UserBox.create &.age(1)
@@ -390,6 +390,59 @@ describe Avram::Query do
       UserBox.create &.age(3)
       sum = UserQuery.new.age.gte(2).age.select_sum
       sum.should eq 5
+    end
+
+    it "returns nil if there are no records" do
+      queried_sum = UserQuery.new.age.select_sum
+      queried_sum.should be_nil
+    end
+  end
+
+  describe "#select_sum for Int64 column" do
+    it "returns the sum" do
+      sum = UserBox.create.id + UserBox.create.id
+      query_sum = UserQuery.new.id.select_sum
+      query_sum.should eq sum
+    end
+
+    it "works with chained where clauses" do
+      user1 = UserBox.create
+      user2 = UserBox.create
+      user3 = UserBox.create
+      sum = user1.id + user2.id
+
+      query_sum = UserQuery.new.id.not.eq(user3.id).id.select_sum
+      query_sum.should eq sum
+    end
+
+    it "returns nil if there are no records" do
+      queried_sum = UserQuery.new.id.select_sum
+      queried_sum.should be_nil
+    end
+  end
+
+  describe "#select_sum for Int16 column" do
+    it "returns the sum" do
+      years = [1990_i16, 1995_i16]
+      sum = years.sum
+      years.each { |year| UserBox.create &.year_born(year) }
+      query_sum = UserQuery.new.year_born.select_sum
+      query_sum.should eq sum
+    end
+
+    it "works with chained where clauses" do
+      years = [1990_i16, 1995_i16]
+      out_of_range = 2000_i16
+      sum = years.sum
+      years.each { |year| UserBox.create &.year_born(year) }
+      UserBox.create &.year_born(out_of_range)
+      query_sum = UserQuery.new.year_born.lt(2000).year_born.select_sum
+      query_sum.should eq sum
+    end
+
+    it "returns nil if there are no records" do
+      queried_sum = UserQuery.new.year_born.select_sum
+      queried_sum.should be_nil
     end
   end
 
@@ -798,7 +851,7 @@ describe Avram::Query do
         .available_for_hire(true)
         .created_at(a_day)
 
-      query.to_prepared_sql.should eq(%{SELECT users.id, users.created_at, users.updated_at, users.name, users.age, users.nickname, users.joined_at, users.average_score, users.available_for_hire FROM users WHERE users.name = 'Don' AND users.age > '21' AND users.age < '99' AND users.nickname ILIKE 'j%' AND users.nickname ILIKE '%y' AND users.joined_at > '#{a_week}' AND users.joined_at < '#{an_hour}' AND users.average_score > '1.2' AND users.average_score < '4.9' AND users.available_for_hire = 'true' AND users.created_at = '#{a_day}'})
+      query.to_prepared_sql.should eq(%{SELECT users.id, users.created_at, users.updated_at, users.name, users.age, users.year_born, users.nickname, users.joined_at, users.average_score, users.available_for_hire FROM users WHERE users.name = 'Don' AND users.age > '21' AND users.age < '99' AND users.nickname ILIKE 'j%' AND users.nickname ILIKE '%y' AND users.joined_at > '#{a_week}' AND users.joined_at < '#{an_hour}' AND users.average_score > '1.2' AND users.average_score < '4.9' AND users.available_for_hire = 'true' AND users.created_at = '#{a_day}'})
     end
   end
 

--- a/spec/support/boxes/user_box.cr
+++ b/spec/support/boxes/user_box.cr
@@ -12,6 +12,7 @@ class UserBox < BaseBox
       updated_at: Time.utc,
       joined_at: Time.utc,
       age: 18,
+      year_born: nil,
       name: "Paul Smith",
       nickname: nil,
       average_score: nil,

--- a/spec/support/user.cr
+++ b/spec/support/user.cr
@@ -1,9 +1,10 @@
 class User < BaseModel
-  COLUMN_SQL = "users.id, users.created_at, users.updated_at, users.name, users.age, users.nickname, users.joined_at, users.average_score, users.available_for_hire"
+  COLUMN_SQL = "users.id, users.created_at, users.updated_at, users.name, users.age, users.year_born, users.nickname, users.joined_at, users.average_score, users.available_for_hire"
 
   table do
     column name : String
     column age : Int32
+    column year_born : Int16?
     column nickname : String?
     column joined_at : Time
     column average_score : Float64?

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -51,6 +51,12 @@ struct Float64
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)
+
+      def select_sum : Float64?
+        if sum = super
+          sum.as(PG::Numeric).to_f
+        end
+      end
     end
   end
 end

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -57,6 +57,10 @@ struct Float64
           sum.as(PG::Numeric).to_f
         end
       end
+
+      def select_sum! : Float64
+        select_sum || 0_f64
+      end
     end
   end
 end

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -45,6 +45,10 @@ struct Int16
       def select_sum : Int64?
         super.as(Int64?)
       end
+
+      def select_sum! : Int64
+        select_sum || 0_i64
+      end
     end
   end
 end

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -41,6 +41,10 @@ struct Int16
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)
+
+      def select_sum : Int64?
+        super.as(Int64?)
+      end
     end
   end
 end

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -41,6 +41,10 @@ struct Int32
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)
+
+      def select_sum : Int64?
+        super.as(Int64?)
+      end
     end
   end
 end

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -45,6 +45,10 @@ struct Int32
       def select_sum : Int64?
         super.as(Int64?)
       end
+
+      def select_sum! : Int64
+        select_sum || 0_i64
+      end
     end
   end
 end

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -45,6 +45,10 @@ struct Int64
           sum.as(PG::Numeric).to_f.to_i64
         end
       end
+
+      def select_sum! : Int64
+        select_sum || 0_i64
+      end
     end
   end
 end

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -39,6 +39,12 @@ struct Int64
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)
+
+      def select_sum : Int64?
+        if sum = super
+          sum.as(PG::Numeric).to_f.to_i64
+        end
+      end
     end
   end
 end

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -115,9 +115,9 @@ class Avram::Criteria(T, V)
     rows.exec_scalar.as(PG::Numeric).to_f
   end
 
-  def select_sum : Int64
+  def select_sum
     rows.query.select_sum(column)
-    rows.exec_scalar.as(Int64)
+    rows.exec_scalar
   end
 
   def in(values) : T


### PR DESCRIPTION
Currently select_sum only works for Int32 and Int16 columns. The fix allows select_sum for Int16, Int32, Int62, and Float64 columns.

This also fixes an issue when the result is nil which was failing before.

This change also ads a `select_sum!` method that returns 0 of the correct type instead of nil if there are no records.

See issue #292 