### PR TITLE
Add associations list to SaveOperation

### DIFF
--- a/src/avram/inherit_associations.cr
+++ b/src/avram/inherit_associations.cr
@@ -1,0 +1,24 @@
+module Avram::InheritAssociations
+  macro included
+    macro inherited
+      inherit_associations
+    end
+  end
+
+  macro inherit_associations
+
+    \{% if !@type.constant(:ASSOCIATIONS) %}
+      ASSOCIATIONS = [] of Nil
+    \{% end %}
+
+    \{% if !@type.ancestors.first.abstract? %}
+      \{% for association in @type.ancestors.first.constant :ASSOCIATIONS %}
+        \{% ASSOCIATIONS << association %}
+      \{% end %}
+    \{% end %}
+
+    macro inherited
+      inherit_associations
+    end
+  end
+end

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -15,6 +15,7 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
   include Avram::NestedSaveOperation
   include Avram::MarkAsFailed
   include Avram::InheritColumnAttributes
+  include Avram::InheritAssociations
 
   enum SaveStatus
     Saved
@@ -161,6 +162,13 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
         {% end %}
       )
     end
+  end
+
+  # :nodoc:
+  macro add_associations(associations)
+    {% for association in associations %}
+      {% ASSOCIATIONS << association %}
+    {% end %}
   end
 
   # Runs `before_save` steps,

--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -1,5 +1,5 @@
 class Avram::SaveOperationTemplate
-  macro setup(type, columns, table_name, primary_key_type, primary_key_name, *args, **named_args)
+  macro setup(type, columns, associations, table_name, primary_key_type, primary_key_name, *args, **named_args)
     class ::{{ type }}::BaseForm
       macro inherited
         \{% raise "BaseForm has been renamed to SaveOperation. Please inherit from {{ type }}::SaveOperation." %}
@@ -42,6 +42,7 @@ class Avram::SaveOperationTemplate
 
       add_column_attributes({{ primary_key_type }}, {{ columns }})
       add_cast_value_methods({{ columns }})
+      add_associations({{ associations }})
     end
   end
 end


### PR DESCRIPTION
**This adds no functionality.**

In order to complete https://github.com/luckyframework/avram/issues/385 we need to know about associations in the SaveOperation. Model was already passing in the associations, we just had to hold on to it. This is copying how SaveOperation holds on to column attributes.

## Just Talking

By adding this, there are now two sets of the same list in two different places. The Model has two lists for column attributes and associations and now SaveOperation has two lists for the same thing. The only difference I see is that SaveOperation is adding parent column attributes / associations to the lists. https://github.com/luckyframework/avram/blob/629e89d5d3463185c49e12a0bca15af74d448aad/src/avram/inherit_column_attributes.cr#L13-L17

Is there any way to consolidate the two lists?