### PR TITLE
Log failed queries

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,6 +13,13 @@ Spec.before_each do
   TestDatabase.truncate
 end
 
+logger = Dexter::Logger.new(STDERR, level: Logger::Severity::ERROR)
+
+Avram.configure do |settings|
+  settings.logger = logger
+  settings.query_failed_log_level = Logger::Severity::ERROR
+end
+
 class SampleBackupDatabase < Avram::Database
 end
 

--- a/src/avram.cr
+++ b/src/avram.cr
@@ -21,6 +21,7 @@ module Avram
     setting logger : Dexter::Logger = Dexter::Logger.new(nil)
     setting query_log_level : ::Logger::Severity?
     setting save_failed_log_level : ::Logger::Severity? = ::Logger::Severity::WARN
+    setting query_failed_log_level : ::Logger::Severity? = ::Logger::Severity::ERROR
     setting database_to_migrate : Avram::Database.class, example: "AppDatabase"
     setting time_formats : Array(String) = [] of String
   end

--- a/src/avram/pool_statement_logging.cr
+++ b/src/avram/pool_statement_logging.cr
@@ -3,26 +3,41 @@ module DB
     def exec : ExecResult
       log_query
       statement_with_retry &.exec
+    rescue e : PQ::PQError
+      log_error
+      raise e
     end
 
     def exec(*args_, args : Array? = nil) : ExecResult
       log_query(*args_, args: args)
       statement_with_retry &.exec(*args_, args: args)
+    rescue e : PQ::PQError
+      log_error(*args_, args: args)
+      raise e
     end
 
     def query : ResultSet
       log_query
       statement_with_retry &.query
+    rescue e : PQ::PQError
+      log_error
+      raise e
     end
 
     def query(*args_, args : Array? = nil) : ResultSet
       log_query(*args_, args: args)
       statement_with_retry &.query(*args_, args: args)
+    rescue e : PQ::PQError
+      log_error(*args_, args: args)
+      raise e
     end
 
     def scalar(*args_, args : Array? = nil)
       log_query(*args_, args: args)
       statement_with_retry &.scalar(*args_, args: args)
+    rescue e : PQ::PQError
+      log_error(*args_, args: args)
+      raise e
     end
 
     private def log_query(*args_, args : Array? = nil)
@@ -30,6 +45,14 @@ module DB
         logging_args = EnumerableConcat.build(args_, args)
         logging_args = logging_args.to_a if logging_args.is_a?(EnumerableConcat)
         Avram.logger.log(level, {query: @query, args: logging_args})
+      end
+    end
+
+    private def log_error(*args_, args : Array? = nil)
+      Avram.settings.query_failed_log_level.try do |level|
+        logging_args = EnumerableConcat.build(args_, args)
+        logging_args = logging_args.to_a if logging_args.is_a?(EnumerableConcat)
+        Avram.logger.log(level, {failed_query: @query, args: logging_args})
       end
     end
   end


### PR DESCRIPTION
Ran into this while working on #322. I wanted to see the failed query.

The downside to this is that if you happen to rescue a `PQ::PQError` later in your app the failed query will still be logged. I think this is acceptable though since I can't think of a reason not to.

I've added a setting though just in case you don't want to log failed queries