### PR TITLE
Reverting the db.create task connection test

### DIFF
--- a/spec/tasks/db_create_spec.cr
+++ b/spec/tasks/db_create_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Db::Create do
   it "raises a connection error when unable to connect" do
     Avram.temp_config(database_to_migrate: DatabaseWithIncorrectSettings) do
-      expect_raises(Avram::ConnectionError, /Failed to connect to database/) do
+      expect_raises(Avram::PGNotRunningError, /It looks like Postgres is not running/) do
         Db::Create.new(quiet: true).call
       end
     end

--- a/spec/tasks/db_create_spec.cr
+++ b/spec/tasks/db_create_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Db::Create do
   it "raises a connection error when unable to connect" do
     Avram.temp_config(database_to_migrate: DatabaseWithIncorrectSettings) do
-      expect_raises(Avram::PGNotRunningError, /It looks like Postgres is not running/) do
+      expect_raises(Exception, /It looks like Postgres is not running/) do
         Db::Create.new(quiet: true).call
       end
     end

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -117,7 +117,7 @@ module Avram
     private def macos_postgres_tools_link
       "https://postgresapp.com/documentation/cli-tools.html".colorize(:green)
     end
-  
+
     private def linux_postgres_installation_instructions
       "sudo apt-get update && sudo apt-get install postgresql postgresql-contrib".colorize(:green)
     end
@@ -127,7 +127,7 @@ module Avram
     def initialize(original_message : String)
       error = String.build do |message|
         message << <<-ERROR
-        Creating the database failed. It looks like Postgres is not running.
+        It looks like Postgres is not running.
   
         Message from Postgres:
   

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -96,22 +96,19 @@ module Avram
 
   class PGClientNotInstalledError < AvramError
     def initialize(original_message : String)
-      error = String.build do |message|
-        message << <<-ERROR
-        Message from Postgres:
+      super <<-ERROR
+      Message from Postgres:
 
-          #{original_message}
-  
-        Try this...
-  
-          ▸ If you are on macOS  you can install postgres tools from #{macos_postgres_tools_link}
-          ▸ If you are on linux you can try running #{linux_postgres_installation_instructions}
-          ▸ If you are on CI or some servers, there may already be a database created so you don't need this command"
-  
-  
-        ERROR
-      end
-      super error
+        #{original_message}
+
+      Try this...
+
+        ▸ If you are on macOS  you can install postgres tools from #{macos_postgres_tools_link}
+        ▸ If you are on linux you can try running #{linux_postgres_installation_instructions}
+        ▸ If you are on CI or some servers, there may already be a database created so you don't need this command"
+
+
+      ERROR
     end
 
     private def macos_postgres_tools_link
@@ -125,23 +122,20 @@ module Avram
 
   class PGNotRunningError < AvramError
     def initialize(original_message : String)
-      error = String.build do |message|
-        message << <<-ERROR
-        It looks like Postgres is not running.
-  
-        Message from Postgres:
-  
-          #{original_message}
-  
-        Try this...
-  
-          ▸ Make sure Postgres is running
-          ▸ Check your database configuration settings
-  
-  
-        ERROR
-      end
-      super error
+      super <<-ERROR
+      It looks like Postgres is not running.
+
+      Message from Postgres:
+
+        #{original_message}
+
+      Try this...
+
+        ▸ Make sure Postgres is running
+        ▸ Check your database configuration settings
+
+
+      ERROR
     end
   end
 end

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -93,4 +93,55 @@ module Avram
       super error
     end
   end
