### PR TITLE
Represent wheres and raw wheres in the same way

### DIFF
--- a/spec/query_builder/merge_spec.cr
+++ b/spec/query_builder/merge_spec.cr
@@ -4,16 +4,16 @@ describe "Avram::QueryBuilder#merge" do
   it "merges the wheres and joins" do
     query_1 = new_query
       .where(Avram::Where::Equal.new(:age, "42"))
-      .raw_where(Avram::Where::Raw.new("name = ?", "Mary"))
+      .where(Avram::Where::Raw.new("name = ?", "Mary"))
       .join(Avram::Join::Inner.new(:users, :posts))
     query_2 = new_query
       .where(Avram::Where::Equal.new(:age, "20"))
-      .raw_where(Avram::Where::Raw.new("name = ?", "Greg"))
+      .where(Avram::Where::Raw.new("name = ?", "Greg"))
       .join(Avram::Join::Inner.new(:users, :tasks))
 
     query_1.merge(query_2)
 
-    query_1.statement.should eq "SELECT * FROM users INNER JOIN posts ON users.id = posts.user_id INNER JOIN tasks ON users.id = tasks.user_id WHERE age = $1 AND age = $2 AND name = 'Mary' AND name = 'Greg'"
+    query_1.statement.should eq "SELECT * FROM users INNER JOIN posts ON users.id = posts.user_id INNER JOIN tasks ON users.id = tasks.user_id WHERE age = $1 AND name = 'Mary' AND age = $2 AND name = 'Greg'"
     query_1.args.should eq ["42", "20"]
   end
 

--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -1,20 +1,19 @@
 require "./spec_helper"
 
 describe Avram::QueryBuilder do
-  it "ensures uniqueness for where, raw_where, orders, and joins" do
+  it "ensures uniqueness for where, orders, and joins" do
     query = new_query
       .where(Avram::Where::Equal.new(:name, "Paul"))
       .where(Avram::Where::Equal.new(:name, "Paul"))
-      .raw_where(Avram::Where::Raw.new("name = ?", "Mikias"))
-      .raw_where(Avram::Where::Raw.new("name = ?", "Mikias"))
-      .raw_where(Avram::Where::Raw.new("name = ?", args: ["Mikias"]))
+      .where(Avram::Where::Raw.new("name = ?", "Mikias"))
+      .where(Avram::Where::Raw.new("name = ?", "Mikias"))
+      .where(Avram::Where::Raw.new("name = ?", args: ["Mikias"]))
       .join(Avram::Join::Inner.new(:users, :posts))
       .join(Avram::Join::Inner.new(:users, :posts))
       .order_by(Avram::OrderBy.new(:my_column, :asc))
       .order_by(Avram::OrderBy.new(:my_column, :asc))
 
-    query.wheres.size.should eq(1)
-    query.raw_wheres.size.should eq(1)
+    query.wheres.size.should eq(2)
     query.joins.size.should eq(1)
     query.statement.should eq "SELECT * FROM users INNER JOIN posts ON users.id = posts.user_id WHERE name = $1 AND name = 'Mikias' ORDER BY my_column ASC"
     query.args.should eq ["Paul"]
@@ -87,9 +86,9 @@ describe Avram::QueryBuilder do
 
   it "accepts raw where clauses" do
     query = new_query
-      .raw_where(Avram::Where::Raw.new("name = ?", "Mikias"))
-      .raw_where(Avram::Where::Raw.new("age > ?", 26))
-      .raw_where(Avram::Where::Raw.new("age < ?", args: [30]))
+      .where(Avram::Where::Raw.new("name = ?", "Mikias"))
+      .where(Avram::Where::Raw.new("age > ?", 26))
+      .where(Avram::Where::Raw.new("age < ?", args: [30]))
       .limit(1)
     query.statement.should eq "SELECT * FROM users WHERE name = 'Mikias' AND age > 26 AND age < 30 LIMIT 1"
     query.args.empty?.should be_true

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -345,7 +345,7 @@ describe Avram::Query do
       user = UserBox.new.name("Mikias Abera").age(26).nickname("miki").create
       users = UserQuery.new.where("name = ? AND age = ?", "Mikias Abera", 26).where(:nickname, "miki")
 
