### PR TITLE
Handle duplicate joins

### DIFF
--- a/spec/query_associations_spec.cr
+++ b/spec/query_associations_spec.cr
@@ -1,5 +1,11 @@
 require "./spec_helper"
 
+class LineItemProductQuery < LineItemProduct::BaseQuery
+end
+
+class ProductQuery < Product::BaseQuery
+end
+
 # Ensure it works with inherited query classes
 class CommentQuery < Comment::BaseQuery
   def body_eq(value)
@@ -139,5 +145,20 @@ describe "Query associations" do
 
     staff = NamedSpaced::Staff::BaseQuery.new
     staff.to_sql[0].should contain "named_spaced_staffs"
+  end
+
+  it "can query with potentially unnecessary joins" do
+    item = LineItemBox.create
+    product = ProductBox.create
+    line_item_product = LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)
+
+    line_item_query = LineItemQuery.new
+      .id(item.id)
+      .where_products(ProductQuery.new.id(product.id))
+    result = LineItemProductQuery.new
+      .where_line_items(line_item_query)
+      .find(line_item_product.id)
+
+    result.should eq(line_item_product)
   end
 end

--- a/spec/query_associations_spec.cr
+++ b/spec/query_associations_spec.cr
@@ -161,4 +161,19 @@ describe "Query associations" do
 
     result.should eq(line_item_product)
   end
+
+  it "can query with potentially unnecessary joins again" do
+    item = LineItemBox.create
+    product = ProductBox.create
+    line_item_product = LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)
+
+    line_item_query = LineItemQuery.new
+      .id(item.id)
+      .where_line_items_products(LineItemProductQuery.new.id(line_item_product.id))
+    result = ProductQuery.new
+      .where_line_items(line_item_query)
+      .find(product.id)
+
+    result.should eq(product)
+  end
 end

--- a/spec/query_associations_spec.cr
+++ b/spec/query_associations_spec.cr
@@ -147,7 +147,7 @@ describe "Query associations" do
     staff.to_sql[0].should contain "named_spaced_staffs"
   end
 
-  it "can query with potentially unnecessary joins" do
+  it "handles potential joins over the table queried" do
     item = LineItemBox.create
     product = ProductBox.create
     line_item_product = LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)
@@ -162,7 +162,7 @@ describe "Query associations" do
     result.should eq(line_item_product)
   end
 
-  it "can query with potentially unnecessary joins again" do
+  it "handles duplicate joins" do
     item = LineItemBox.create
     product = ProductBox.create
     line_item_product = LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -274,7 +274,7 @@ class Avram::QueryBuilder
   end
 
   def join(join_clause : Avram::Join::SqlClause)
-    if join_clause.to != table
+    if join_clause.to != table && @joins.none? { |join| join.to == join_clause.to }
       @joins << join_clause
     end
     self

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -274,7 +274,9 @@ class Avram::QueryBuilder
   end
 
   def join(join_clause : Avram::Join::SqlClause)
-    @joins << join_clause
+    if join_clause.to != table
+      @joins << join_clause
+    end
     self
   end
 


### PR DESCRIPTION
Fixes #370 

## Summary

Querying with joins can sometimes produce invalid sql. The two cases that this PR handles are:
1. When they potential join is to the table being queried
2. When the potential join has already been joined

## Description

These situations are rather easy to get to when users attempt to make composable methods that limit the scope of queries. Say an app has the concept of a `Business` and a `User` and if the user belongs to a business they are considered an `Employee` of that business. If the app allowed users to access the api, it might make sense to limit their API access to businesses they are an employee of. Rather than having to remember how to scope their access correctly every time you have a new query, you could make helper methods like (granted this is convoluted, I'm sure there are more realistic ways to get in this situation):

```crystal
def user_scoped(query)
  scoped_user_query = UserQuery.new.id(current_user.id)
  query.where_users(scoped_user_query)
end

def business_scoped(query)
  scoped_business_query = user_scoped(BusinessQuery.new.id(current_business.id))
  query.where_businesses(scoped_business_query)
end
```

(Those methods would require that `Business` has a has many through association to `User` through `Employee`)
The problem arises when you want to provide an endpoint that returns all the employees for the user's current business. The action would do something like:
```crystal
employees = business_scoped(EmployeeQuery.new)
```

You end up with an error: `table name "employees" specified more than once (PQ::PQError)` because the BusinessQuery adds a join to limit by the user id and the main query is on the employees table.

## Note

I'm sure there are situations this doesn't handle and this might even cause issues so _PLEASE_ poke holes in this change.