### PR TITLE
added enum support

### DIFF
--- a/db/migrations/20200324211956_create_issue.cr
+++ b/db/migrations/20200324211956_create_issue.cr
@@ -1,0 +1,14 @@
+class CreateIssue::V20200324211956 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(Issue) do
+      primary_key id : Int64
+      add status : Int32
+      add role : Int32
+      add_timestamps
+    end
+  end
+
+  def rollback
+    drop table_for(Issue)
+  end
+end

--- a/spec/support/boxes/issue_box.cr
+++ b/spec/support/boxes/issue_box.cr
@@ -1,7 +1,7 @@
 class IssueBox < BaseBox
   def initialize
-    status Issue::AvramStatus.new(0)
-    role Issue::AvramRole.new(0)
+    status Issue::AvramStatus.new(:opened)
+    role Issue::AvramRole.new(:issue)
   end
 
   def build_model

--- a/spec/support/boxes/issue_box.cr
+++ b/spec/support/boxes/issue_box.cr
@@ -1,0 +1,14 @@
+class IssueBox < BaseBox
+  def initialize
+    status Issue::AvramStatus.new(0)
+    role Issue::AvramRole.new(0)
+  end
+
+  def build_model
+    Issue.new(
+      id: 123_i64,
+      status: 0,
+      role: 0
+    )
+  end
+end

--- a/spec/support/boxes/issue_box.cr
+++ b/spec/support/boxes/issue_box.cr
@@ -1,7 +1,7 @@
 class IssueBox < BaseBox
   def initialize
-    status Issue::AvramStatus.new(:opened)
-    role Issue::AvramRole.new(:issue)
+    status Issue::Status.new(:opened)
+    role Issue::Role.new(:issue)
   end
 
   def build_model

--- a/spec/support/issue.cr
+++ b/spec/support/issue.cr
@@ -1,0 +1,23 @@
+class Issue < BaseModel
+  COLUMN_SQL = "issues.id, issues.status, issues.role"
+
+  avram_enum Status do
+    Opened = 0
+    Closed = 1
+    Duplicated = 2
+  end
+
+  avram_enum Role do
+    Issue = 0
+    Bug = 1
+    Critical = 2
+  end
+
+  table do
+    column status : Issue::AvramStatus
+    column role : Issue::AvramRole
+  end
+end
+
+class IssueQuery < Issue::BaseQuery
+end

--- a/spec/support/issue.cr
+++ b/spec/support/issue.cr
@@ -2,14 +2,14 @@ class Issue < BaseModel
   COLUMN_SQL = "issues.id, issues.status, issues.role"
 
   avram_enum Status do
-    Opened = 0
-    Closed = 1
+    Opened     = 0
+    Closed     = 1
     Duplicated = 2
   end
 
   avram_enum Role do
-    Issue = 0
-    Bug = 1
+    Issue    = 0
+    Bug      = 1
     Critical = 2
   end
 

--- a/spec/support/issue.cr
+++ b/spec/support/issue.cr
@@ -2,9 +2,9 @@ class Issue < BaseModel
   COLUMN_SQL = "issues.id, issues.status, issues.role"
 
   avram_enum Status do
-    Opened     = 0
-    Closed     = 1
-    Duplicated = 2
+    Opened
+    Closed
+    Duplicated
   end
 
   avram_enum Role do

--- a/spec/support/issue.cr
+++ b/spec/support/issue.cr
@@ -14,8 +14,8 @@ class Issue < BaseModel
   end
 
   table do
-    column status : Issue::AvramStatus
-    column role : Issue::AvramRole
+    column status : Issue::Status
+    column role : Issue::Role
   end
 end
 

--- a/spec/support/issue.cr
+++ b/spec/support/issue.cr
@@ -8,9 +8,9 @@ class Issue < BaseModel
   end
 
   avram_enum Role do
-    Issue    = 0
-    Bug      = 1
-    Critical = 2
+    Issue    = 1
+    Bug      = 2
+    Critical = 3
   end
 
   table do

