### PR TITLE
Adding new SubmitOperation class.

### DIFF
--- a/spec/operation_spec.cr
+++ b/spec/operation_spec.cr
@@ -45,7 +45,7 @@ private class NeedyOperation < Avram::SubmitOperation
   needs test_operation : TestOperation
   attribute secret : String
 
-  def execute
+  def submit
     "The secret to #{test_operation.class} is #{secret.value}"
   end
 end

--- a/src/avram/needy_submit_operation_initializer.cr
+++ b/src/avram/needy_submit_operation_initializer.cr
@@ -1,0 +1,124 @@
+module Avram::NeedySubmitOperationInitializer
+  macro included
+    OPERATION_NEEDS = [] of Nil
+
+    macro inherited
+      inherit_needs
+    end
+  end
+
+  macro needs(type_declaration)
+    {% OPERATION_NEEDS << type_declaration %}
+    @{{ type_declaration.var }} : {{ type_declaration.type }}
+    property {{ type_declaration.var }}
+  end
+
+  macro needs(type_declaration, on)
+    {% on.raise "The 'on' option is no longer supported. Please use needs without 'on' instead." %}
+  end
+
+  macro inherit_needs
+    \{% if !@type.constant(:OPERATION_NEEDS) %}
+      OPERATION_NEEDS = [] of Nil
+    \{% end %}
+
+    \{% if !@type.ancestors.first.abstract? %}
+      \{% for type_declaration in @type.ancestors.first.constant :OPERATION_NEEDS %}
+        \{% OPERATION_NEEDS << type_declaration %}
+      \{% end %}
+    \{% end %}
+
+    macro inherited
+      inherit_needs
+    end
+
+    macro finished
+      setup_initializer
+    end
+  end
+
+  macro setup_initializer
+    # Build up a list of method arguments
+    #
+    # These method arguments can be used in macros fro generating create/update/new
+    #
+    # This way everything has a name and type and we don't have to rely on
+    # **named_args. **named_args** are easy but you get horrible type errors.
+    #
+    # attribute_method_args would look something like:
+    #
+    #   name : String | Nothing = Nothing.new,
+    #   email : String | Nil | Nothing = Nothing.new
+    #
+    # This can be passed to macros as a string, and then the macro can call .id
+    # on it to output the string as code!
+    {% attribute_method_args = "" %}
+
+    # Build up a list of params so you can use the method args
+    #
+    # This looks something like:
+    #
+    #   name: name,
+    #   email: email
+    {% attribute_params = "" %}
+
+    {% if @type.constant :COLUMN_ATTRIBUTES %}
+      {% for attribute in COLUMN_ATTRIBUTES.uniq %}
+        {% attribute_method_args = attribute_method_args + "#{attribute[:name]} : #{attribute[:type]} | Nothing" %}
+        {% if attribute[:nilable] %}{% attribute_method_args = attribute_method_args + " | Nil" %}{% end %}
+        {% attribute_method_args = attribute_method_args + " = Nothing.new,\n" %}
+
+        {% attribute_params = attribute_params + "#{attribute[:name]}: #{attribute[:name]},\n" %}
+      {% end %}
+    {% end %}
+
+    {% for attribute in ATTRIBUTES %}
+      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Nothing = Nothing.new,\n" %}
+      {% attribute_params = attribute_params + "#{attribute.var}: #{attribute.var},\n" %}
+    {% end %}
+
+    generate_initializers({{ attribute_method_args }}, {{ attribute_params }})
+  end
+
+  private class Nothing
+  end
+
+  macro generate_initializers(attribute_method_args, attribute_params)
+    {% needs_method_args = "" %}
+    {% for type_declaration in OPERATION_NEEDS %}
+      {% needs_method_args = needs_method_args + "@#{type_declaration},\n" %}
+    {% end %}
+
+    def initialize(
+        @params : Avram::Paramable,
+        {{ needs_method_args.id }}
+        {{ attribute_method_args.id }}
+      )
+      set_attributes({{ attribute_params.id }})
+    end
+
+    def initialize(
+        {{ needs_method_args.id }}
+        {{ attribute_method_args.id }}
+      )
+      @params = Avram::Params.new
+      set_attributes({{ attribute_params.id }})
+    end
+
+    def set_attributes({{ attribute_method_args.id }})
+      {% if @type.constant :COLUMN_ATTRIBUTES %}
+        {% for attribute in COLUMN_ATTRIBUTES.uniq %}
+          unless {{ attribute[:name] }}.is_a? Nothing
+            self.{{ attribute[:name] }}.value = {{ attribute[:name] }}
+          end
+        {% end %}
+      {% end %}
+
+      {% for attribute in ATTRIBUTES %}
+        unless {{ attribute.var }}.is_a? Nothing
+          self.{{ attribute.var }}.value = {{ attribute.var }}
+        end
+      {% end %}
+    end
+  end
+end

