### PR TITLE
Fix select_count edge case of raising an exception

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -532,6 +532,11 @@ describe Avram::Query do
         UserQuery.new.offset(1).select_count
       end
     end
+
+    it "returns 0 if postgres returns no results" do
+      query = UserQuery.new.distinct_on(&.name).average_score.gt(5).group(&.name).group(&.id).select_count
+      query.should eq 0
+    end
   end
 
   describe "#not with an argument" do

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -182,6 +182,8 @@ module Avram::Queryable(T)
   def select_count : Int64
     query.select_count
     exec_scalar.as(Int64)
+  rescue e : DB::NoResultsError
+    0_i64
   end
 
   def each


### PR DESCRIPTION
Fixes #297

In a more complex case, postgres won't return any value when trying to do a count. This causes DB to just raise an exception instead of returning 0.