### PR TITLE
Fixed passing an empty string to a nilable type through params

### DIFF
--- a/spec/save_operation_spec.cr
+++ b/spec/save_operation_spec.cr
@@ -79,16 +79,13 @@ describe "Avram::SaveOperation" do
     bucket.names.should eq([] of String)
   end
 
-  it "ignores empty params on nilable fields" do
+  it "treats empty strings as nil for Time? types instead of failing to parse" do
     avram_params = Avram::Params.new({"title" => "Test", "published_at" => ""})
 
-    SavePost.create(avram_params) do |operation, post|
-      operation.errors.should be_empty
-      operation.valid?.should eq true
-      post.should_not be_nil
-      post.not_nil!.published_at.should eq nil
-      post.not_nil!.title.should eq "Test"
-    end
+    post = SavePost.create!(avram_params)
+
+    post.published_at.should eq nil
+    post.title.should eq "Test"
   end
 
   describe ".create" do

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -153,6 +153,11 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
       end
 
       def set_{{ attribute[:name] }}_from_param(_value)
+        {% if attribute[:nilable] %}
+          # The type is nilable, but if the value is blank, it will return a FailedCast
+          # in types like `Time?` or `Int32?`, etc...
+          return nil if _value.blank?
+        {% end %}
         {% if attribute[:type].is_a?(Generic) %}
           # Pass `_value` in as an Array. Currently only single values are supported.
           # TODO: Update this once Lucky params support Arrays natively

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -153,11 +153,12 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
       end
 
       def set_{{ attribute[:name] }}_from_param(_value)
-        {% if attribute[:nilable] %}
-          # The type is nilable, but if the value is blank, it will return a FailedCast
-          # in types like `Time?` or `Int32?`, etc...
-          return nil if _value.blank?
-        {% end %}
+        # In nilable types, `nil` is ok, and non-nilable types we will get the
+        # "is required" error.
+        if _value.blank?
+          {{ attribute[:name] }}.value = nil
+          return
+        end
         {% if attribute[:type].is_a?(Generic) %}
           # Pass `_value` in as an Array. Currently only single values are supported.
           # TODO: Update this once Lucky params support Arrays natively


### PR DESCRIPTION
Fixes #447
Fixes #20 

If you pass a permitted column that's nilable through params as an empty string, then it will fail to cast that like in the case of `Time?` being parsed https://github.com/luckyframework/avram/blob/master/src/avram/charms/time_extensions.cr#L27. So in this case, if the type is nilable, and we send an empty value, just return nil instead of assigning a value. 

One case to note here that we may need to handle separately would be if you defined a `String?` and were ok with this being an empty string. In this case, you should just make your column NOT nilable, but as of right now we don't tell you that. 