### PR TITLE
Extract PrimaryKeyQueryable from Queryable

### DIFF
--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -5,6 +5,7 @@ class Avram::BaseQueryTemplate
       end
 
       def_clone
+      include Avram::Queryable({{ type }})
       include Avram::PrimaryKeyQueryable({{ type }})
 
       def database : Avram::Database.class

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -5,7 +5,7 @@ class Avram::BaseQueryTemplate
       end
 
       def_clone
-      include Avram::Queryable({{ type }})
+      include Avram::PrimaryKeyQueryable({{ type }})
 
       def database : Avram::Database.class
         {{ type }}.database

--- a/src/avram/primary_key_queryable.cr
+++ b/src/avram/primary_key_queryable.cr
@@ -1,13 +1,11 @@
 require "./errors"
-require "./queryable"
 
 module Avram::PrimaryKeyQueryable(T)
   abstract def id
   abstract def id(id_val)
+  abstract def query
 
   macro included
-    include Avram::Queryable(T)
-
     def self.find(id)
       new.find(id)
     end

--- a/src/avram/primary_key_queryable.cr
+++ b/src/avram/primary_key_queryable.cr
@@ -1,10 +1,6 @@
 require "./errors"
 
 module Avram::PrimaryKeyQueryable(T)
-  abstract def id
-  abstract def id(id_val)
-  abstract def query
-
   macro included
     def self.find(id)
       new.find(id)

--- a/src/avram/primary_key_queryable.cr
+++ b/src/avram/primary_key_queryable.cr
@@ -1,0 +1,27 @@
+require "./errors"
+require "./queryable"
+
+module Avram::PrimaryKeyQueryable(T)
+  abstract def id
+  abstract def id(id_val)
+
+  macro included
+    include Avram::Queryable(T)
+
+    def self.find(id)
+      new.find(id)
+    end
+
+    def find(id)
+      id(id).limit(1).first? || raise Avram::RecordNotFoundError.new(model: @@table_name, id: id.to_s)
+    end
+
+    private def with_ordered_query : self
+      if query.ordered?
+        self
+      else
+        id.asc_order
+      end
+    end
+  end
+end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -1,8 +1,6 @@
 module Avram::Queryable(T)
   include Enumerable(T)
 
-  abstract def id
-
   @query : Avram::QueryBuilder?
   setter query
 
@@ -15,10 +13,6 @@ module Avram::Queryable(T)
 
     def self.all
       new
-    end
-
-    def self.find(id)
-      new.find(id)
     end
 
     def self.first
@@ -149,10 +143,6 @@ module Avram::Queryable(T)
     clone.tap &.query.offset(amount)
   end
 
-  def find(id)
-    id(id).limit(1).first? || raise RecordNotFoundError.new(model: @@table_name, id: id.to_s)
-  end
-
   def first?
     with_ordered_query
       .limit(1)
@@ -213,11 +203,7 @@ module Avram::Queryable(T)
   end
 
   private def with_ordered_query : self
-    if query.ordered?
-      self
-    else
-      id.asc_order
-    end
+    self
   end
 
   def to_sql


### PR DESCRIPTION
Related to #453 

If we want to support database views in the future, one step in getting there is removing the requirement of the database table having a primary key.

When the time comes to allow not setting a primary key, the `BaseQueryTemplate` not include `PrimaryKeyQueryable` which will remove any ability to query by the primary key for that model.