--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -6,8 +6,8 @@ describe "Enum" do
   it "check enum" do
     issue = IssueBox.create
 
-    issue.status.value.should eq(Issue::AvramStatus::Opened)
-    issue.role.value.should eq(Issue::AvramRole::Issue)
+    issue.status.enum.should eq(Issue::AvramStatus::Opened)
+    issue.role.enum.should eq(Issue::AvramRole::Issue)
   end
 
   it "update enum" do
@@ -15,7 +15,7 @@ describe "Enum" do
 
     updated_issue = Issue::SaveOperation.update!(issue, status: Issue::Status.new(:closed))
 
-    updated_issue.status.value.should eq(Issue::AvramStatus::Closed)
-    updated_issue.role.value.should eq(Issue::AvramRole::Issue)
+    updated_issue.status.enum.should eq(Issue::AvramStatus::Closed)
+    updated_issue.role.enum.should eq(Issue::AvramRole::Issue)
   end
 end

--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -18,4 +18,11 @@ describe "Enum" do
     updated_issue.status.enum.should eq(Issue::AvramStatus::Closed)
     updated_issue.role.enum.should eq(Issue::AvramRole::Issue)
   end
+
+  it "access enum methods" do
+    issue = IssueBox.create
+
+    issue.status.opened?.should eq(true)
+    issue.status.value.should eq(0)
+  end
 end

--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -6,16 +6,16 @@ describe "Enum" do
   it "check enum" do
     issue = IssueBox.create
 
-    issue.status.value.should eq(Issue::Status::Opened)
-    issue.role.value.should eq(Issue::Role::Issue)
+    issue.status.value.should eq(Issue::AvramStatus::Opened)
+    issue.role.value.should eq(Issue::AvramRole::Issue)
   end
 
   it "update enum" do
     issue = IssueBox.create
 
-    updated_issue = Issue::SaveOperation.update!(issue, status: Issue::AvramStatus.new(:closed))
+    updated_issue = Issue::SaveOperation.update!(issue, status: Issue::Status.new(:closed))
 
-    updated_issue.status.value.should eq(Issue::Status::Closed)
-    updated_issue.role.value.should eq(Issue::Role::Issue)
+    updated_issue.status.value.should eq(Issue::AvramStatus::Closed)
+    updated_issue.role.value.should eq(Issue::AvramRole::Issue)
   end
 end

--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -1,0 +1,21 @@
+require "../spec_helper"
+
+include LazyLoadHelpers
+
+describe "Enum" do
+  it "check enum" do
+    issue = IssueBox.create
+
+    issue.status.value.should eq(Issue::Status::Opened)
+    issue.role.value.should eq(Issue::Role::Issue)
+  end
+
+  it "update enum" do
+    issue = IssueBox.create
+
+    updated_issue = Issue::SaveOperation.update!(issue, status: Issue::AvramStatus.new(:closed))
+
+    updated_issue.status.value.should eq(Issue::Status::Closed)
+    updated_issue.role.value.should eq(Issue::Role::Issue)
+  end
+end

