### PR TITLE
Clone instead of mutate when changing query criteria

### DIFF
--- a/spec/array_column_spec.cr
+++ b/spec/array_column_spec.cr
@@ -1,8 +1,5 @@
 require "./spec_helper"
 
-private class BucketQuery < Bucket::BaseQuery
-end
-
 describe "Array Columns" do
   it "fails when passing a single value to an array query" do
     BucketBox.new.numbers([1, 2, 3]).create

--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -270,8 +270,8 @@ describe Avram::QueryBuilder do
         .order_by(Avram::OrderBy.new(:id, :asc))
         .limit(1)
         .offset(2)
-      cloned_query = new_query
-        .clone(old_query)
+      cloned_query = old_query
+        .clone
         .where(Avram::Where::GreaterThan.new(:age, "20"))
         .limit(10)
         .offset(5)

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -159,10 +159,9 @@ describe Avram::Query do
       UserBox.new.name("First").create
       UserBox.new.name("Last").create
 
-      user = (user_query = UserQuery.new).first?
+      user = UserQuery.new.first?
       user.should_not be_nil
       user.not_nil!.name.should eq "First"
-      user_query.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users ORDER BY users.id ASC LIMIT 1"
     end
 
     it "returns nil if no record found" do
@@ -237,10 +236,9 @@ describe Avram::Query do
       UserBox.new.name("First").create
       UserBox.new.name("Last").create
 
-      last = (user_query = UserQuery.new).last?
+      last = UserQuery.new.last?
       last.should_not be_nil
       last && last.name.should eq "Last"
-      user_query.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users ORDER BY users.id DESC LIMIT 1"
     end
 
     it "returns nil if last record is not found" do

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -224,9 +224,10 @@ describe Avram::Query do
       UserBox.new.name("First").create
       UserBox.new.name("Last").create
 
-      last = UserQuery.last?
-      last.should_not be_nil
-      last && last.name.should eq "Last"
+      user = UserQuery.last?
+
+      user.should_not be_nil
+      user.not_nil!.name.should eq "Last"
     end
 
     it "returns nil if last record is not found" do

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -924,7 +924,6 @@ describe Avram::Query do
       it "returns 1 result" do
         bucket = BucketBox.new.names(["pumpkin", "zucchini"]).create
 
-        query = ArrayQuery.new.names(["pumpkin", "zucchini"])
         query = BucketQuery.new.names(["pumpkin", "zucchini"])
         query.to_sql.should eq ["SELECT #{Bucket::COLUMN_SQL} FROM buckets WHERE buckets.names = $1", "{\"pumpkin\",\"zucchini\"}"]
         result = query.first

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -316,8 +316,8 @@ describe Avram::Query do
     end
 
     it "doesn't mutate the query" do
-      user = UserBox.new.name("name").create
-      query = UserQuery.new.name("name")
+      user = UserBox.new.create
+      query = UserQuery.new
       original_query_sql = query.to_sql
 
       query.find(user.id)

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -160,8 +160,11 @@ describe Avram::Query do
       UserBox.new.name("Last").create
 
       user = UserQuery.new.first?
+      user_query = Avram::Events::QueryEvent.logged_events.last.query
+
       user.should_not be_nil
       user.not_nil!.name.should eq "First"
+      user_query.should eq "SELECT #{User::COLUMN_SQL} FROM users ORDER BY users.id ASC LIMIT 1"
     end
 
     it "returns nil if no record found" do
@@ -236,9 +239,12 @@ describe Avram::Query do
       UserBox.new.name("First").create
       UserBox.new.name("Last").create
 
-      last = UserQuery.new.last?
-      last.should_not be_nil
-      last && last.name.should eq "Last"
+      user = UserQuery.new.last?
+      user_query = Avram::Events::QueryEvent.logged_events.last.query
+
+      user.should_not be_nil
+      user.not_nil!.name.should eq "Last"
+      user_query.should eq "SELECT #{User::COLUMN_SQL} FROM users ORDER BY users.id DESC LIMIT 1"
     end
 
     it "returns nil if last record is not found" do

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -939,7 +939,7 @@ describe Avram::Query do
     end
   end
 
-  describe "#truncate" do
+  describe ".truncate" do
     it "truncates the table" do
       10.times { UserBox.create }
       UserQuery.new.select_count.should eq 10

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -571,6 +571,15 @@ describe Avram::Query do
       query_sum = UserQuery.new.age.select_sum
       query_sum.should be_nil
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.total_score.select_sum
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#select_sum for Int64 column" do
@@ -688,6 +697,15 @@ describe Avram::Query do
     it "returns 0 if postgres returns no results" do
       query = UserQuery.new.distinct_on(&.name).average_score.gt(5).group(&.name).group(&.id).select_count
       query.should eq 0
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.select_count
+
+      query.to_sql.should eq original_query_sql
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -20,11 +20,6 @@ class JSONQuery < Blob::BaseQuery
   end
 end
 
-class BucketQuery < Bucket::BaseQuery
-end
-
-alias ArrayQuery = BucketQuery
-
 describe Avram::Query do
   it "can chain scope methods" do
     ChainedQuery.new.young.named("Paul")
@@ -932,6 +927,7 @@ describe Avram::Query do
         bucket = BucketBox.new.names(["pumpkin", "zucchini"]).create
 
         query = ArrayQuery.new.names(["pumpkin", "zucchini"])