-      users.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE nickname = $1 AND name = 'Mikias Abera' AND age = 26"
+      users.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE name = 'Mikias Abera' AND age = 26 AND nickname = $1"
 
       users.query.args.should eq ["miki"]
       users.results.should eq [user]

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -291,6 +291,7 @@ class Avram::QueryBuilder
     self
   end
 
+  @[Deprecated("Use `#where` instead.")]
   def raw_where(where_clause : Avram::Where::Raw)
     @wheres << where_clause
     self
@@ -314,6 +315,7 @@ class Avram::QueryBuilder
     @wheres.uniq
   end
 
+  @[Deprecated("Use `#wheres` instead. Raw wheres are included.")]
   def raw_wheres
     wheres.select(&.is_a?(Avram::Where::Raw))
   end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -309,8 +309,7 @@ class Avram::QueryBuilder
 
   private def joined_wheres_queries
     if wheres.any? || raw_wheres.any?
-      statements = wheres.map(&.prepare(->next_prepared_statement_placeholder))
-      statements += raw_wheres.map(&.to_sql)
+      statements = (wheres + raw_wheres).map(&.prepare(->next_prepared_statement_placeholder))
 
       "WHERE " + statements.join(" AND ")
     end
@@ -321,7 +320,7 @@ class Avram::QueryBuilder
   end
 
   def raw_wheres
-    @raw_wheres.uniq(&.to_sql)
+    @raw_wheres.uniq(&.prepare(->{"unused"}))
   end
 
   private def prepared_statement_values

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -313,7 +313,7 @@ class Avram::QueryBuilder
         if sql_clause.is_a?(Avram::Where::NullSqlClause)
           sql_clause.prepare
         else
-          sql_clause.prepare(next_prepared_statement_placeholder)
+          sql_clause.prepare(->next_prepared_statement_placeholder)
         end
       end
       statements += raw_wheres.map(&.to_sql)
@@ -323,7 +323,7 @@ class Avram::QueryBuilder
   end
 
   def wheres
-    @wheres.uniq { |where| where.prepare(prepared_statement_placeholder: "unused") + where.value.to_s }
+    @wheres.uniq { |where| where.prepare(->{"unused"}) + where.value.to_s }
   end
 
   def raw_wheres

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -293,8 +293,7 @@ class Avram::QueryBuilder
 
   @[Deprecated("Use `#where` instead.")]
   def raw_where(where_clause : Avram::Where::Raw)
-    @wheres << where_clause
-    self
+    where(where_clause)
   end
 
   @_wheres_sql : String?

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -320,7 +320,7 @@ class Avram::QueryBuilder
   end
 
   def raw_wheres
-    @raw_wheres.uniq(&.prepare(->{"unused"}))
+    @raw_wheres.uniq
   end
 
   private def prepared_statement_values

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -325,7 +325,7 @@ class Avram::QueryBuilder
 
   private def prepared_statement_values
     wheres.compact_map do |sql_clause|
-      sql_clause.value unless sql_clause.is_a?(Avram::Where::NullSqlClause)
+      sql_clause.value if sql_clause.is_a?(Avram::Where::ValueHoldingSqlClause)
     end
   end
 

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -6,7 +6,7 @@ class Avram::QueryBuilder
   getter distinct_on : ColumnName | Nil = nil
   @limit : Int32?
   @offset : Int32?
-  @wheres = [] of Avram::Where::SqlClause
+  @wheres = [] of Avram::Where::Condition
   @raw_wheres = [] of Avram::Where::Raw
   @joins = [] of Avram::Join::SqlClause
   @orders = [] of Avram::OrderBy
@@ -153,7 +153,7 @@ class Avram::QueryBuilder
   end
 
   def reset_where(column : ColumnName)
-    @wheres.reject! { |clause| clause.column.to_s == column.to_s }
+    @wheres.reject! { |clause| clause.is_a?(Avram::Where::SqlClause) && clause.column.to_s == column.to_s }
     self
   end
 