--- a/src/avram/charms/enum.cr
+++ b/src/avram/charms/enum.cr
@@ -1,0 +1,69 @@
+macro avram_enum(enum_name, &block)
+  enum {{ enum_name }}
+    {{ block.body }}
+  end
+
+  class Avram{{ enum_name }}
+    def self.adapter
+      Lucky
+    end
+
+    # You may need to prefix with {{ @type }}
+    #
+    #   {{ @type }}::{{enum_name}}
+    def initialize(@enum : {{ enum_name }})
+    end
+
+    def initialize(enum_value : Int32)
+      @enum = {{ enum_name }}.from_value(enum_value)
+    end
+
+    def initialize(enum_value : String)
+      @enum = {{ enum_name }}.from_value(enum_value.to_i)
+    end
+
+    def to_s
+      @enum.to_s
+    end
+
+    def value
+      @enum
+    end
+
+    def blank?
+      @enum.nil?
+    end
+
+    module Lucky
+      alias ColumnType = Int32
+      include Avram::Type
+
+      def from_db!(value : Int32)
+        Avram{{ enum_name }}.new(value)
+      end
+
+      def parse(value : Avram{{ enum_name }})
+        SuccessfulCast(Avram{{ enum_name }}).new(value)
+      end
+
+      def parse(value : String)
+        SuccessfulCast(Avram{{ enum_name }}).new(Avram{{ enum_name }}.new(value.to_i))
+      end
+
+      def parse(value : Int32)
+        SuccessfulCast(Avram{{ enum_name }}).new(Avram{{ enum_name }}.new(value))
+      end
+
+      def to_db(value : Int32)
+        value.to_s
+      end
+
+      def to_db(value : Avram{{ enum_name }})
+        value.value.value.to_s
+      end
+
+      class Criteria(T, V) < Int32::Lucky::Criteria(T, V)
+      end
+    end
+  end
+end

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -1,9 +1,9 @@
 macro avram_enum(enum_name, &block)
-  enum {{ enum_name }}
+  enum Avram{{ enum_name }}
     {{ block.body }}
   end
 
-  class Avram{{ enum_name }}
+  class {{ enum_name }}
     def self.adapter
       Lucky
     end
@@ -11,55 +11,45 @@ macro avram_enum(enum_name, &block)
     # You may need to prefix with {{ @type }}
     #
     #   {{ @type }}::{{enum_name}}
-    def initialize(@enum : {{ enum_name }})
+    def initialize(@enum : Avram{{ enum_name }})
     end
 
     def initialize(enum_value : Int32)
-      @enum = {{ enum_name }}.from_value(enum_value)
+      @enum = Avram{{ enum_name }}.from_value(enum_value)
     end
 
     def initialize(enum_value : String)
-      @enum = {{ enum_name }}.from_value(enum_value.to_i)
+      @enum = Avram{{ enum_name }}.from_value(enum_value.to_i)
     end
 
-    def to_s
-      @enum.to_s
-    end
-
-    def value
-      @enum
-    end
-
-    def blank?
-      @enum.nil?
-    end
+    forward_missing_to @enum
 
     module Lucky
       alias ColumnType = Int32
       include Avram::Type
 
       def from_db!(value : Int32)
-        Avram{{ enum_name }}.new(value)
+        {{ enum_name }}.new(value)
       end
 
       def parse(value : Avram{{ enum_name }})
-        SuccessfulCast(Avram{{ enum_name }}).new(value)
+        SuccessfulCast({{ enum_name }}).new(value)
       end
 
       def parse(value : String)
-        SuccessfulCast(Avram{{ enum_name }}).new(Avram{{ enum_name }}.new(value.to_i))
+        SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
       end
 
       def parse(value : Int32)
-        SuccessfulCast(Avram{{ enum_name }}).new(Avram{{ enum_name }}.new(value))
+        SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
       end
 
       def to_db(value : Int32)
         value.to_s
       end
 
-      def to_db(value : Avram{{ enum_name }})
-        value.value.value.to_s
+      def to_db(value : {{ enum_name }})
+        value.value.to_s
       end
 
       class Criteria(T, V) < Int32::Lucky::Criteria(T, V)

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -8,6 +8,8 @@ macro avram_enum(enum_name, &block)
       Lucky
     end
 
+    getter :enum
+
     # You may need to prefix with {{ @type }}
     #
     #   {{ @type }}::{{enum_name}}


### PR DESCRIPTION
Got help a bit from @paulcsmith with this.

It is a bit hacky. 

Instead of using enum Status, you use this macro.

Like this:
```
class Issue <  BaseModel
avram_enum Status do
  Opened = 1
end
```
and for the int32 type add `Status` as type instead.

It shall now work, but with some changes in create and update:
```
status: Issue::Status.new(:opened)
```

No tests as I am not sure how you would like to test this macro?