### PR TITLE
Adding new triggers feature to generate postgres triggers.

### DIFF
--- a/spec/migrator/create_trigger_statement_spec.cr
+++ b/spec/migrator/create_trigger_statement_spec.cr
@@ -1,0 +1,27 @@
+require "../spec_helper"
+
+describe Avram::Migrator::CreateTriggerStatement do
+  it "builds the proper SQL for creating a before update trigger" do
+    statement = Avram::Migrator::CreateTriggerStatement.new(:users, "trigger_set_timestamp", function: "set_timestamp")
+
+    full_statement = statement.build
+    full_statement.should eq <<-SQL
+    CREATE TRIGGER trigger_set_timestamp
+    BEFORE UPDATE ON users
+    FOR EACH ROW
+    EXECUTE PROCEDURE set_timestamp();
+    SQL
+  end
+
+  it "builds the statement for after trigger on insert, update, and delete" do
+    statement = Avram::Migrator::CreateTriggerStatement.new(:users, "trigger_update_counts", function: "update_counts", callback: :after, on: [:insert, :update, :delete])
+
+    full_statement = statement.build
+    full_statement.should eq <<-SQL
+    CREATE TRIGGER trigger_update_counts
+    AFTER INSERT OR UPDATE OR DELETE ON users
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_counts();
+    SQL
+  end
+end

--- a/spec/migrator/drop_trigger_statement_spec.cr
+++ b/spec/migrator/drop_trigger_statement_spec.cr
@@ -1,0 +1,8 @@
+require "../spec_helper"
+
+describe Avram::Migrator::DropTriggerStatement do
+  it "builds the proper SQL for dropping a trigger" do
+    statement = Avram::Migrator::DropTriggerStatement.new(:users, "trigger_set_timestamp")
+    statement.build.should eq %{DROP TRIGGER IF EXISTS trigger_set_timestamp ON users;}
+  end
+end

--- a/spec/migrator/migration_spec.cr
+++ b/spec/migrator/migration_spec.cr
@@ -55,12 +55,12 @@ class MigrationWithFunctionAndTrigger::V996 < Avram::Migrator::Migration::V1
     RETURN NEW;
     SQL
 
-    create_trigger table_for(User), "touch_updated_at"
+    create_trigger table_for(User), "trigger_touch_updated_at", "touch_updated_at"
   end
 
   def rollback
     drop_function "touch_updated_at"
-    drop_trigger :users, "touch_updated_at"
+    drop_trigger :users, "trigger_touch_updated_at"
   end
 end
 

--- a/spec/migrator/migration_spec.cr
+++ b/spec/migrator/migration_spec.cr
@@ -46,6 +46,24 @@ class MigrationWithAlterAndFillExisting::V997 < Avram::Migrator::Migration::V1
   end
 end
 
+class MigrationWithFunctionAndTrigger::V996 < Avram::Migrator::Migration::V1
+  def migrate
+    create_function "touch_updated_at", <<-SQL
+    IF NEW.updated_at IS NULL OR NEW.updated_at = OLD.updated_at THEN
+      NEW.updated_at := now();
+    END IF;
+    RETURN NEW;
+    SQL
+
+    create_trigger table_for(User), "touch_updated_at"
+  end
+
+  def rollback
+    drop_function "touch_updated_at"
+    drop_trigger :users, "touch_updated_at"
+  end
+end
+
 describe Avram::Migrator::Migration::V1 do
   it "executes statements in a transaction" do
     expect_raises Exception, %(relation "table_does_not_exist" does not exist) do
@@ -81,6 +99,18 @@ describe Avram::Migrator::Migration::V1 do
       ensure
         MigrationWithAlterAndFillExisting::V997.new.down(quiet: true)
       end
+    end
+  end
+
+  describe "helper statements" do
+    it "appends function and trigger statments to prepared statements" do
+      migration = MigrationWithFunctionAndTrigger::V996.new
+      migration.migrate
+      sql = migration.prepared_statements.join("\n")
+
+      sql.should contain "CREATE OR REPLACE FUNCTION touch_updated_at"
+      sql.should contain "DROP TRIGGER IF EXISTS trigger_touch_updated_at"
+      sql.should contain "CREATE TRIGGER trigger_touch_updated_at"
     end
   end
 end

--- a/src/avram/migrator/create_trigger_statement.cr
+++ b/src/avram/migrator/create_trigger_statement.cr
@@ -1,0 +1,25 @@
+class Avram::Migrator::CreateTriggerStatement
+  def initialize(
+    @table_name : Symbol,
+    @trigger_name : String,
+    @function : String,
+    callback @trigger_when : Symbol = :before,
+    on @trigger_operation : Array(Symbol) = [:update]
+  )
+  end
+
+  def build
+    <<-SQL
+    CREATE TRIGGER #{@trigger_name}
+    #{@trigger_when.to_s.upcase} #{operation_statement} ON #{@table_name}
+    FOR EACH ROW
+    EXECUTE PROCEDURE #{@function}();
+    SQL
+  end
+
+  private def operation_statement
+    @trigger_operation.map { |op|
+      op.to_s.upcase
+    }.join(" OR ")
+  end
+end

