### PR TITLE
Provide better error when primary key is missing

### DIFF
--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -118,6 +118,8 @@ abstract class Avram::Model
 
     {{ yield }}
 
+    validate_primary_key
+
     setup({{table_name}})
     {% MACRO_CHECKS[:setup_complete] = true %}
   end
@@ -142,6 +144,22 @@ abstract class Avram::Model
       def id
         {{ type_declaration.var.id }}
       end
+    {% end %}
+  end
+
+  macro validate_primary_key
+    {% if !@type.has_constant? "PRIMARY_KEY_TYPE" %}
+      \{% raise <<-ERROR
+        No primary key was specified.
+
+        Example:
+
+          table do
+            primary_key id : Int64
+            ...
+          end
+        ERROR
+      %}
     {% end %}
   end
 


### PR DESCRIPTION
Pointed out in [this issue comment](https://github.com/luckyframework/avram/issues/6#issuecomment-515215447)

If a model uses `skip_default_columns`, they are required to call `primary_key` in the `table` block. If they forget, the error is cryptic. This updates the process to actually check for a primary key and provide a more clear error.

## Before

```
Showing last frame. Use --error-trace for full trace.

In src/avram/model.cr:170:30

 170 | primary_key_type: {{ PRIMARY_KEY_TYPE }},
                            ^
Error: undefined constant PRIMARY_KEY_TYPE
```

## After

```
Showing last frame. Use --error-trace for full trace.

There was a problem expanding macro 'table'

Code in spec/support/line_item_product.cr:4:3

 4 | table :line_items_products do
     ^
Called macro defined in src/avram/model.cr:112:3

 112 | macro table(table_name = nil)

Which expanded to:

 >  8 |  end
 >  9 | 
 > 10 |     validate_primary_key
            ^
Error: No primary key was specified.

Example:

  table do
    primary_key id : Int64
    ...
  end
```