### PR TITLE
Disallow raw Hash in SaveOperation

### DIFF
--- a/spec/define_attribute_spec.cr
+++ b/spec/define_attribute_spec.cr
@@ -108,5 +108,5 @@ describe "attribute in operations" do
 end
 
 private def operation(attrs = {} of String => String)
-  Operation.new(attrs)
+  Operation.new(Avram::Params.new(attrs))
 end

--- a/spec/operation_needs_spec.cr
+++ b/spec/operation_needs_spec.cr
@@ -28,7 +28,7 @@ end
 
 describe "Avram::SaveOperation needs" do
   it "doesn't change the initializer if an 'on' option is used'" do
-    params = {"name" => "Paul"}
+    params = Avram::Params.new({"name" => "Paul"})
     user = UserBox.create
 
     operation = NeedsWithOnOptionSaveOperation.new(params)
@@ -42,7 +42,7 @@ describe "Avram::SaveOperation needs" do
   end
 
   it "sets up a method arg for save, update, and new" do
-    params = {"name" => "Paul"}
+    params = Avram::Params.new({"name" => "Paul"})
     UserBox.create
     user = UserQuery.new.first
 
@@ -70,7 +70,7 @@ describe "Avram::SaveOperation needs" do
   end
 
   it "can have needs for just save, create or update" do
-    params = {"name" => "Paul"}
+    params = Avram::Params.new({"name" => "Paul"})
     UserBox.create
     user = UserQuery.new.first
 

--- a/spec/save_operation_callbacks_spec.cr
+++ b/spec/save_operation_callbacks_spec.cr
@@ -125,7 +125,7 @@ describe "Avram::SaveOperation callbacks" do
   end
 
   it "runs before_save in parent class and before_save in child class" do
-    params = {"name" => "A fancy hat"}
+    params = Avram::Params.new({"name" => "A fancy hat"})
     SaveLineItemSub.create params do |operation, record|
       operation.locked.should be_true
       operation.loaded.should be_true

--- a/spec/save_operation_spec.cr
+++ b/spec/save_operation_spec.cr
@@ -372,7 +372,7 @@ describe "Avram::SaveOperation" do
 
     context "on failure" do
       it "raises an exception" do
-        params = {"name" => "", "age" => "30"}
+        params = Avram::Params.new({"name" => "", "age" => "30"})
 
         expect_raises Avram::InvalidOperationError do
           SaveUser.create!(params)
@@ -391,7 +391,7 @@ describe "Avram::SaveOperation" do
     end
 
     it "can handle an attribute named 'value'" do
-      ValueColumnModelSaveOperation.new({"value" => "value"}).value.value.should eq "value"
+      ValueColumnModelSaveOperation.new(Avram::Params.new({"value" => "value"})).value.value.should eq "value"
     end
   end
 
@@ -436,7 +436,7 @@ describe "Avram::SaveOperation" do
 
       it "updates updated_at" do
         user = UserBox.new.updated_at(1.day.ago).create
-        params = {"name" => "New Name"}
+        params = Avram::Params.new({"name" => "New Name"})
         SaveUser.update user, with: params do |operation, record|
           operation.saved?.should be_true
           record.updated_at.should be > 1.second.ago
@@ -448,7 +448,7 @@ describe "Avram::SaveOperation" do
       it "yields the operation and nil" do
         UserBox.new.name("Old Name").create
         user = UserQuery.new.first
-        params = {"name" => ""}
+        params = Avram::Params.new({"name" => ""})
         SaveUser.update user, with: params do |operation, record|
           operation.save_failed?.should be_true
           record.name.should eq "Old Name"
@@ -470,7 +470,7 @@ describe "Avram::SaveOperation" do
     context "with a uuid backed model" do
       it "doesn't generate a new uuid" do
         line_item = LineItemBox.create
-        SaveLineItem.update(line_item, {"name" => "Another pair of shoes"}) do |operation, record|
+        SaveLineItem.update(line_item, Avram::Params.new({"name" => "Another pair of shoes"})) do |operation, record|
           operation.saved?.should be_true
           record.id.should eq line_item.id
         end
@@ -489,7 +489,7 @@ describe "Avram::SaveOperation" do
       it "updates and returns the record" do
         UserBox.new.name("Old Name").create
         user = UserQuery.new.first
-        params = {"name" => "New Name"}
+        params = Avram::Params.new({"name" => "New Name"})
 
         record = SaveUser.update! user, with: params
 
@@ -502,7 +502,7 @@ describe "Avram::SaveOperation" do
       it "raises an exception" do
         UserBox.new.name("Old Name").create
         user = UserQuery.new.first