+        query = BucketQuery.new.names(["pumpkin", "zucchini"])
         query.to_sql.should eq ["SELECT #{Bucket::COLUMN_SQL} FROM buckets WHERE buckets.names = $1", "{\"pumpkin\",\"zucchini\"}"]
         result = query.first
         result.should eq bucket

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -55,6 +55,15 @@ describe Avram::Query do
       query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users"
       query.args.should eq [] of String
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.order_by(:name, :asc)
+      original_query_sql = query.to_sql
+
+      query.reset_order
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#reset_where" do
@@ -63,6 +72,15 @@ describe Avram::Query do
 
       query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE users.age = $1"
       query.args.should eq ["35"] of String
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name").age(35)
+      original_query_sql = query.to_sql
+
+      query.reset_where(&.name)
+
+      query.to_sql.should eq original_query_sql
     end
   end
 
@@ -84,6 +102,15 @@ describe Avram::Query do
       first.age.should eq 55
       second.name.should eq "Purcell"
       second.age.should eq 22
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.distinct_on(&.name)
+
+      query.to_sql.should eq original_query_sql
     end
   end
 
@@ -287,6 +314,16 @@ describe Avram::Query do
         UserQuery.new.find("id")
       end
     end
+
+    it "doesn't mutate the query" do
+      user = UserBox.new.name("name").create
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.find(user.id)
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#where" do
@@ -319,6 +356,15 @@ describe Avram::Query do
         UserQuery.new.where("name = ?", "bound", "extra")
       end
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.where(:first_name, "Paul")
+      original_query_sql = query.to_sql
+
+      query.where(:last_name, "Smith")
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#limit" do
@@ -337,6 +383,15 @@ describe Avram::Query do
 
       users.results.size.should eq(1)
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.limit(2)
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#offset" do
@@ -344,6 +399,15 @@ describe Avram::Query do
       query = UserQuery.new.offset(2).query
 
       query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users OFFSET 2"
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.offset(2)
+
+      query.to_sql.should eq original_query_sql
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -30,12 +30,21 @@ describe Avram::Query do
     ChainedQuery.new.young.named("Paul")
   end
 
-  describe "#destinct" do
+  describe "#distinct" do
     it "selects distinct" do
       query = UserQuery.new.distinct.query
 
       query.statement.should eq "SELECT DISTINCT #{User::COLUMN_SQL} FROM users"
       query.args.should eq [] of String
+    end
+
+    it "clones the original query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.distinct
+
+      query.to_sql.should eq original_query_sql
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -417,6 +417,15 @@ describe Avram::Query do
 
       query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users ORDER BY name ASC"
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.order_by(:name, :asc)
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#none" do
@@ -426,6 +435,15 @@ describe Avram::Query do
       query = UserQuery.new.none
 
       query.results.size.should eq 0
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.none
+
+      query.to_sql.should eq original_query_sql
     end
   end
 
@@ -450,6 +468,15 @@ describe Avram::Query do
       min = UserQuery.new.age.select_min
       min.should be_nil
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.age.select_min
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#select_max" do
@@ -472,6 +499,15 @@ describe Avram::Query do
     it "returns nil if no records" do
       max = UserQuery.new.age.select_max
       max.should be_nil
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.age.select_max
+
+      query.to_sql.should eq original_query_sql
     end
   end
 
@@ -496,6 +532,15 @@ describe Avram::Query do
       UserBox.create &.age(3)
       average = UserQuery.new.age.gte(2).age.select_average
       average.should eq 2.5
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.age.select_average
+
+      query.to_sql.should eq original_query_sql
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -139,7 +139,6 @@ describe Avram::Query do
     end
 
     it "clones the original query" do
-      UserBox.new.name("name").create
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql
 
@@ -218,7 +217,6 @@ describe Avram::Query do
     end
 
     it "clones the original query" do
-      UserBox.new.name("name").create
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -30,44 +30,52 @@ describe Avram::Query do
     ChainedQuery.new.young.named("Paul")
   end
 
-  it "can select distinct" do
-    query = UserQuery.new.distinct.query
+  describe "#destinct" do
+    it "selects distinct" do
+      query = UserQuery.new.distinct.query
 
-    query.statement.should eq "SELECT DISTINCT #{User::COLUMN_SQL} FROM users"
-    query.args.should eq [] of String
+      query.statement.should eq "SELECT DISTINCT #{User::COLUMN_SQL} FROM users"
+      query.args.should eq [] of String
+    end
   end
 
-  it "can reset order" do
-    query = UserQuery.new.order_by(:some_column, :asc).reset_order.query
+  describe "#reset_order" do
+    it "resets the order" do
+      query = UserQuery.new.order_by(:some_column, :asc).reset_order.query
 
-    query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users"
-    query.args.should eq [] of String
+      query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users"
+      query.args.should eq [] of String
+    end
   end
 
-  it "can reset where on a specific column" do
-    query = UserQuery.new.name("Purcell").age(35).reset_where(&.name).query
+  describe "#reset_where" do
+    it "resets where on a specific column" do
+      query = UserQuery.new.name("Purcell").age(35).reset_where(&.name).query
 
-    query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE users.age = $1"
-    query.args.should eq ["35"] of String
+      query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE users.age = $1"
+      query.args.should eq ["35"] of String
+    end
   end
 
-  it "can select distinct on a specific column" do
-    UserBox.new.name("Purcell").age(22).create
-    UserBox.new.name("Purcell").age(84).create
-    UserBox.new.name("Griffiths").age(55).create
-    UserBox.new.name("Griffiths").age(75).create
-    queryable = UserQuery.new.distinct_on(&.name).order_by(:name, :asc).order_by(:age, :asc)
-    query = queryable.query
+  describe "#distinct_on" do
+    it "selects distinct on a specific column" do
+      UserBox.new.name("Purcell").age(22).create
+      UserBox.new.name("Purcell").age(84).create
+      UserBox.new.name("Griffiths").age(55).create
+      UserBox.new.name("Griffiths").age(75).create
+      queryable = UserQuery.new.distinct_on(&.name).order_by(:name, :asc).order_by(:age, :asc)
+      query = queryable.query
 
