### PR TITLE
Fix fill_existing_with when there's already data existing

### DIFF
--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -23,7 +23,7 @@ describe Avram::Migrator::AlterTableStatement do
     built.statements.first.should eq <<-SQL
     ALTER TABLE users
       ADD name text,
-      ADD email text NOT NULL,
+      ADD email text,
       ADD nickname text NOT NULL,
       ADD age int NOT NULL DEFAULT '1',
       ADD num bigint NOT NULL DEFAULT '1',
@@ -31,12 +31,12 @@ describe Avram::Migrator::AlterTableStatement do
       ADD completed boolean NOT NULL DEFAULT 'false',
       ADD meta jsonb NOT NULL DEFAULT '{"default":"value"}',
       ADD joined_at timestamptz NOT NULL DEFAULT NOW(),
-      ADD updated_at timestamptz NOT NULL,
+      ADD updated_at timestamptz,
       ADD future_time timestamptz NOT NULL DEFAULT '#{Time.local.to_utc}',
       ADD new_id uuid NOT NULL DEFAULT '46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0',
       ADD numbers int[] NOT NULL,
       DROP old_column,
-      DROP employee_id
+      DROP employee_id;
     SQL
 
     built.statements.size.should eq 9
@@ -80,7 +80,7 @@ describe Avram::Migrator::AlterTableStatement do
         ADD post_id bigint REFERENCES posts ON DELETE RESTRICT,
         ADD category_label_id bigint NOT NULL REFERENCES custom_table ON DELETE SET NULL,
         ADD employee_id bigint NOT NULL REFERENCES users ON DELETE CASCADE,
-        ADD line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE
+        ADD line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE;
       SQL
 
       built.statements[1].should eq "CREATE INDEX comments_user_id_index ON comments USING btree (user_id);"

--- a/spec/migrator/migration_spec.cr
+++ b/spec/migrator/migration_spec.cr
@@ -31,6 +31,21 @@ class MigrationWithOrderDependentExecute::V998 < Avram::Migrator::Migration::V1
   end
 end
 
+class MigrationWithAlterAndFillExisting::V997 < Avram::Migrator::Migration::V1
+  def migrate
+    execute "CREATE TABLE execution_order (x integer NOT NULL);"
+    execute "INSERT INTO execution_order (x) VALUES (1);"
+
+    alter :execution_order do
+      add y : Int32, fill_existing_with: "2"
+    end
+  end
+
+  def rollback
+    drop :execution_order
+  end
+end
+
 describe Avram::Migrator::Migration::V1 do
   it "executes statements in a transaction" do
     expect_raises Exception, %(relation "table_does_not_exist" does not exist) do
@@ -48,10 +63,23 @@ describe Avram::Migrator::Migration::V1 do
       begin
         MigrationWithOrderDependentExecute::V998.new.up(quiet: true)
         columns = get_column_names("execution_order")
-        columns.includes?("new_col").should be_true
-        columns.includes?("bar").should be_true
+        columns.includes?({"new_col", true}).should be_true
+        columns.includes?({"bar", true}).should be_true
       ensure
         MigrationWithOrderDependentExecute::V998.new.down(quiet: true)
+      end
+    end
+  end
+
+  describe "altering a table with records" do
+    it "adds the new column without raising an exception" do
+      begin
+        MigrationWithAlterAndFillExisting::V997.new.up(quiet: true)
+        columns = get_column_names("execution_order")
+        columns.includes?({"x", false}).should be_true
+        columns.includes?({"y", false}).should be_true
+      ensure
+        MigrationWithAlterAndFillExisting::V997.new.down(quiet: true)
       end
     end
   end
@@ -65,5 +93,5 @@ private def get_column_names(table_name)
     AND table_name = '#{table_name}'
   SQL
 
-  TestDatabase.run { |db| db.query_all statement, as: String }
+  TestDatabase.run { |db| db.query_all statement, as: {String, Bool} }
 end

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -67,6 +67,7 @@ class Avram::Migrator::AlterTableStatement
         statement << "ALTER TABLE #{@table_name}"
         statement << "\n"
         statement << (rows + dropped_rows).join(",\n")
+        statement << ';'
       end
       [statement]
     end
@@ -110,7 +111,7 @@ class Avram::Migrator::AlterTableStatement
       {% array = true %}
     {% else %}
       {% type = type_declaration.type %}
-      {% nilable = false %}
+      {% nilable = (fill_existing_with != nil) && (fill_existing_with != :nothing) %}
       {% array = false %}
     {% end %}
 


### PR DESCRIPTION
Fixes #278

Currently, this fails when your table already has data in it. If your table is empty, then it works fine.

```crystal
  def migrate
    alter table_for(User) do
      add name : String, fill_existing_with: "anonymous"
    end
  end
```

What happens is postgres goes to add the column and sees that it's `NOT NULL`, but we don't fill the "anonymous" string in until after the column exists. So this would give you a NULL value in the new column. That makes postgres sad. 

This PR fixes that by looking to see that there's a `fill_existing_with`, and it's not equal to `:nothing`, then it makes the column temporarily nullable. Then after the column is added, we update it afterward to make it `NOT NULL`.
