### PR TITLE
Added reset_where method for specific columns.

### DIFF
--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -29,6 +29,23 @@ describe Avram::QueryBuilder do
     query.statement.should eq "SELECT * FROM users"
   end
 
+  it "can reset where for a specific column" do
+    query = new_query
+      .where(Avram::Where::GreaterThan.new(:age, "18"))
+      .where(Avram::Where::LessThan.new(:age, "81"))
+      .where(Avram::Where::Equal.new(:name, "Pauline"))
+    query.args.should eq ["18", "81", "Pauline"]
+
+    query.reset_where("name")
+
+    query.statement.should eq "SELECT * FROM users WHERE age > $1 AND age < $2"
+    query.args.should eq ["18", "81"]
+
+    query.reset_where(:age)
+
+    query.args.should be_empty
+  end
+
   it "selects all" do
     new_query.statement.should eq "SELECT * FROM users"
     new_query.args.should eq [] of String

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -42,6 +42,13 @@ describe Avram::Query do
     query.args.should eq [] of String
   end
 
+  it "can reset where on a specific column" do
+    query = UserQuery.new.name("Purcell").age(35).reset_where(&.name).query
+
+    query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE users.age = $1"
+    query.args.should eq ["35"] of String
+  end
+
   it "can select distinct on a specific column" do
     UserBox.new.name("Purcell").age(22).create
     UserBox.new.name("Purcell").age(84).create

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -135,6 +135,11 @@ class Avram::Criteria(T, V)
     rows.query.group_by(column)
   end
 
+  # :nodoc:
+  def __reset_where : Avram::QueryBuilder
+    rows.query.reset_where(column)
+  end
+
   private def add_clause(sql_clause) : T
     sql_clause = build_sql_clause(sql_clause)
     rows.query.where(sql_clause)

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -1,7 +1,7 @@
 class Avram::QueryBuilder
   alias ColumnName = Symbol | String
   getter table
-  getter distinct_on : String | Symbol | Nil = nil
+  getter distinct_on : ColumnName | Nil = nil
   @limit : Int32?
   @offset : Int32?
   @wheres = [] of Avram::Where::SqlClause
@@ -122,7 +122,7 @@ class Avram::QueryBuilder
     self
   end
 
-  def distinct_on(column : Symbol | String)
+  def distinct_on(column : ColumnName)
     @distinct_on = column
     self
   end
@@ -153,6 +153,11 @@ class Avram::QueryBuilder
 
   def order_by(order : OrderBy)
     @orders << order
+    self
+  end
+
+  def reset_where(column : ColumnName)
+    @wheres.reject! { |clause| clause.column.to_s == column.to_s }
     self
   end
 
@@ -243,7 +248,7 @@ class Avram::QueryBuilder
       .map { |column| column.split(".").last }
   end
 
-  def select(selection : Array(Symbol | String))
+  def select(selection : Array(ColumnName))
     @selections = selection
       .map { |column| "#{@table}.#{column}" }
       .join(", ")

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -78,6 +78,12 @@ module Avram::Queryable(T)
     self
   end
 
+  def reset_where(&block) : self
+    criteria = yield self
+    criteria.__reset_where
+    self
+  end
+
   # Delete the records using the query's where clauses,
   # or all the records if no wheres are added.
   #


### PR DESCRIPTION
This will reset where for a specific column. Initially, you could also call `query.reset_where` without a block, which would reset all where clauses. But I removed that because it could lead to unexpected/unwanted results.

Closes #319