-    query.statement.should eq "SELECT DISTINCT ON (users.name) #{User::COLUMN_SQL} FROM users ORDER BY name ASC, age ASC"
-    query.args.should eq [] of String
-    results = queryable.results
-    first = results.first
-    second = results.last
-    first.name.should eq "Griffiths"
-    first.age.should eq 55
-    second.name.should eq "Purcell"
-    second.age.should eq 22
+      query.statement.should eq "SELECT DISTINCT ON (users.name) #{User::COLUMN_SQL} FROM users ORDER BY name ASC, age ASC"
+      query.args.should eq [] of String
+      results = queryable.results
+      first = results.first
+      second = results.last
+      first.name.should eq "Griffiths"
+      first.age.should eq 55
+      second.name.should eq "Purcell"
+      second.age.should eq 22
+    end
   end
 
   describe ".first" do

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -138,7 +138,7 @@ describe Avram::Query do
       UserQuery.new.first?.should be_nil
     end
 
-    it "doesn't mutate the original query" do
+    it "clones the original query" do
       UserBox.new.name("name").create
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql
@@ -217,7 +217,7 @@ describe Avram::Query do
       UserQuery.new.last?.should be_nil
     end
 
-    it "doesn't mutate the original query" do
+    it "clones the original query" do
       UserBox.new.name("name").create
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -20,8 +20,10 @@ class JSONQuery < Blob::BaseQuery
   end
 end
 
-class ArrayQuery < Bucket::BaseQuery
+class BucketQuery < Bucket::BaseQuery
 end
+
+alias ArrayQuery = BucketQuery
 
 describe Avram::Query do
   it "can chain scope methods" do

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -418,6 +418,12 @@ describe Avram::Query do
       query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users ORDER BY name ASC"
     end
 
+    it "returns a nice error when trying to order by a weird direction" do
+      expect_raises(Exception, /Accepted values are: :asc, :desc/) do
+        Post::BaseQuery.new.order_by(:published_at, :sideways)
+      end
+    end
+
     it "doesn't mutate the query" do
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql
@@ -841,7 +847,7 @@ describe Avram::Query do
     end
   end
 
-  describe "truncate" do
+  describe "#truncate" do
     it "truncates the table" do
       10.times { UserBox.create }
       UserQuery.new.select_count.should eq 10
@@ -850,7 +856,7 @@ describe Avram::Query do
     end
   end
 
-  describe "update" do
+  describe "#update" do
     it "updates records when wheres are added" do
       UserBox.create &.available_for_hire(false)
       UserBox.create &.available_for_hire(false)
@@ -907,7 +913,7 @@ describe Avram::Query do
     end
   end
 
-  describe "delete" do
+  describe "#delete" do
     it "deletes user records that are young" do
       UserBox.new.name("Tony").age(48).create
       UserBox.new.name("Peter").age(15).create
@@ -931,7 +937,7 @@ describe Avram::Query do
     end
   end
 
-  describe "ordering" do
+  describe "#asc_order" do
     it "orders by a joined table" do
       query = Post::BaseQuery.new.where_comments(Comment::BaseQuery.new.created_at.asc_order)
       query.to_sql[0].should contain "ORDER BY comments.created_at ASC"
@@ -948,15 +954,9 @@ describe Avram::Query do
 
       query.to_sql[0].should contain "ORDER BY posts.published_at ASC NULLS LAST"
     end
-
-    it "returns a nice error when trying to order by a weird direction" do
-      expect_raises(Exception, /Accepted values are: :asc, :desc/) do
-        Post::BaseQuery.new.order_by(:published_at, :sideways)
-      end
-    end
   end
 
-  describe "cloning queries" do
+  describe "#clone" do
     it "leaves the original query unaffected" do
       original_query = ChainedQuery.new.young
       new_query = original_query.clone.named("bruce wayne").joined_at.asc_order

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -743,6 +743,15 @@ describe Avram::Query do
         results.map(&.name).should eq ["Joyce"]
       end
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.age.not.eq(5)
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#in" do
@@ -760,6 +769,15 @@ describe Avram::Query do
       results = UserQuery.new.name.not.in(["Mikias"])
       results.map(&.name).should eq [] of String
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.age.in([1, 2, 3])
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#join methods for associations" do
@@ -774,6 +792,15 @@ describe Avram::Query do
       result.post.should eq post
     end
 
+    it "doesn't mutate the query when inner joining on belongs to" do
+      query = Comment::BaseQuery.new
+      original_query_sql = query.to_sql
+
+      query.join_posts
+
+      query.to_sql.should eq original_query_sql
+    end
+
     it "inner join on has many" do
       post = PostBox.create
       comment = CommentBox.new.post_id(post.id).create
@@ -783,6 +810,15 @@ describe Avram::Query do
 
       result = query.first
       result.comments.first.should eq comment
+    end
+
+    it "doesn't mutate the query when inner joining on has_many" do
+      query = Post::BaseQuery.new
+      original_query_sql = query.to_sql
+
+      query.join_comments
+
+      query.to_sql.should eq original_query_sql
     end
 
     it "multiple inner joins on has many through" do
@@ -795,6 +831,15 @@ describe Avram::Query do
 
       result = query.first
       result.tags.first.should eq tag
+    end
+
+    it "doesn't mutate the query when inner joining multiple inner joins on has many through" do
+      query = Post::BaseQuery.new
+      original_query_sql = query.to_sql
+
+      query.join_tags
+
+      query.to_sql.should eq original_query_sql
     end
   end
 