--- a/src/avram/migrator/drop_trigger_statement.cr
+++ b/src/avram/migrator/drop_trigger_statement.cr
@@ -1,0 +1,10 @@
+class Avram::Migrator::DropTriggerStatement
+  def initialize(@table_name : Symbol, @trigger_name : String)
+  end
+
+  def build
+    <<-SQL
+    DROP TRIGGER IF EXISTS #{@trigger_name} ON #{@table_name};
+    SQL
+  end
+end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -71,24 +71,22 @@ module Avram::Migrator::StatementHelpers
   # Drop any existing trigger by this name first before creating.
   # Postgres does not support updating or replacing a trigger as of version 12
   #
-  # Creates a new TRIGGER named the same as the `function_name` prefixed with "trigger" on the table `table_name`.
+  # Creates a new TRIGGER named `name` on the table `table_name`.
   # `function_name` - The PG function to run from this trigger.
   # `callback` - When to run this trigger (BEFORE or AFTER). Default `:before`
   # `on` - The operation(s) for this trigger (INSERT, UPDATE, DELETE). Default is `[:update]`
   #
   # ```crystal
-  # create_trigger(:users, "set_timestamps")
+  # create_trigger(:users, "trigger_set_timestamps", "set_timestamps")
   # # => CREATE TRIGGER trigger_set_timestamps BEFORE UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE set_timestamps();
   # ```
-  def create_trigger(table_name : Symbol, function_name : String, callback : Symbol = :before, on : Array(Symbol) = [:update])
-    name = "trigger_#{function_name}"
+  def create_trigger(table_name : Symbol, name : String, function_name : String, callback : Symbol = :before, on : Array(Symbol) = [:update])
     drop_trigger(table_name, name)
     prepared_statements << Avram::Migrator::CreateTriggerStatement.new(table_name, name, function_name, callback, on).build
   end
 
   # Drop the tigger `name` for the table `table_name`
   def drop_trigger(table_name : Symbol, name : String)
-    name = "trigger_#{name}" unless name.starts_with?("trigger")
     prepared_statements << Avram::Migrator::DropTriggerStatement.new(table_name, name).build
   end
 end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -67,4 +67,28 @@ module Avram::Migrator::StatementHelpers
   def drop_function(name : String)
     prepared_statements << Avram::Migrator::DropFunctionStatement.new(name).build
   end
+
+  # Drop any existing trigger by this name first before creating.
+  # Postgres does not support updating or replacing a trigger as of version 12
+  #
+  # Creates a new TRIGGER named the same as the `function_name` prefixed with "trigger" on the table `table_name`.
+  # `function_name` - The PG function to run from this trigger.
+  # `callback` - When to run this trigger (BEFORE or AFTER). Default `:before`
+  # `on` - The operation(s) for this trigger (INSERT, UPDATE, DELETE). Default is `[:update]`
+  #
+  # ```crystal
+  # create_trigger(:users, "set_timestamps")
+  # # => CREATE TRIGGER trigger_set_timestamps BEFORE UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE set_timestamps();
+  # ```
+  def create_trigger(table_name : Symbol, function_name : String, callback : Symbol = :before, on : Array(Symbol) = [:update])
+    name = "trigger_#{function_name}"
+    drop_trigger(table_name, name)
+    prepared_statements << Avram::Migrator::CreateTriggerStatement.new(table_name, name, function_name, callback, on).build
+  end
+
+  # Drop the tigger `name` for the table `table_name`
+  def drop_trigger(table_name : Symbol, name : String)
+    name = "trigger_#{name}" unless name.starts_with?("trigger")
+    prepared_statements << Avram::Migrator::DropTriggerStatement.new(table_name, name).build
+  end
 end


### PR DESCRIPTION
This is a stepping stone to closing out 

https://github.com/luckyframework/avram/issues/337
https://github.com/luckyframework/avram/issues/393

This PR introduces the ability to set simple triggers. As with most Postgres things, it can get super hairy, so if you need something complex, it's best to hop out of Avram anyway. These should cover the 90% use case though.

This create a BEFORE UPDATE trigger called "trigger_set_timestamp" that will call the "set_timestamp()" function

```crystal
create_trigger table_for(User), "set_timestamp"
```

You can create a trigger for BEFORE/AFTER and on INSERT/UPDATE/DELETE by passing some options:

```crystal
create_function "update_counts", <<-SQL
  NEW.some_count = OLD.some_count + 1
  RETURN NEW;
SQL

create_trigger :users, "update_counts", callback: :after, on: [:insert, :update]
```