@@ -291,7 +291,7 @@ class Avram::QueryBuilder
     joins.map(&.to_sql).join(" ")
   end
 
-  def where(where_clause : Avram::Where::SqlClause)
+  def where(where_clause : Avram::Where::Condition)
     @wheres << where_clause
     self
   end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -316,7 +316,7 @@ class Avram::QueryBuilder
   end
 
   def wheres
-    @wheres.uniq { |where| where.prepare(->{"unused"}) + where.value.to_s }
+    @wheres.uniq
   end
 
   def raw_wheres

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -7,7 +7,7 @@ class Avram::QueryBuilder
   @limit : Int32?
   @offset : Int32?
   @wheres = [] of Avram::Where::Condition
-  @raw_wheres = [] of Avram::Where::Raw
+  @raw_wheres = [] of Avram::Where::Condition
   @joins = [] of Avram::Join::SqlClause
   @orders = [] of Avram::OrderBy
   @groups = [] of ColumnName
@@ -296,7 +296,7 @@ class Avram::QueryBuilder
     self
   end
 
-  def raw_where(where_clause : Avram::Where::Raw)
+  def raw_where(where_clause : Avram::Where::Condition)
     @raw_wheres << where_clause
     self
   end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -309,13 +309,7 @@ class Avram::QueryBuilder
 
   private def joined_wheres_queries
     if wheres.any? || raw_wheres.any?
-      statements = wheres.map do |sql_clause|
-        if sql_clause.is_a?(Avram::Where::NullSqlClause)
-          sql_clause.prepare
-        else
-          sql_clause.prepare(->next_prepared_statement_placeholder)
-        end
-      end
+      statements = wheres.map(&.prepare(->next_prepared_statement_placeholder))
       statements += raw_wheres.map(&.to_sql)
 
       "WHERE " + statements.join(" AND ")

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -104,7 +104,7 @@ module Avram::Queryable(T)
   end
 
   def where(statement : String, *, args bind_vars : Array) : self
-    clone.tap &.query.raw_where(Avram::Where::Raw.new(statement, args: bind_vars))
+    clone.tap &.query.where(Avram::Where::Raw.new(statement, args: bind_vars))
   end
 
   def where(sql_clause : Avram::Where::SqlClause) : self

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -1,9 +1,8 @@
 module Avram::Where
   abstract class SqlClause
-    getter :column
-    getter :value
+    getter column : Symbol | String
 
-    def initialize(@column : Symbol | String, @value : String | Array(String) | Array(Int32))
+    def initialize(@column)
     end
 
     abstract def operator : String
@@ -18,7 +17,7 @@ module Avram::Where
     end
 
     def ==(other : SqlClause)
-      (prepare(->{"unusued"}) + value.to_s) == (other.prepare(->{"unused"}) + other.value.to_s)
+      prepare(->{"unusued"}) == other.prepare(->{"unused"})
     end
 
     def ==(other)
@@ -26,14 +25,24 @@ module Avram::Where
     end
   end
 
-  abstract class NullSqlClause < SqlClause
-    @value = "NULL"
+  abstract class ValueHoldingSqlClause < SqlClause
+    getter value : String | Array(String) | Array(Int32)
 
-    def initialize(@column : Symbol | String)
+    def initialize(@column, @value)
     end
 
+    def ==(other : ValueHoldingSqlClause)
+      (prepare(->{"unusued"}) + value.to_s) == (other.prepare(->{"unused"}) + other.value.to_s)
+    end
+
+    def ==(other : SqlClause)
+      false
+    end
+  end
+
+  abstract class NullSqlClause < SqlClause
     def prepare(_placeholder_supplier : Proc(String))
-      "#{column} #{operator} #{@value}"
+      "#{column} #{operator} NULL"
     end
   end
 
@@ -43,7 +52,7 @@ module Avram::Where
     end
 
     def negated : NotNull
-      NotNull.new(@column)
+      NotNull.new(column)
     end
   end
 
@@ -53,117 +62,117 @@ module Avram::Where
     end
 
     def negated : Null
-      Null.new(@column)
+      Null.new(column)
     end
   end
 
