### PR TITLE
Add rename and rename_belongs_to for migrations.

### DIFF
--- a/db/migrations/20200513065134_test_rename_columns.cr
+++ b/db/migrations/20200513065134_test_rename_columns.cr
@@ -1,0 +1,27 @@
+class TestRenameColumns::V20200513065134 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(RenamableOwner) do
+      primary_key id : Int64
+      add_timestamps
+    end
+
+    create table_for(Renamable) do
+      primary_key id : Int64
+      add_timestamps
+      add thingies : JSON::Any
+      add gsm_number : String
+      add_belongs_to boss : RenamableOwner, on_delete: :cascade
+    end
+
+    alter table_for(Renamable) do
+      rename :gsm_number, :mobile
+      rename_belongs_to :boss, :owner
+      rename :thingies, :options
+    end
+  end
+
+  def rollback
+    drop table_for(Renamable)
+    drop table_for(RenamableOwner)
+  end
+end

--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -22,7 +22,12 @@ describe Avram::Migrator::AlterTableStatement do
       remove_belongs_to :employee
     end
 
-    built.statements.first.should eq <<-SQL
+    built.statements.size.should eq 11
+
+    built.statements[0].should eq "ALTER TABLE users RENAME COLUMN old_name TO new_name;"
+    built.statements[1].should eq "ALTER TABLE users RENAME COLUMN owner_id TO boss_id;"
+
+    built.statements[2].should eq <<-SQL
     ALTER TABLE users
       ADD name text,
       ADD email text,
@@ -37,19 +42,16 @@ describe Avram::Migrator::AlterTableStatement do
       ADD future_time timestamptz NOT NULL DEFAULT '#{Time.local.to_utc}',
       ADD new_id uuid NOT NULL DEFAULT '46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0',
       ADD numbers int[] NOT NULL,
-      RENAME COLUMN old_name TO new_name,
-      RENAME COLUMN owner_id TO boss_id,
       DROP old_column,
       DROP employee_id;
     SQL
 
-    built.statements.size.should eq 9
-    built.statements[1].should eq "CREATE UNIQUE INDEX users_age_index ON users USING btree (age);"
-    built.statements[2].should eq "CREATE INDEX users_num_index ON users USING btree (num);"
-    built.statements[3].should eq "UPDATE users SET email = 'noreply@lucky.com';"
-    built.statements[4].should eq "ALTER TABLE users ALTER COLUMN email SET NOT NULL;"
-    built.statements[5].should eq "UPDATE users SET updated_at = NOW();"
-    built.statements[6].should eq "ALTER TABLE users ALTER COLUMN updated_at SET NOT NULL;"
+    built.statements[3].should eq "CREATE UNIQUE INDEX users_age_index ON users USING btree (age);"
+    built.statements[4].should eq "CREATE INDEX users_num_index ON users USING btree (num);"
+    built.statements[5].should eq "UPDATE users SET email = 'noreply@lucky.com';"
+    built.statements[6].should eq "ALTER TABLE users ALTER COLUMN email SET NOT NULL;"
+    built.statements[7].should eq "UPDATE users SET updated_at = NOW();"
+    built.statements[8].should eq "ALTER TABLE users ALTER COLUMN updated_at SET NOT NULL;"
   end
 
   it "does not build statements if nothing is altered" do

--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -16,6 +16,8 @@ describe Avram::Migrator::AlterTableStatement do
       add future_time : Time, default: Time.local
       add new_id : UUID, default: UUID.new("46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0")
       add numbers : Array(Int32), fill_existing_with: [1]
+      rename :old_name, :new_name
+      rename_belongs_to :owner, :boss
       remove :old_column
       remove_belongs_to :employee
     end
@@ -35,6 +37,8 @@ describe Avram::Migrator::AlterTableStatement do
       ADD future_time timestamptz NOT NULL DEFAULT '#{Time.local.to_utc}',
       ADD new_id uuid NOT NULL DEFAULT '46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0',
       ADD numbers int[] NOT NULL,
+      RENAME COLUMN old_name TO new_name,
+      RENAME COLUMN owner_id TO boss_id,
       DROP old_column,
       DROP employee_id;
     SQL

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -188,8 +188,11 @@ class Avram::Migrator::AlterTableStatement
     rename {{old_association_name}}_id, {{new_association_name}}_id
   end
 
-  def remove(name : Symbol)
-    dropped_rows << "  DROP #{name.to_s}"
+  macro remove(name)
+    {% unless name.is_a?(SymbolLiteral) %}
+      {% raise symbol_expected_message % {"remove", name} %}
+    {% end %}
+    dropped_rows << "  DROP #{{{name}}}"
   end
 
   macro remove_belongs_to(association_name)


### PR DESCRIPTION
A proposal as suggested in #365. This makes me think about picking up #321 as well, since the same is true.