### PR TITLE
Specs for empty boxes

### DIFF
--- a/db/migrations/20200227193531_create_virgin.cr
+++ b/db/migrations/20200227193531_create_virgin.cr
@@ -1,0 +1,12 @@
+class CreateVirgin::V20200227193533 < Avram::Migrator::Migration::V1
+  def migrate
+    create :virgins do
+      primary_key id : Int64
+      add_timestamps
+    end
+  end
+
+  def rollback
+    drop :virgins
+  end
+end

--- a/spec/box_spec.cr
+++ b/spec/box_spec.cr
@@ -1,6 +1,12 @@
 require "./spec_helper"
 
 describe Avram::Box do
+  describe "Virgin model" do
+    it "creates a model without additional columns" do
+      VirginBox.create.id.should_not be_nil
+    end
+  end
+
   describe "Sequences" do
     it "increases a value every time it's called" do
       BaseBox::SEQUENCES["name"] = 0

--- a/spec/support/boxes/virgin_box.cr
+++ b/spec/support/boxes/virgin_box.cr
@@ -1,0 +1,4 @@
+class VirginBox < BaseBox
+  def initialize
+  end
+end

--- a/spec/support/virgin.cr
+++ b/spec/support/virgin.cr
@@ -1,0 +1,4 @@
+class Virgin < BaseModel
+  table do
+  end
+end


### PR DESCRIPTION
Added a model with just the default columns, its box and a spec to verify the box is created properly. With the old code it failed, with the new code, which is already in master, all specs pass. So this confirms the fix for #309.