-  class Equal < SqlClause
+  class Equal < ValueHoldingSqlClause
     def operator : String
       "="
     end
 
     def negated : NotEqual
-      NotEqual.new(@column, @value)
+      NotEqual.new(column, value)
     end
   end
 
-  class NotEqual < SqlClause
+  class NotEqual < ValueHoldingSqlClause
     def operator : String
       "!="
     end
 
     def negated : Equal
-      Equal.new(@column, @value)
+      Equal.new(column, value)
     end
   end
 
-  class GreaterThan < SqlClause
+  class GreaterThan < ValueHoldingSqlClause
     def operator : String
       ">"
     end
 
     def negated : LessThanOrEqualTo
-      LessThanOrEqualTo.new(@column, @value)
+      LessThanOrEqualTo.new(column, value)
     end
   end
 
-  class GreaterThanOrEqualTo < SqlClause
+  class GreaterThanOrEqualTo < ValueHoldingSqlClause
     def operator : String
       ">="
     end
 
     def negated : LessThan
-      LessThan.new(@column, @value)
+      LessThan.new(column, value)
     end
   end
 
-  class LessThan < SqlClause
+  class LessThan < ValueHoldingSqlClause
     def operator : String
       "<"
     end
 
     def negated : GreaterThanOrEqualTo
-      GreaterThanOrEqualTo.new(@column, @value)
+      GreaterThanOrEqualTo.new(column, value)
     end
   end
 
-  class LessThanOrEqualTo < SqlClause
+  class LessThanOrEqualTo < ValueHoldingSqlClause
     def operator : String
       "<="
     end
 
     def negated : GreaterThan
-      GreaterThan.new(@column, @value)
+      GreaterThan.new(column, value)
     end
   end
 
-  class Like < SqlClause
+  class Like < ValueHoldingSqlClause
     def operator : String
       "LIKE"
     end
 
     def negated : NotLike
-      NotLike.new(@column, @value)
+      NotLike.new(column, value)
     end
   end
 
-  class Ilike < SqlClause
+  class Ilike < ValueHoldingSqlClause
     def operator : String
       "ILIKE"
     end
 
     def negated : NotIlike
-      NotIlike.new(@column, @value)
+      NotIlike.new(column, value)
     end
   end
 
-  class NotLike < SqlClause
+  class NotLike < ValueHoldingSqlClause
     def operator : String
       "NOT LIKE"
     end
 
     def negated : Like
-      Like.new(@column, @value)
+      Like.new(column, value)
     end
   end
 
-  class NotIlike < SqlClause
+  class NotIlike < ValueHoldingSqlClause
     def operator : String
       "NOT ILIKE"
     end
 
     def negated : Ilike
-      Ilike.new(@column, @value)
+      Ilike.new(column, value)
     end
   end
 
-  class In < SqlClause
+  class In < ValueHoldingSqlClause
     def operator : String
       "= ANY"
     end
 
     def negated : NotIn
-      NotIn.new(@column, @value)
+      NotIn.new(column, value)
     end
 
     def prepare(placeholder_supplier : Proc(String))
@@ -171,13 +180,13 @@ module Avram::Where
     end
   end
 
-  class NotIn < SqlClause
+  class NotIn < ValueHoldingSqlClause
     def operator : String
       "!= ALL"
     end
 
     def negated : In
-      In.new(@column, @value)
+      In.new(column, value)
     end
 
     def prepare(placeholder_supplier : Proc(String))

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -16,6 +16,14 @@ module Avram::Where
     def clone
       self
     end
+
+    def ==(other : SqlClause)
+      (prepare(->{"unusued"}) + value.to_s) == (other.prepare(->{"unused"}) + other.value.to_s)
+    end
+
+    def ==(other)
+      false
+    end
   end
 
   abstract class NullSqlClause < SqlClause

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -3,7 +3,7 @@ module Avram::Where
     abstract def prepare(placeholder_supplier : Proc(String)) : String
 
     def ==(other : Condition)
-      prepare(->{"unused"}) == other.prepare(->{"unused"})
+      prepare(->{ "unused" }) == other.prepare(->{ "unused" })
     end
 
     def ==(other)
