### PR TITLE
Update for lastet crystal-pg support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -17,12 +17,9 @@ dependencies:
   lucky_cli:
     github: luckyframework/lucky_cli
     version: ~> 0.20.0
-  db:
-    github: crystal-lang/crystal-db
-    version: ~> 0.8.0
   pg:
     github: will/crystal-pg
-    version: ~> 0.20.0
+    version: ~> 0.21.0
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4.0


### PR DESCRIPTION
We don't actually need the `crystal-db` in here since `crystal-pg` already has that as a dependency. This lets us stay in line with what ever pg uses. That way we don't accidentally forget to update db, or have them out of sync. 

This also updates crystal-pg to latest which just has better crystal 0.34 support.