--- a/src/avram/needy_submit_operation_initializer.cr
+++ b/src/avram/needy_submit_operation_initializer.cr
@@ -13,10 +13,6 @@ module Avram::NeedySubmitOperationInitializer
     property {{ type_declaration.var }}
   end
 
-  macro needs(type_declaration, on)
-    {% on.raise "The 'on' option is no longer supported. Please use needs without 'on' instead." %}
-  end
-
   macro inherit_needs
     \{% if !@type.constant(:OPERATION_NEEDS) %}
       OPERATION_NEEDS = [] of Nil
@@ -40,10 +36,8 @@ module Avram::NeedySubmitOperationInitializer
   macro setup_initializer
     # Build up a list of method arguments
     #
-    # These method arguments can be used in macros fro generating create/update/new
-    #
     # This way everything has a name and type and we don't have to rely on
-    # **named_args. **named_args** are easy but you get horrible type errors.
+    # **named_args**. **named_args** are easy but you get horrible type errors.
     #
     # attribute_method_args would look something like:
     #

--- a/src/avram/submit_operation.cr
+++ b/src/avram/submit_operation.cr
@@ -6,9 +6,9 @@ abstract class Avram::SubmitOperation < Avram::Operation
 
   def self.run(params : Avram::Paramable, **needs)
     inst = self.new(params, **needs)
-    result = inst.execute
+    result = inst.submit
     yield(inst, result)
   end
 
-  abstract def execute
+  abstract def submit
 end

--- a/src/avram/submit_operation.cr
+++ b/src/avram/submit_operation.cr
@@ -4,11 +4,20 @@ require "./needy_initializer_and_save_methods"
 abstract class Avram::SubmitOperation < Avram::Operation
   include Avram::NeedySubmitOperationInitializer
 
-  def self.run(params : Avram::Paramable, **needs)
-    inst = self.new(params, **needs)
-    result = inst.submit
-    yield(inst, result)
+  # Yields a block passing in the `operation`, and the
+  # return value of the `submit` method.
+  def self.run(params : Avram::Paramable, **needs) : Nil
+    operation = self.new(params, **needs)
+    result = operation.submit
+    if operation.valid?
+      yield(operation, result)
+    else
+      yield(operation, nil)
+    end
   end
 
+  # This method should return `nil` if your operation fails
+  # otherwise return any value you want to be yield to your
+  # `Operation.run` block.
   abstract def submit
 end

--- a/src/avram/submit_operation.cr
+++ b/src/avram/submit_operation.cr
@@ -1,0 +1,14 @@
+require "./operation"
+require "./needy_initializer_and_save_methods"
+
+abstract class Avram::SubmitOperation < Avram::Operation
+  include Avram::NeedySubmitOperationInitializer
+
+  def self.run(params : Avram::Paramable, **needs)
+    inst = self.new(params, **needs)
+    result = inst.execute
+    yield(inst, result)
+  end
+
+  abstract def execute
+end


### PR DESCRIPTION
### What

This PR adds in a new subclass to `Avram::Operation`. Current name I went with was `SubmitOperation`, but I'm not sold on the name if anyone has any better suggestions. This new class does a few things:

* Designed for use when your operation is not backed by a model
* Allows for using `attribute` just as you would now with a `SaveOperation` or even just `Operation`.
* Allows for using `needs` like `SaveOperation` because a regular `Operation` doesn't.
* Sets up structure for future allowing callbacks to match up with `SaveOperation`. 

The eventual goal would be that you either inherit from this class or `SaveOperation`, and never really `Operation` as the base class. However, by branching off, this will allow people to slowly roll over as they need without breaking anything out there currently. 

### Using

To use this, you would create your class, and inherit from it. Then call the `run` method on your operation passing in your params and such.

```crystal
class SignInUser < Avram::SubmitOperation
  param_key :user
  include UserFromEmail

  attribute email : String
  attribute password : String

  # You must define this method,
  # And it should return the thing you want (or nil)
  def submit
    user = user_from_email
    validate_credentials(user)

    user
  end

  private def validate_credentials(user)
    if user
      unless Authentic.correct_password?(user, password.value.to_s)
        password.add_error "is wrong"
      end
    else
      email.add_error "is not in our system"
    end
  end
end

post "/sign_in" do
    SignInUser.run(params) do |operation, authenticated_user|
      if authenticated_user
        # sign in
      else
        # failed
      end
    end
  end
```


### Future API

Eventually, the above might look like this:

```crystal
before_submit :validate_credentials

def submit
  user
end

memoize def user
  user_from_email
end

private def validate_credentials
  # validate user
end
```

Then you'd have access to the errors if it failed

```crystal
SignInUser.run(params) do |operation, authenticated_user|
  # assuming `authenticated_user` is nil
  # you can check out your `operation.errors` like normal      
end
```