-        params = {"name" => ""}
+        params = Avram::Params.new({"name" => ""})
 
         expect_raises Avram::InvalidOperationError do
           SaveUser.update! user, with: params

--- a/spec/transaction_spec.cr
+++ b/spec/transaction_spec.cr
@@ -35,7 +35,7 @@ describe "Avram::SaveOperation" do
 
   describe "updating" do
     it "runs in a transaction" do
-      params = {"title" => "New Title"}
+      params = Avram::Params.new({"title" => "New Title"})
       post = PostBox.new.title("Old Title").create
       Post::BaseQuery.new.first.title.should eq "Old Title"
 
@@ -53,7 +53,7 @@ describe "Avram::SaveOperation" do
 
   describe "creating" do
     it "runs in a transaction" do
-      params = {"title" => "New Title"}
+      params = Avram::Params.new({"title" => "New Title"})
       PostTransactionSaveOperation.create(params, rollback_after_save: true) do |operation, post|
         Post::BaseQuery.new.select_count.to_i.should eq(0)
         post.should be_nil
@@ -70,7 +70,7 @@ describe "Avram::SaveOperation" do
 
   describe "raising an error" do
     it "rolls back the transaction and re-raises the error" do
-      params = {"title" => "New Title"}
+      params = Avram::Params.new({"title" => "New Title"})
       expect_raises Exception, "Sad face" do
         BadSaveOperation.create(params) do |operation, post|
           raise "This should not be executed"

--- a/spec/type_extension_spec.cr
+++ b/spec/type_extension_spec.cr
@@ -29,7 +29,7 @@ describe "TypeExtensions" do
   end
 
   it "should convert params and save forms" do
-    operation = SaveCompany.new({"sales" => "10", "earnings" => "10"})
+    operation = SaveCompany.new(Avram::Params.new({"sales" => "10", "earnings" => "10"}))
     operation.sales.value.should eq 10_i64
     operation.earnings.value.should eq 10.0
   end

--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -185,7 +185,6 @@ module Avram::NeedyInitializerAndSaveMethods
 
   macro generate_initializer
     def initialize(
-        # params : Hash(String, String) | Avram::Paramable,
         @params : Avram::Paramable,
         {% for type_declaration in NEEDS_ON_INITIALIZE %}
           @{{ type_declaration }},
@@ -205,7 +204,6 @@ module Avram::NeedyInitializerAndSaveMethods
 
     def initialize(
         @record : T,
-        # params : Hash(String, String) | Avram::Paramable,
         @params : Avram::Paramable,
         {% for type_declaration in NEEDS_ON_INITIALIZE %}
           @{{ type_declaration }},

--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -185,12 +185,12 @@ module Avram::NeedyInitializerAndSaveMethods
 
   macro generate_initializer
     def initialize(
-        params : Hash(String, String) | Avram::Paramable,
+        # params : Hash(String, String) | Avram::Paramable,
+        @params : Avram::Paramable,
         {% for type_declaration in NEEDS_ON_INITIALIZE %}
           @{{ type_declaration }},
         {% end %}
       )
-      @params = ensure_paramable(params)
       extract_changes_from_params
     end
 
@@ -205,12 +205,12 @@ module Avram::NeedyInitializerAndSaveMethods
 
     def initialize(
         @record : T,
-        params : Hash(String, String) | Avram::Paramable,
+        # params : Hash(String, String) | Avram::Paramable,
+        @params : Avram::Paramable,
         {% for type_declaration in NEEDS_ON_INITIALIZE %}
           @{{ type_declaration }},
         {% end %}
       )
-      @params = ensure_paramable(params)
       extract_changes_from_params
     end
 

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -163,8 +163,6 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
     end
   end
 
-  # Avram::Params.new(params)
-
   # Runs `before_save` steps,
   # required validation, then returns `true` if all attributes are valid.
   def valid? : Bool

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -163,13 +163,7 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
     end
   end
 
-  private def ensure_paramable(params)
-    if params.is_a? Avram::Paramable
-      params
-    else
-      Avram::Params.new(params)
-    end
-  end
+  # Avram::Params.new(params)
 
   # Runs `before_save` steps,
   # required validation, then returns `true` if all attributes are valid.


### PR DESCRIPTION
PR for #204 
**BREAKING CHANGE**

**Reasoning:**
> The main problem we're trying to solve with disallowing hash directly is that people use it without realizing the alternative and end up losing type-safety (and making their apps more complex because they try to merge things together)