@@ -36,7 +36,7 @@ module Avram::Where
     end
 
     def ==(other : ValueHoldingSqlClause)
-      (prepare(->{"unused"}) + value.to_s) == (other.prepare(->{"unused"}) + other.value.to_s)
+      (prepare(->{ "unused" }) + value.to_s) == (other.prepare(->{ "unused" }) + other.value.to_s)
     end
 
     def ==(other : Condition)

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -9,8 +9,8 @@ module Avram::Where
     abstract def operator : String
     abstract def negated : SqlClause
 
-    def prepare(prepared_statement_placeholder : String)
-      "#{column} #{operator} #{prepared_statement_placeholder}"
+    def prepare(placeholder_supplier : Proc(String))
+      "#{column} #{operator} #{placeholder_supplier.call}"
     end
 
     def clone
@@ -158,8 +158,8 @@ module Avram::Where
       NotIn.new(@column, @value)
     end
 
-    def prepare(prepared_statement_placeholder : String)
-      "#{column} #{operator} (#{prepared_statement_placeholder})"
+    def prepare(placeholder_supplier : Proc(String))
+      "#{column} #{operator} (#{placeholder_supplier.call})"
     end
   end
 
@@ -172,8 +172,8 @@ module Avram::Where
       In.new(@column, @value)
     end
 
-    def prepare(prepared_statement_placeholder : String)
-      "#{column} #{operator} (#{prepared_statement_placeholder})"
+    def prepare(placeholder_supplier : Proc(String))
+      "#{column} #{operator} (#{placeholder_supplier.call})"
     end
   end
 

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -45,7 +45,7 @@ module Avram::Where
   end
 
   abstract class NullSqlClause < SqlClause
-    def prepare(_placeholder_supplier : Proc(String))
+    def prepare(_placeholder_supplier : Proc(String)) : String
       "#{column} #{operator} NULL"
     end
   end
@@ -179,7 +179,7 @@ module Avram::Where
       NotIn.new(column, value)
     end
 
-    def prepare(placeholder_supplier : Proc(String))
+    def prepare(placeholder_supplier : Proc(String)) : String
       "#{column} #{operator} (#{placeholder_supplier.call})"
     end
   end
@@ -193,7 +193,7 @@ module Avram::Where
       In.new(column, value)
     end
 
-    def prepare(placeholder_supplier : Proc(String))
+    def prepare(placeholder_supplier : Proc(String)) : String
       "#{column} #{operator} (#{placeholder_supplier.call})"
     end
   end

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -1,6 +1,10 @@
 module Avram::Where
   abstract class Condition
     abstract def prepare(placeholder_supplier : Proc(String)) : String
+
+    def clone
+      self
+    end
   end
 
   abstract class SqlClause < Condition
@@ -14,10 +18,6 @@ module Avram::Where
 
     def prepare(placeholder_supplier : Proc(String)) : String
       "#{column} #{operator} #{placeholder_supplier.call}"
-    end
-
-    def clone
-      self
     end
 
     def ==(other : SqlClause)
@@ -212,10 +212,6 @@ module Avram::Where
 
     def prepare(_placeholder_supplier : Proc(String)) : String
       @clause
-    end
-
-    def clone
-      self
     end
 
     def ==(other : Raw)

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -205,6 +205,14 @@ module Avram::Where
       self
     end
 
+    def ==(other : Raw)
+      prepare(->{"unused"}) == other.prepare(->{"unused"})
+    end
+
+    def ==(other)
+      false
+    end
+
     private def ensure_enough_bind_variables_for!(statement, bind_vars)
       bindings = statement.chars.select(&.== '?')
       if bindings.size != bind_vars.size

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -2,6 +2,14 @@ module Avram::Where
   abstract class Condition
     abstract def prepare(placeholder_supplier : Proc(String)) : String
 
+    def ==(other : Condition)
+      prepare(->{"unused"}) == other.prepare(->{"unused"})
+    end
+
+    def ==(other)
+      false
+    end
+
     def clone
       self
     end
@@ -19,14 +27,6 @@ module Avram::Where
     def prepare(placeholder_supplier : Proc(String)) : String
       "#{column} #{operator} #{placeholder_supplier.call}"
     end