@@ -809,6 +854,15 @@ describe Avram::Query do
       result.should eq employee
     end
 
+    it "doesn't mutate the query when left joining on belongs to" do
+      query = Employee::BaseQuery.new
+      original_query_sql = query.to_sql
+
+      query.left_join_managers
+
+      query.to_sql.should eq original_query_sql
+    end
+
     it "left join on has many" do
       post = PostBox.create
 
@@ -819,6 +873,15 @@ describe Avram::Query do
       result.should eq post
     end
 
+    it "doesn't mutate the query when left joining on has many" do
+      query = Post::BaseQuery.new
+      original_query_sql = query.to_sql
+
+      query.left_join_comments
+
+      query.to_sql.should eq original_query_sql
+    end
+
     it "multiple left joins on has many through" do
       post = PostBox.create
 
@@ -827,6 +890,15 @@ describe Avram::Query do
 
       result = query.first
       result.should eq post
+    end
+
+    it "doesn't mutate the query when left joining on has many through" do
+      query = Post::BaseQuery.new
+      original_query_sql = query.to_sql
+
+      query.left_join_tags
+
+      query.to_sql.should eq original_query_sql
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -1027,6 +1027,15 @@ describe Avram::Query do
       result.should eq 2
       ChainedQuery.new.select_count.should eq 0
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.delete
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#asc_order" do
@@ -1045,6 +1054,15 @@ describe Avram::Query do
       query = Post::BaseQuery.new.published_at.asc_order(:nulls_last)
 
       query.to_sql[0].should contain "ORDER BY posts.published_at ASC NULLS LAST"
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.name.asc_order
+
+      query.to_sql.should eq original_query_sql
     end
   end
 
@@ -1146,6 +1164,15 @@ describe Avram::Query do
       companies.query.args.should eq ["123.45", "678.901"]
       companies.first.should eq company
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.age.between(1, 3)
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#group" do
@@ -1165,6 +1192,15 @@ describe Avram::Query do
       expect_raises(PQ::PQError, /column "users\.id" must appear in the GROUP BY/) do
         users.map(&.name).should contain "Pam"
       end
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.group(&.age)
+
+      query.to_sql.should eq original_query_sql
     end
   end
 
@@ -1233,6 +1269,15 @@ describe Avram::Query do
       users.query.limit.should eq 10
       users.reset_limit.query.limit.should eq nil
     end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.limit(10)
+      original_query_sql = query.to_sql
+
+      query.reset_limit
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe "#reset_offset" do
@@ -1240,6 +1285,15 @@ describe Avram::Query do
       users = UserQuery.new.offset(10)
       users.query.offset.should eq 10
       users.reset_offset.query.offset.should eq nil
+    end
+
+    it "doesn't mutate the query" do
+      query = UserQuery.new.offset(10)
+      original_query_sql = query.to_sql
+
+      query.reset_offset
+
+      query.to_sql.should eq original_query_sql
     end
   end
 end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -709,37 +709,39 @@ describe Avram::Query do
     end
   end
 
-  describe "#not with an argument" do
-    it "negates the given where condition as 'equal'" do
-      UserBox.new.name("Paul").create
+  describe "#not" do
+    context "with an argument" do
+      it "negates the given where condition as 'equal'" do
+        UserBox.new.name("Paul").create
 
-      results = UserQuery.new.name.not.eq("not existing").results
-      results.should eq UserQuery.new.results
+        results = UserQuery.new.name.not.eq("not existing").results
+        results.should eq UserQuery.new.results
 
-      results = UserQuery.new.name.not.eq("Paul").results
-      results.should eq [] of User
+        results = UserQuery.new.name.not.eq("Paul").results
+        results.should eq [] of User
 
-      UserBox.new.name("Alex").create
-      UserBox.new.name("Sarah").create
-      results = UserQuery.new.name.lower.not.eq("alex").results
-      results.map(&.name).should eq ["Paul", "Sarah"]
-    end
-  end
-
-  describe "#not with no arguments" do
-    it "negates any previous condition" do
-      UserBox.new.name("Paul").create
-
-      results = UserQuery.new.name.not.eq("Paul").results
-      results.should eq [] of User
+        UserBox.new.name("Alex").create
+        UserBox.new.name("Sarah").create
+        results = UserQuery.new.name.lower.not.eq("alex").results
+        results.map(&.name).should eq ["Paul", "Sarah"]
+      end
     end
 
-    it "can be used with operators" do
-      UserBox.new.age(33).name("Joyce").create
-      UserBox.new.age(34).name("Jil").create
+    context "with no arguments" do
+      it "negates any previous condition" do
+        UserBox.new.name("Paul").create
 
-      results = UserQuery.new.age.not.gt(33).results
-      results.map(&.name).should eq ["Joyce"]
+        results = UserQuery.new.name.not.eq("Paul").results
+        results.should eq [] of User
+      end
+
+      it "can be used with operators" do
+        UserBox.new.age(33).name("Joyce").create
+        UserBox.new.age(34).name("Jil").create
+
+        results = UserQuery.new.age.not.gt(33).results
+        results.map(&.name).should eq ["Joyce"]
+      end
     end
   end
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -38,7 +38,7 @@ describe Avram::Query do
       query.args.should eq [] of String
     end
 
-    it "clones the original query" do
+    it "doesn't mutate the query" do
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql
 
@@ -147,7 +147,7 @@ describe Avram::Query do
       UserQuery.new.first?.should be_nil
     end
 
-    it "clones the original query" do
+    it "doesn't mutate the query" do
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql
 
@@ -225,7 +225,7 @@ describe Avram::Query do
       UserQuery.new.last?.should be_nil
     end
 
