### PR TITLE
Adding define functions

### DIFF
--- a/spec/migrator/create_function_statement_spec.cr
+++ b/spec/migrator/create_function_statement_spec.cr
@@ -1,0 +1,28 @@
+require "../spec_helper"
+
+describe Avram::Migrator::CreateFunctionStatement do
+  it "builds the proper SQL for creating a function" do
+    sql = <<-SQL
+    IF NEW.updated_at IS NULL OR NEW.updated_at = OLD.updated_at THEN
+      NEW.updated_at := now();
+    END IF;
+    RETURN NEW;
+    SQL
+    statement = Avram::Migrator::CreateFunctionStatement.new(:set_updated_at, sql)
+
+    full_statement = statement.build
+    full_statement.should contain "CREATE OR REPLACE FUNCTION set_updated_at()"
+    full_statement.should contain "RETURNS trigger"
+    full_statement.should contain "IF NEW.updated_at IS NULL OR NEW.updated_at = OLD.updated_at THEN"
+  end
+
+  it "builds more complex functions" do
+    sql = "RETURN i + 1;"
+    statement = Avram::Migrator::CreateFunctionStatement.new("increment(i integer)", sql, returns: "integer")
+
+    full_statement = statement.build
+    full_statement.should contain "CREATE OR REPLACE FUNCTION increment(i integer)"
+    full_statement.should contain "RETURNS integer"
+    full_statement.should contain "RETURN i + 1;"
+  end
+end

--- a/spec/migrator/create_function_statement_spec.cr
+++ b/spec/migrator/create_function_statement_spec.cr
@@ -8,7 +8,7 @@ describe Avram::Migrator::CreateFunctionStatement do
     END IF;
     RETURN NEW;
     SQL
-    statement = Avram::Migrator::CreateFunctionStatement.new(:set_updated_at, sql)
+    statement = Avram::Migrator::CreateFunctionStatement.new("set_updated_at", sql)
 
     full_statement = statement.build
     full_statement.should contain "CREATE OR REPLACE FUNCTION set_updated_at()"

--- a/spec/migrator/drop_function_statement_spec.cr
+++ b/spec/migrator/drop_function_statement_spec.cr
@@ -1,0 +1,8 @@
+require "../spec_helper"
+
+describe Avram::Migrator::DropFunctionStatement do
+  it "builds the proper SQL for dropping a function" do
+    statement = Avram::Migrator::DropFunctionStatement.new("set_updated_at")
+    statement.build.should eq %{DROP FUNCTION IF EXISTS "set_updated_at" CASCADE;}
+  end
+end

--- a/src/avram/migrator/create_function_statement.cr
+++ b/src/avram/migrator/create_function_statement.cr
@@ -1,9 +1,9 @@
 class Avram::Migrator::CreateFunctionStatement
-  def initialize(@name : String | Symbol, @body : String, @returns : String = "trigger")
+  def initialize(@name : String, @body : String, @returns : String = "trigger")
   end
 
   def function_name
-    if @name.to_s.ends_with?(')')
+    if @name.ends_with?(')')
       @name
     else
       "#{@name}()"

--- a/src/avram/migrator/create_function_statement.cr
+++ b/src/avram/migrator/create_function_statement.cr
@@ -1,0 +1,23 @@
+class Avram::Migrator::CreateFunctionStatement
+  def initialize(@name : String | Symbol, @body : String, @returns : String = "trigger")
+  end
+
+  def function_name
+    if @name.to_s.ends_with?(')')
+      @name
+    else
+      "#{@name}()"
+    end
+  end
+
+  def build
+    <<-SQL
+    CREATE OR REPLACE FUNCTION #{function_name}
+      RETURNS #{@returns} AS $$
+    BEGIN
+      #{@body}
+    END
+    $$ LANGUAGE 'plpgsql';
+    SQL
+  end
+end

--- a/src/avram/migrator/drop_function_statement.cr
+++ b/src/avram/migrator/drop_function_statement.cr
@@ -1,0 +1,10 @@
+class Avram::Migrator::DropFunctionStatement
+  def initialize(@name : String)
+  end
+
+  def build
+    <<-SQL
+    DROP FUNCTION IF EXISTS "#{@name}" CASCADE;
+    SQL
+  end
+end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -60,8 +60,8 @@ module Avram::Migrator::StatementHelpers
     prepared_statements << Avram::Migrator::AlterExtensionStatement.new(name, to: to).build
   end
 
-  def create_function(name : String, body : String)
-    prepared_statements << Avram::Migrator::CreateFunctionStatement.new(name, body: body).build
+  def create_function(name : String, body : String, returns : String = "trigger")
+    prepared_statements << Avram::Migrator::CreateFunctionStatement.new(name, body: body, returns: returns).build
   end
 
   def drop_function(name : String)

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -63,4 +63,8 @@ module Avram::Migrator::StatementHelpers
   def create_function(name : String, body : String)
     prepared_statements << Avram::Migrator::CreateFunctionStatement.new(name, body: body).build
   end
+
+  def drop_function(name : String)
+    prepared_statements << Avram::Migrator::DropFunctionStatement.new(name).build
+  end
 end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -60,7 +60,7 @@ module Avram::Migrator::StatementHelpers
     prepared_statements << Avram::Migrator::AlterExtensionStatement.new(name, to: to).build
   end
 
-  def create_function(name : Symbol, function_body : String)
-    prepared_statements << Avram::Migrator::CreateFunctionStatement.new(name, body: function_body).build
+  def create_function(name : String, body : String)
+    prepared_statements << Avram::Migrator::CreateFunctionStatement.new(name, body: body).build
   end
 end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -59,4 +59,8 @@ module Avram::Migrator::StatementHelpers
   def update_extension(name : String, to : String? = nil)
     prepared_statements << Avram::Migrator::AlterExtensionStatement.new(name, to: to).build
   end
+
+  def create_function(name : Symbol, function_body : String)
+    prepared_statements << Avram::Migrator::CreateFunctionStatement.new(name, body: function_body).build
+  end
 end


### PR DESCRIPTION
This is a precursor to #393 

This PR adds the ability to define postgres functions. By default I have made these trigger functions because I feel those may be the most common. A trigger function is a function that can only be called from a trigger. A trigger is just basically a callback in postgres. 

Now, postgres functions can get super complicated real quick. There's a ton of possible options you can have, and all kinds of return types. What this PR does is gives you the ability to do some simple functions by providing you with some boilerplate. Beyond the simple ones you may need you can always use the `execute()` method in your migrations to hand roll your own complex functions.

The ability to define triggers will come in another PR.

```crystal
def migrate
  # simple trigger function
  create_function "set_updated_at", <<-SQL
    IF NEW.updated_at IS NULL OR NEW.updated_at = OLD.updated_at THEN
      NEW.updated_at := now();
    END IF;
    RETURN NEW;
  SQL
end

def migrate
  # more complex example
  create_function "increment(i integer)", <<-SQL, returns: "integer"
    RETURN i + 1;
  SQL

  execute("SELECT increment(1)") #=> returns 2
end
```