-
-    def ==(other : SqlClause)
-      prepare(->{"unused"}) == other.prepare(->{"unused"})
-    end
-
-    def ==(other)
-      false
-    end
   end
 
   abstract class ValueHoldingSqlClause < SqlClause
@@ -39,7 +39,7 @@ module Avram::Where
       (prepare(->{"unused"}) + value.to_s) == (other.prepare(->{"unused"}) + other.value.to_s)
     end
 
-    def ==(other : SqlClause)
+    def ==(other : Condition)
       false
     end
   end
@@ -212,14 +212,6 @@ module Avram::Where
 
     def prepare(_placeholder_supplier : Proc(String)) : String
       @clause
-    end
-
-    def ==(other : Raw)
-      prepare(->{"unused"}) == other.prepare(->{"unused"})
-    end
-
-    def ==(other)
-      false
     end
 
     private def ensure_enough_bind_variables_for!(statement, bind_vars)

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -21,7 +21,7 @@ module Avram::Where
     end
 
     def ==(other : SqlClause)
-      prepare(->{"unusued"}) == other.prepare(->{"unused"})
+      prepare(->{"unused"}) == other.prepare(->{"unused"})
     end
 
     def ==(other)
@@ -36,7 +36,7 @@ module Avram::Where
     end
 
     def ==(other : ValueHoldingSqlClause)
-      (prepare(->{"unusued"}) + value.to_s) == (other.prepare(->{"unused"}) + other.value.to_s)
+      (prepare(->{"unused"}) + value.to_s) == (other.prepare(->{"unused"}) + other.value.to_s)
     end
 
     def ==(other : SqlClause)

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -189,7 +189,7 @@ module Avram::Where
       @clause = build_clause(statement, bind_vars)
     end
 
-    def to_sql
+    def prepare(_placeholder_supplier : Proc(String))
       @clause
     end
 

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -24,7 +24,7 @@ module Avram::Where
     def initialize(@column : Symbol | String)
     end
 
-    def prepare
+    def prepare(_placeholder_supplier : Proc(String))
       "#{column} #{operator} #{@value}"
     end
   end

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -1,5 +1,9 @@
 module Avram::Where
-  abstract class SqlClause
+  abstract class Condition
+    abstract def prepare(placeholder_supplier : Proc(String)) : String
+  end
+
+  abstract class SqlClause < Condition
     getter column : Symbol | String
 
     def initialize(@column)
@@ -8,7 +12,7 @@ module Avram::Where
     abstract def operator : String
     abstract def negated : SqlClause
 
-    def prepare(placeholder_supplier : Proc(String))
+    def prepare(placeholder_supplier : Proc(String)) : String
       "#{column} #{operator} #{placeholder_supplier.call}"
     end
 
@@ -194,7 +198,7 @@ module Avram::Where
     end
   end
 
-  class Raw
+  class Raw < Condition
     @clause : String
 
     def self.new(statement : String, *bind_vars)
@@ -206,7 +210,7 @@ module Avram::Where
       @clause = build_clause(statement, bind_vars)
     end
 
-    def prepare(_placeholder_supplier : Proc(String))
+    def prepare(_placeholder_supplier : Proc(String)) : String
       @clause
     end
 


### PR DESCRIPTION
Fixes #459

`Avram::Where::Raw` and `Avram::Where::SqlClause` did not have overlapping ancestors so they were stored in separate lists in `Avram::QueryBuilder` and had different APIs. When the sql string was put together, raw wheres were appended to the where clause. When "OR" support is added, this will no longer be acceptable.

It simplifies the API to have them be used in the same way. This adds a common ancestor of `Avram::Where::Condition` that has the one method of `#prepare`. The only problem of doing this is that `SqlClause`s where being passed a placeholder string that had an incrementing number. Rather than keeping with the push style and checking which types were save to give the placeholder to, I switched the where conditions to take in a supplier of those placeholders so that it could get one if it wanted or just ignore it and not cause the number to increment.

PS: Naming is hard, any ideas on how to name the different abstract classes better?