### PR TITLE
Removed trailing spaces in project files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,6 +24,6 @@ Finally, don't forget that it is human to make mistakes! We all do. Let’s work
 Thanks to the CocoaPods Code of Conduct, Bundler Code of Conduct, JSConf Code of Conduct, and Contributor Covenant for inspiration and ideas.
 
 ## License
-To the extent possible under law, the thoughtbot team has waived all copyright and related or neighboring rights to thoughtbot Code of Conduct. This work is published from the United States. 
+To the extent possible under law, the thoughtbot team has waived all copyright and related or neighboring rights to thoughtbot Code of Conduct. This work is published from the United States.
 
 [homepage](https://thoughtbot.com/open-source-code-of-conduct)

--- a/script/test
+++ b/script/test
@@ -16,7 +16,7 @@ if [ $# -eq 0 ]
 then
     printf "\nChecking that tasks build correctly\n\n"
     $COMPOSE shards build
-    
+
     printf "\nChecking code formatting\n\n"
     if ! $COMPOSE crystal tool format --check src spec config > /dev/null; then
         printf "\nCode is not formatted.\n"

--- a/src/avram/define_attribute.cr
+++ b/src/avram/define_attribute.cr
@@ -111,7 +111,7 @@ module Avram::DefineAttribute
     @_{{ name }} : Avram::Attribute(Avram::Uploadable?)?
 
     ensure_base_attributes_method_is_present
-    
+
     def attributes
       ([{{ name }}] + previous_def + super).uniq
     end


### PR DESCRIPTION
Based on the same PR to Lucky: https://github.com/luckyframework/lucky/pull/1223.

Removed trailing spaces in project files:

- CODE_OF_CONDUCT.md
- script/test
- src/avram/define_attribute.cr
