### PR TITLE
Fix primary key name in SaveOperationTemplate when key type is UUID

### DIFF
--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -20,7 +20,7 @@ class Avram::SaveOperationTemplate
         before_save set_uuid
 
         def set_uuid
-          id.value ||= UUID.random()
+          {{ primary_key_name.id }}.value ||= UUID.random()
         end
       {% end %}
 


### PR DESCRIPTION
Should fix https://github.com/luckyframework/avram/issues/379

While it compiles, and pass the tests (using `./script/test`), ~I'm not sure it actually fixes the issue (I'm very new to Crystal and I couldn't find a way to use local shards yet ^^')~ I could test it, and it seems to work 😄 