+
+  class PGClientNotInstalledError < AvramError
+    def initialize(original_message : String)
+      error = String.build do |message|
+        message << <<-ERROR
+        Message from Postgres:
+
+          #{original_message}
+  
+        Try this...
+  
+          ▸ If you are on macOS  you can install postgres tools from #{macos_postgres_tools_link}
+          ▸ If you are on linux you can try running #{linux_postgres_installation_instructions}
+          ▸ If you are on CI or some servers, there may already be a database created so you don't need this command"
+  
+  
+        ERROR
+      end
+      super error
+    end
+
+    private def macos_postgres_tools_link
+      "https://postgresapp.com/documentation/cli-tools.html".colorize(:green)
+    end
+  
+    private def linux_postgres_installation_instructions
+      "sudo apt-get update && sudo apt-get install postgresql postgresql-contrib".colorize(:green)
+    end
+  end
+
+  class PGNotRunningError < AvramError
+    def initialize(original_message : String)
+      error = String.build do |message|
+        message << <<-ERROR
+        Creating the database failed. It looks like Postgres is not running.
+  
+        Message from Postgres:
+  
+          #{original_message}
+  
+        Try this...
+  
+          ▸ Make sure Postgres is running
+          ▸ Check your database configuration settings
+  
+  
+        ERROR
+      end
+      super error
+    end
+  end
 end

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -71,32 +71,9 @@ class Avram::Migrator::Runner
         puts "Already created #{self.db_name.colorize(:green)}"
       end
     elsif (message = e.message) && (message.includes?("createdb: not found") || message.includes?("No command 'createdb' found"))
-      raise <<-ERROR
-      #{message}
-
-      Try this...
-
-        ▸ If you are on macOS  you can install postgres tools from #{macos_postgres_tools_link}
-        ▸ If you are on linux you can try running #{linux_postgres_installation_instructions}
-        ▸ If you are on CI or some servers, there may already be a database created so you don't need this command"
-
-
-      ERROR
+      raise PGClientNotInstalledError.new(message)
     elsif (message = e.message) && message.includes?("could not connect to database template")
-      raise <<-ERROR
-      Creating the database failed. It looks like Postgres is not running.
-
-      Message from Postgres:
-
-        #{message}
-
-      Try this...
-
-        ▸ Make sure Postgres is running
-        ▸ Check your database configuration settings
-
-
-      ERROR
+      raise PGNotRunningError.new(message)
     else
       raise e
     end
@@ -134,14 +111,6 @@ class Avram::Migrator::Runner
       version bigint NOT NULL
     )
     SQL
-  end
-
-  private def self.macos_postgres_tools_link
-    "https://postgresapp.com/documentation/cli-tools.html".colorize(:green)
-  end
-
-  private def self.linux_postgres_installation_instructions
-    "sudo apt-get update && sudo apt-get install postgresql postgresql-contrib".colorize(:green)
   end
 
   def self.run(command : String, output : IO = STDOUT)

--- a/src/avram/tasks/db/create.cr
+++ b/src/avram/tasks/db/create.cr
@@ -20,26 +20,8 @@ class Db::Create < LuckyCli::Task
   end
 
   def call
-    attempt_to_connect
     Migrator.run do
       Migrator::Runner.create_db(@quiet)
     end
-  rescue
-    uri = URI.parse(connection_url)
-    raise Avram::ConnectionError.new(uri, Avram.settings.database_to_migrate)
-  end
-
-  private def connection_url : String
-    Avram::PostgresURL.build(
-      database: "",
-      hostname: Migrator::Runner.db_host.to_s,
-      username: Migrator::Runner.db_user.to_s,
-      password: Migrator::Runner.db_password.to_s,
-      port: Migrator::Runner.db_port.to_s
-    )
-  end
-
-  private def attempt_to_connect
-    Migrator::Runner.run("psql -q -l #{connection_url}", output: IO::Memory.new)
   end
 end


### PR DESCRIPTION
Fixes #417 

It turns out that if your postgres username is the same as your OS username, and you don't pass a database name to `psql`, then it tries to assume you want to connect to a database of that name. If that database name doesn't exist (because it really shouldn't), then it fails. This also means that `./script/setup` fails. 

It's ok anyway, because the `create_db` method already throws errors based on connection. In this PR I'm moving those error messages to Error classes as well. This keeps all of these errors in a single location.