-    it "clones the original query" do
+    it "doesn't mutate the query" do
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql
 

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -129,6 +129,16 @@ describe Avram::Query do
     it "returns nil if no record found" do
       UserQuery.new.first?.should be_nil
     end
+
+    it "doesn't mutate the original query" do
+      UserBox.new.name("name").create
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.first?
+
+      query.to_sql.should eq original_query_sql
+    end
   end
 
   describe ".last" do
@@ -197,6 +207,16 @@ describe Avram::Query do
 
     it "returns nil if last record is not found" do
       UserQuery.new.last?.should be_nil
+    end
+
+    it "doesn't mutate the original query" do
+      UserBox.new.name("name").create
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.last?
+
+      query.to_sql.should eq original_query_sql
     end
   end
 

--- a/spec/support/bucket_query.cr
+++ b/spec/support/bucket_query.cr
@@ -1,0 +1,2 @@
+class BucketQuery < Bucket::BaseQuery
+end

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -109,8 +109,7 @@ class Avram::BaseQueryTemplate
                 )
               )
             {% elsif assoc[:through] %}
-              clone
-                .{{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
+              {{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
                 .__yield_where_{{ assoc[:through].id }} do |join_query|
                   join_query.{{ join_type.downcase.id }}_join_{{ assoc[:table_name] }}
                 end
@@ -129,24 +128,18 @@ class Avram::BaseQueryTemplate
 
 
         def where_{{ assoc[:table_name] }}(assoc_query : {{ assoc[:type] }}::BaseQuery, auto_inner_join : Bool = true)
-          new_instance = if auto_inner_join
-                           join_{{ assoc[:table_name] }}
-                         else
-                           clone
-                         end
-
-          new_instance.query.merge(assoc_query.query)
-          new_instance
+          if auto_inner_join
+            join_{{ assoc[:table_name] }}.merge_query(assoc_query.query)
+          else
+            merge_query(assoc_query.query)
+          end
         end
 
         # :nodoc:
         # Used internally for has_many through queries
         def __yield_where_{{ assoc[:table_name] }}
           assoc_query = yield {{ assoc[:type] }}::BaseQuery.new
-          new_instance = clone
-          new_instance.query.merge(assoc_query.query)
-
-          new_instance
+          merge_query(assoc_query.query)
         end
 
         def {{ assoc[:table_name] }}

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -4,6 +4,7 @@ class Avram::BaseQueryTemplate
       private class Nothing
       end
 
+      def_clone
       include Avram::Queryable({{ type }})
 
       def database : Avram::Database.class

--- a/src/avram/between_criteria.cr
+++ b/src/avram/between_criteria.cr
@@ -2,8 +2,10 @@ module Avram::BetweenCriteria(T, V)
   macro included
     # WHERE @column >= `low_value` AND @column <= `high_value`
     def between(low_value : V, high_value : V)
-      add_clause(Avram::Where::GreaterThanOrEqualTo.new(@column, V::Lucky.to_db!(low_value)))
-      add_clause(Avram::Where::LessThanOrEqualTo.new(@column, V::Lucky.to_db!(high_value)))
+      add_clauses([
+        Avram::Where::GreaterThanOrEqualTo.new(@column, V::Lucky.to_db!(low_value)),
+        Avram::Where::LessThanOrEqualTo.new(@column, V::Lucky.to_db!(high_value))
+      ])
     end
   end
 end

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -125,21 +125,15 @@ class Avram::Criteria(T, V)
   end
 
   def select_min : V | Nil
-    new_instance = rows.clone
-    new_instance.query.select_min(column)
-    new_instance.exec_scalar.as(V | Nil)
+    rows.exec_scalar(&.select_min(column)).as(V | Nil)
   end
 
   def select_max : V | Nil
-    new_instance = rows.clone
-    new_instance.query.select_max(column)
-    new_instance.exec_scalar.as(V | Nil)
+    rows.exec_scalar(&.select_max(column)).as(V | Nil)
   end
 
   def select_average : Float64?
-    new_instance = rows.clone
-    new_instance.query.select_average(column)
-    new_instance.exec_scalar.as(PG::Numeric | Nil).try &.to_f64
+    rows.exec_scalar(&.select_average(column)).as(PG::Numeric | Nil).try &.to_f64
   end
 
   def select_average! : Float64
@@ -147,9 +141,7 @@ class Avram::Criteria(T, V)
   end
 
   def select_sum
-    new_instance = rows.clone
-    new_instance.query.select_sum(column)
-    new_instance.exec_scalar
+    rows.exec_scalar(&.select_sum(column))
   end
 
   def in(values) : T

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -173,9 +173,13 @@ class Avram::Criteria(T, V)
   end
 
   private def add_clause(sql_clause) : T
-    sql_clause = build_sql_clause(sql_clause)
-    rows.query.where(sql_clause)
-    rows
+    rows.where(build_sql_clause(sql_clause))
+  end
+
+  private def add_clauses(sql_clauses : Array(Avram::Where::SqlClause)) : T
+    sql_clauses.reduce(rows) do |r, sql_clause|
+      r.where(build_sql_clause(sql_clause))
+    end
   end
 
   private def build_sql_clause(sql_clause : Avram::Where::SqlClause) : Avram::Where::SqlClause

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -127,18 +127,21 @@ class Avram::Criteria(T, V)
   end
 
   def select_min : V | Nil
-    rows.query.select_min(column)
-    rows.exec_scalar.as(V | Nil)
+    new_instance = rows.clone
+    new_instance.query.select_min(column)
+    new_instance.exec_scalar.as(V | Nil)
   end
 
   def select_max : V | Nil
-    rows.query.select_max(column)
-    rows.exec_scalar.as(V | Nil)
+    new_instance = rows.clone
+    new_instance.query.select_max(column)
+    new_instance.exec_scalar.as(V | Nil)
   end
 
   def select_average : Float64?
-    rows.query.select_average(column)
-    rows.exec_scalar.as(PG::Numeric | Nil).try &.to_f64
+    new_instance = rows.clone
+    new_instance.query.select_average(column)
+    new_instance.exec_scalar.as(PG::Numeric | Nil).try &.to_f64
   end
 
   def select_average! : Float64
@@ -146,8 +149,9 @@ class Avram::Criteria(T, V)
   end
 
   def select_sum
-    rows.query.select_sum(column)
-    rows.exec_scalar
+    new_instance = rows.clone
+    new_instance.query.select_sum(column)
+    new_instance.exec_scalar
   end
 
   def in(values) : T
@@ -172,8 +176,8 @@ class Avram::Criteria(T, V)
 
   private def add_clause(sql_clause) : T
     sql_clause = build_sql_clause(sql_clause)
-    rows.query.where(sql_clause)
-    rows
+
+    rows.clone.tap &.query.where(sql_clause)
   end
 
   private def build_sql_clause(sql_clause : Avram::Where::SqlClause) : Avram::Where::SqlClause

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -7,13 +7,11 @@ class Avram::Criteria(T, V)
   end
 
   def desc_order(null_sorting : Avram::OrderBy::NullSorting = :default) : T
-    rows.query.order_by(Avram::OrderBy.new(column, :desc, null_sorting))
-    rows
+    rows.order_by(Avram::OrderBy.new(column, :desc, null_sorting))
   end
 
   def asc_order(null_sorting : Avram::OrderBy::NullSorting = :default) : T
-    rows.query.order_by(Avram::OrderBy.new(column, :asc, null_sorting))
-    rows
+    rows.order_by(Avram::OrderBy.new(column, :asc, null_sorting))
   end
 
   def eq(value) : T

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -176,8 +176,8 @@ class Avram::Criteria(T, V)
 
   private def add_clause(sql_clause) : T
     sql_clause = build_sql_clause(sql_clause)
-
-    rows.clone.tap &.query.where(sql_clause)
+    rows.query.where(sql_clause)
+    rows
   end
 
   private def build_sql_clause(sql_clause : Avram::Where::SqlClause) : Avram::Where::SqlClause

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -150,18 +150,18 @@ class Avram::Criteria(T, V)
   end
 
   # :nodoc:
-  def private_distinct_on : Avram::QueryBuilder
-    rows.query.distinct_on(column)
+  def private_distinct_on : T
+    rows.tap &.query.distinct_on(column)
   end
 
   # :nodoc:
-  def private_group : Avram::QueryBuilder
-    rows.query.group_by(column)
+  def private_group : T
+    rows.tap &.query.group_by(column)
   end
 
   # :nodoc:
-  def private_reset_where : Avram::QueryBuilder
-    rows.query.reset_where(column)
+  def private_reset_where : T
+    rows.tap &.query.reset_where(column)
   end
 
   private def add_clause(sql_clause) : T

--- a/src/avram/join.cr
+++ b/src/avram/join.cr
@@ -35,6 +35,10 @@ module Avram::Join
     def default_foreign_key
       Wordsmith::Inflector.singularize(@from) + "_id"
     end
+
+    def clone
+      self
+    end
   end
 
   class Inner < SqlClause

--- a/src/avram/order_by.cr
+++ b/src/avram/order_by.cr
@@ -15,6 +15,8 @@ module Avram
       DESC
     end
 
+    def_clone
+
     getter column
     getter direction
     getter nulls

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -1,4 +1,6 @@
 class Avram::QueryBuilder
+  def_clone
+
   alias ColumnName = Symbol | String
   getter table
   getter distinct_on : ColumnName | Nil = nil
@@ -55,16 +57,6 @@ class Avram::QueryBuilder
     query_to_merge.groups.each do |group|
       group_by(group)
     end
-  end
-
-  # Similar to `merge`, but includes ALL query parts
-  def clone(query_to_merge : Avram::QueryBuilder)
-    merge(query_to_merge)
-    self.select(query_to_merge.selects)
-    distinct if query_to_merge.distinct?
-    distinct_on(query_to_merge.distinct_on.to_s) if query_to_merge.has_distinct_on?
-    limit(query_to_merge.limit)
-    offset(query_to_merge.offset)
   end
 
   def statement

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -155,7 +155,7 @@ module Avram::Queryable(T)
   end
 
   def find(id)
-    clone.id(id).limit(1).first? || raise RecordNotFoundError.new(model: @@table_name, id: id.to_s)
+    id(id).limit(1).first? || raise RecordNotFoundError.new(model: @@table_name, id: id.to_s)
   end
 
   def first?

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -105,8 +105,7 @@ module Avram::Queryable(T)
   end
 
   def where(column : Symbol, value) : self
-    query.where(Avram::Where::Equal.new(column, value.to_s))
-    self
+    clone.tap &.query.where(Avram::Where::Equal.new(column, value.to_s))
   end
 
   def where(statement : String, *bind_vars) : self
@@ -114,8 +113,7 @@ module Avram::Queryable(T)
   end
 
   def where(statement : String, *, args bind_vars : Array) : self
-    query.raw_where(Avram::Where::Raw.new(statement, args: bind_vars))
-    self
+    clone.tap &.query.raw_where(Avram::Where::Raw.new(statement, args: bind_vars))
   end
 
   def order_by(column, direction) : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -46,39 +46,19 @@ module Avram::Queryable(T)
   end
 
   def distinct : self
-    clone.distinct!
-  end
-
-  protected def distinct! : self
-    query.distinct
-    self
+    clone.tap &.query.distinct
   end
 
   def reset_order : self
-    clone.reset_order!
-  end
-
-  protected def reset_order! : self
-    query.reset_order
-    self
+    clone.tap &.query.reset_order
   end
 
   def reset_limit : self
-    clone.reset_limit!
-  end
-
-  protected def reset_limit! : self
-    query.limit(nil)
-    self
+    clone.tap &.query.limit(nil)
   end
 
   def reset_offset : self
-    clone.reset_offset!
-  end
-
-  protected def reset_offset! : self
-    query.offset(nil)
-    self
+    clone.tap &.query.offset(nil)
   end
 
   def distinct_on(&block) : self
@@ -121,12 +101,7 @@ module Avram::Queryable(T)
   abstract def update : Int64
 
   def join(join_clause : Avram::Join::SqlClause) : self
-    clone.join!(join_clause)
-  end
-
-  protected def join!(join_clause : Avram::Join::SqlClause) : self
-    query.join(join_clause)
-    self
+    clone.tap &.query.join(join_clause)
   end
 
   def where(column : Symbol, value) : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -165,8 +165,8 @@ module Avram::Queryable(T)
   end
 
   def select_count : Int64
-    query.select_count
-    exec_scalar.as(Int64)
+    new_instance = clone.tap &.query.select_count
+    new_instance.exec_scalar.as(Int64)
   rescue e : DB::NoResultsError
     0_i64
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -118,8 +118,7 @@ module Avram::Queryable(T)
 
   def order_by(column, direction) : self
     direction = Avram::OrderBy::Direction.parse(direction.to_s)
-    query.order_by(Avram::OrderBy.new(column, direction))
-    self
+    clone.tap &.query.order_by(Avram::OrderBy.new(column, direction))
   rescue e : ArgumentError
     raise "#{e.message}. Accepted values are: :asc, :desc"
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -102,6 +102,10 @@ module Avram::Queryable(T)
   # UserQuery.new.age.lt(21).delete
   # ```
   def delete : Int64
+    clone.delete!
+  end
+
+  protected def delete! : Int64
     query.delete
     database.exec(query.statement, args: query.args).rows_affected
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -61,9 +61,11 @@ module Avram::Queryable(T)
   end
 
   def distinct_on(&block) : self
-    criteria = yield self
+    new_instance = clone
+    criteria = yield new_instance
     criteria.private_distinct_on
-    self
+
+    new_instance
   end
 
   def reset_where(&block) : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -123,6 +123,10 @@ module Avram::Queryable(T)
     clone.tap &.query.where(sql_clause)
   end
 
+  def merge_query(query_to_merge : Avram::QueryBuilder)
+    clone.tap &.query.merge(query_to_merge)
+  end
+
   def order_by(column, direction) : self
     direction = Avram::OrderBy::Direction.parse(direction.to_s)
     order_by(Avram::OrderBy.new(column, direction))

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -55,6 +55,10 @@ module Avram::Queryable(T)
   end
 
   def reset_order : self
+    clone.reset_order!
+  end
+
+  protected def reset_order! : self
     query.reset_order
     self
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -1,6 +1,5 @@
 module Avram::Queryable(T)
   include Enumerable(T)
-  def_clone
 
   abstract def id
 
@@ -134,8 +133,7 @@ module Avram::Queryable(T)
   end
 
   def limit(amount) : self
-    query.limit(amount)
-    self
+    clone.tap &.query.limit(amount)
   end
 
   def offset(amount) : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -117,7 +117,7 @@ module Avram::Queryable(T)
     clone.tap &.query.where(sql_clause)
   end
 
-  def merge_query(query_to_merge : Avram::QueryBuilder)
+  def merge_query(query_to_merge : Avram::QueryBuilder) : self
     clone.tap &.query.merge(query_to_merge)
   end
 
@@ -128,7 +128,7 @@ module Avram::Queryable(T)
     raise "#{e.message}. Accepted values are: :asc, :desc"
   end
 
-  def order_by(order : Avram::OrderBy)
+  def order_by(order : Avram::OrderBy) : self
     clone.tap &.query.order_by(order)
   end
 

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -67,9 +67,11 @@ module Avram::Queryable(T)
   end
 
   def reset_where(&block) : self
-    criteria = yield self
+    new_instance = clone
+    criteria = yield new_instance
     criteria.private_reset_where
-    self
+
+    new_instance
   end
 
   # Delete the records using the query's where clauses, or all records if no wheres are added.

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -119,6 +119,10 @@ module Avram::Queryable(T)
     clone.tap &.query.raw_where(Avram::Where::Raw.new(statement, args: bind_vars))
   end
 
+  def where(sql_clause : Avram::Where::SqlClause) : self
+    clone.tap &.query.where(sql_clause)
+  end
+
   def order_by(column, direction) : self
     direction = Avram::OrderBy::Direction.parse(direction.to_s)
     order_by(Avram::OrderBy.new(column, direction))

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -121,6 +121,10 @@ module Avram::Queryable(T)
   abstract def update : Int64
 
   def join(join_clause : Avram::Join::SqlClause) : self
+    clone.join!(join_clause)
+  end
+
+  protected def join!(join_clause : Avram::Join::SqlClause) : self
     query.join(join_clause)
     self
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -64,6 +64,10 @@ module Avram::Queryable(T)
   end
 
   def reset_limit : self
+    clone.reset_limit!
+  end
+
+  protected def reset_limit! : self
     query.limit(nil)
     self
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -131,8 +131,7 @@ module Avram::Queryable(T)
   end
 
   def none : self
-    query.where(Avram::Where::Equal.new("1", "0"))
-    self
+    clone.tap &.query.where(Avram::Where::Equal.new("1", "0"))
   end
 
   def limit(amount) : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -121,9 +121,13 @@ module Avram::Queryable(T)
 
   def order_by(column, direction) : self
     direction = Avram::OrderBy::Direction.parse(direction.to_s)
-    clone.tap &.query.order_by(Avram::OrderBy.new(column, direction))
+    order_by(Avram::OrderBy.new(column, direction))
   rescue e : ArgumentError
     raise "#{e.message}. Accepted values are: :asc, :desc"
+  end
+
+  def order_by(order : Avram::OrderBy)
+    clone.tap &.query.order_by(order)
   end
 
   def group(&block) : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -1,5 +1,6 @@
 module Avram::Queryable(T)
   include Enumerable(T)
+  def_clone
 
   abstract def id
 
@@ -42,14 +43,6 @@ module Avram::Queryable(T)
     @query ||= Avram::QueryBuilder
       .new(table: @@table_name)
       .select(@@schema_class.column_names)
-  end
-
-  def clone : self
-    original_query = query
-    instance = self.class.new
-    instance.query.clone(original_query)
-    preloads.each { |preload| instance.add_preload(&preload) }
-    instance
   end
 
   def distinct : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -140,8 +140,7 @@ module Avram::Queryable(T)
   end
 
   def offset(amount) : self
-    query.offset(amount)
-    self
+    clone.tap &.query.offset(amount)
   end
 
   def find(id)

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -209,7 +209,7 @@ module Avram::Queryable(T)
 
   def exec_scalar(&block)
     new_query = yield query.clone
-    database.scalar query.statement, args: query.args, queryable: @@schema_class.name
+    database.scalar new_query.statement, args: new_query.args, queryable: @@schema_class.name
   end
 
   private def with_ordered_query : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -145,8 +145,10 @@ module Avram::Queryable(T)
   end
 
   def first?
-    ordered_query.limit(1)
-    results.first?
+    with_ordered_query
+      .limit(1)
+      .results
+      .first?
   end
 
   def first
@@ -154,8 +156,11 @@ module Avram::Queryable(T)
   end
 
   def last?
-    ordered_query.reverse_order.limit(1)
-    results.first?
+    with_ordered_query
+      .tap(&.query.reverse_order)
+      .limit(1)
+      .results
+      .first?
   end
 
   def last
@@ -197,11 +202,11 @@ module Avram::Queryable(T)
     database.scalar query.statement, args: query.args, queryable: @@schema_class.name
   end
 
-  private def ordered_query
+  private def with_ordered_query
     if query.ordered?
-      query
+      clone
     else
-      id.asc_order.query
+      clone.id.asc_order
     end
   end
 

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -46,6 +46,10 @@ module Avram::Queryable(T)
   end
 
   def distinct : self
+    clone.distinct!
+  end
+
+  protected def distinct! : self
     query.distinct
     self
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -73,6 +73,10 @@ module Avram::Queryable(T)
   end
 
   def reset_offset : self
+    clone.reset_offset!
+  end
+
+  protected def reset_offset! : self
     query.offset(nil)
     self
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -127,9 +127,11 @@ module Avram::Queryable(T)
   end
 
   def group(&block) : self
-    criteria = yield self
+    new_instance = clone
+    criteria = yield new_instance
     criteria.private_group
-    self
+
+    new_instance
   end
 
   def none : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -145,7 +145,7 @@ module Avram::Queryable(T)
   end
 
   def find(id)
-    id(id).limit(1).first? || raise RecordNotFoundError.new(model: @@table_name, id: id.to_s)
+    clone.id(id).limit(1).first? || raise RecordNotFoundError.new(model: @@table_name, id: id.to_s)
   end
 
   def first?

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -83,8 +83,8 @@ module Avram::Queryable(T)
   end
 
   protected def delete! : Int64
-    query.delete
-    database.exec(query.statement, args: query.args).rows_affected
+    new_query = query.clone.delete
+    database.exec(new_query.statement, args: new_query.args).rows_affected
   end
 
   # Update the records using the query's where clauses, or all records if no wheres are added.

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -61,19 +61,13 @@ module Avram::Queryable(T)
   end
 
   def distinct_on(&block) : self
-    new_instance = clone
-    criteria = yield new_instance
+    criteria = yield clone
     criteria.private_distinct_on
-
-    new_instance
   end
 
   def reset_where(&block) : self
-    new_instance = clone
-    criteria = yield new_instance
+    criteria = yield clone
     criteria.private_reset_where
-
-    new_instance
   end
 
   # Delete the records using the query's where clauses, or all records if no wheres are added.
@@ -139,11 +133,8 @@ module Avram::Queryable(T)
   end
 
   def group(&block) : self
-    new_instance = clone
-    criteria = yield new_instance
+    criteria = yield clone
     criteria.private_group
-
-    new_instance
   end
 
   def none : self

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -12,6 +12,10 @@ module Avram::Where
     def prepare(prepared_statement_placeholder : String)
       "#{column} #{operator} #{prepared_statement_placeholder}"
     end
+
+    def clone
+      self
+    end
   end
 
   abstract class NullSqlClause < SqlClause
@@ -187,6 +191,10 @@ module Avram::Where
 
     def to_sql
       @clause
+    end
+
+    def clone
+      self
     end
 
     private def ensure_enough_bind_variables_for!(statement, bind_vars)


### PR DESCRIPTION
I would like some feedback on if this a valid path forward or if there is a better way.

There are 2 breaking changes in this PR:
- The clone method on QueryBuilder no longer takes an argument.
- queries are no longer mutated, so you need to chain your criteria calls.

Fixes #194 
Fixes #195
Fixes #242 
