### PR TITLE
Custom name for index

### DIFF
--- a/spec/migrator/create_index_statement_spec.cr
+++ b/spec/migrator/create_index_statement_spec.cr
@@ -13,4 +13,11 @@ describe Avram::Migrator::CreateIndexStatement do
     statement = Avram::Migrator::CreateIndexStatement.new(:users, columns: [:email, :username], using: :btree, unique: true).build
     statement.should eq "CREATE UNIQUE INDEX users_email_username_index ON users USING btree (email, username);"
   end
+
+  context "custom index name" do
+    it "generates correct CREATE INDEX sql with given name" do
+      statement = Avram::Migrator::CreateIndexStatement.new(:users, :email, name: :custom_index_name).build
+      statement.should eq "CREATE INDEX custom_index_name ON users USING btree (email);"
+    end
+  end
 end

--- a/spec/migrator/drop_index_statement_spec.cr
+++ b/spec/migrator/drop_index_statement_spec.cr
@@ -10,4 +10,20 @@ describe Avram::Migrator::DropIndexStatement do
     statement = Avram::Migrator::DropIndexStatement.new(:users, [:email, :username], on_delete: :cascade, if_exists: true).build
     statement.should eq "DROP INDEX IF EXISTS users_email_username_index CASCADE;"
   end
+
+  context "custom index name" do
+    it "generates correct sql with given name" do
+      statement = Avram::Migrator::DropIndexStatement.new(:users, name: :custom_index_name).build
+      statement.should eq "DROP INDEX custom_index_name;"
+    end
+  end
+
+  context "without name and columns" do
+    it "raises Exception" do
+      message = Regex.new("No name or columns specified for drop_index")
+      expect_raises(Exception, message) do
+        statement = Avram::Migrator::DropIndexStatement.new(:users).build
+      end
+    end
+  end
 end

--- a/src/avram/migrator/create_index_statement.cr
+++ b/src/avram/migrator/create_index_statement.cr
@@ -18,20 +18,30 @@ require "./index_statement_helpers"
 # CreateIndexStatement.new(:users, columns: [:email, :username], using: :btree, unique: true).build
 # # => "CREATE UNIQUE INDEX users_email_username_index ON users USING btree (email, username);"
 # ```
+#
+# With custom name:
+#
+# ```
+# CreateIndexStatement.new(:users, columns: [:email, :username], name: :custom_index_name).build
+# # => "CREATE INDEX custom_index_name ON users USING btree (email, username);"
+# ```
 class Avram::Migrator::CreateIndexStatement
   include Avram::Migrator::IndexStatementHelpers
 
   ALLOWED_INDEX_TYPES = %w[btree]
 
-  def initialize(@table : Symbol, @columns : Columns, @using : Symbol = :btree, @unique = false)
+  def initialize(@table : Symbol, @columns : Columns, @using : Symbol = :btree, @unique = false, @name : String? | Symbol? = nil)
     raise "index type '#{using}' not supported" unless ALLOWED_INDEX_TYPES.includes?(using.to_s)
   end
 
   def build
+    index_name = @name
+    index_name ||= "#{@table}_#{columns.join("_")}_index"
+
     String.build do |index|
       index << "CREATE"
       index << " UNIQUE" if @unique
-      index << " INDEX #{@table}_#{columns.join("_")}_index"
+      index << " INDEX #{index_name}"
       index << " ON #{@table}"
       index << " USING #{@using}"
       index << " (#{columns.join(", ")});"

--- a/src/avram/migrator/drop_index_statement.cr
+++ b/src/avram/migrator/drop_index_statement.cr
@@ -17,19 +17,26 @@ require "./index_statement_helpers"
 # DropIndexStatement.new(:users, [:email, :username] if_exists: true, on_delete: :cascade).build
 # # => "DROP INDEX IF EXISTS users_email_username_index CASCADE;"
 # ```
+#
+# For index by name:
+#
+# ```
+# DropIndexStatement.new(:users, name: :custom_index_name).build
+# # => "DROP INDEX custom_index_name;"
+# ```
 class Avram::Migrator::DropIndexStatement
   include Avram::Migrator::IndexStatementHelpers
 
   ALLOWED_ON_DELETE_STRATEGIES = %i[cascade restrict]
 
-  def initialize(@table : Symbol, @columns : Columns, @if_exists = false, @on_delete = :do_nothing)
+  def initialize(@table : Symbol, @columns : Columns? = nil, @if_exists = false, @on_delete = :do_nothing, @name : String? | Symbol? = nil)
   end
 
   def build
     String.build do |index|
       index << "DROP INDEX"
       index << " IF EXISTS" if @if_exists
-      index << " #{@table}_#{columns.join("_")}_index"
+      index << " #{index_name}"
       index << on_delete_strategy(@on_delete)
     end
   end
@@ -51,6 +58,14 @@ class Avram::Migrator::DropIndexStatement
       return columns
     else
       return [columns]
+    end
+  end
+
+  private def index_name
+    if @name || @columns
+      @name.to_s.presence || "#{@table}_#{columns.join("_")}_index"
+    else
+      raise "No name or columns specified for drop_index"
     end
   end
 end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -32,12 +32,12 @@ module Avram::Migrator::StatementHelpers
     prepared_statements << CreateForeignKeyStatement.new(from, to, on_delete, column, primary_key).build
   end
 
-  def create_index(table_name : Symbol, columns : Columns, unique = false, using = :btree)
-    prepared_statements << CreateIndexStatement.new(table_name, columns, using, unique).build
+  def create_index(table_name : Symbol, columns : Columns, unique = false, using = :btree, name : String? | Symbol? = nil)
+    prepared_statements << CreateIndexStatement.new(table_name, columns, using, unique, name).build
   end
 
-  def drop_index(table_name : Symbol, columns : Columns, if_exists = false, on_delete = :do_nothing)
-    prepared_statements << Avram::Migrator::DropIndexStatement.new(table_name, columns, if_exists, on_delete).build
+  def drop_index(table_name : Symbol, columns : Columns? = nil, if_exists = false, on_delete = :do_nothing, name : String? | Symbol? = nil)
+    prepared_statements << Avram::Migrator::DropIndexStatement.new(table_name, columns, if_exists, on_delete, name).build
   end
 
   def make_required(table : Symbol, column : Symbol)


### PR DESCRIPTION
I suggest adding the ability to set custom names for the index.

Postgresql has a length limit on the index name. 

These two indexes will have the same name:
`create_index :items, [:column1, :column2, :column3, :column4, :column5, :column6, :column7, :column8]`
`create_index :items, [:column1, :column2, :column3, :column4, :column5, :column6, :column7, :column8, :column9, :column10]`

The name will be "items_column1_column2_column3_column4_column5_column6_column7_c". So when creating the second index, an error occurs:
`relation "items_column1_column2_column3_column4_column5_column6_column7_c" already exists (Exception)`

In this case, we can set a custom name for the second index and avoid the error.
`create_index :items, [:column1, :column2, :column3, :column4, :column5, :column6, :column7, :column8], name: :all_columns_index`

This can help with the problem from #367 