### PR TITLE
Add DatabaseInfo for SchemaEnforcer use

### DIFF
--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -38,6 +38,12 @@ abstract class Avram::Database
     new.delete
   end
 
+  @@database_info : DatabaseInfo?
+
+  def self.database_info : DatabaseInfo
+    @@database_info ||= DatabaseInfo.load(self)
+  end
+
   # Wrap the block in a database transaction
   #
   # ```

--- a/src/avram/database/column_info.cr
+++ b/src/avram/database/column_info.cr
@@ -1,0 +1,24 @@
+module Avram
+  struct Database::ColumnInfo
+    include DB::Serializable
+
+    property table_catalog : String
+    property table_schema : String
+    property table_name : String
+    property table_type : String
+    property column_name : String
+    property is_nullable : String
+
+    def nilable?
+      is_nullable == "YES"
+    end
+
+    def table
+      TableInfo.new(
+        table_name,
+        table_type,
+        table_schema
+      )
+    end
+  end
+end

--- a/src/avram/database/database_info.cr
+++ b/src/avram/database/database_info.cr
@@ -1,0 +1,45 @@
+module Avram
+  struct Database::DatabaseInfo
+    def self.load(database)
+      sql =  <<-SQL
+      SELECT columns.table_name,
+             tables.table_type,
+             columns.table_schema,
+             columns.table_catalog,
+             columns.column_name,
+             columns.is_nullable
+      FROM information_schema.columns as columns
+      JOIN information_schema.tables as tables
+        ON tables.table_name = columns.table_name
+        AND tables.table_catalog = columns.table_catalog
+        AND tables.table_schema = columns.table_schema
+      WHERE columns.table_schema='public';
+      SQL
+      columns = database.query(sql) { |rs| ColumnInfo.from_rs(rs) }
+
+      grouped = columns.group_by(&.table)
+      grouped.each do |table, columns|
+        columns.each { |c| table.columns << c }
+      end
+      table_infos = grouped.keys
+      new(table_infos)
+    end
+
+    property table_infos : Array(TableInfo)
+
+    def initialize(@table_infos)
+    end
+
+    def table?(name : String)
+      table_names.includes?(name)
+    end
+
+    def table_names
+      table_infos.map(&.table_name)
+    end
+
+    def table(name : String) : TableInfo?
+      table_infos.find { |table_info| table_info.table_name == name }
+    end
+  end
+end

--- a/src/avram/database/database_info.cr
+++ b/src/avram/database/database_info.cr
@@ -15,9 +15,9 @@ module Avram
        AND tables.table_schema = columns.table_schema
      WHERE columns.table_schema='public';
      SQL
-      columns = database.query(sql) { |rs| ColumnInfo.from_rs(rs) }
+      column_infos = database.query(sql) { |rs| ColumnInfo.from_rs(rs) }
 
-      grouped = columns.group_by(&.table)
+      grouped = column_infos.group_by(&.table)
       grouped.each do |table, columns|
         columns.each { |c| table.columns << c }
       end

--- a/src/avram/database/database_info.cr
+++ b/src/avram/database/database_info.cr
@@ -1,21 +1,22 @@
 module Avram
   struct Database::DatabaseInfo
-    def self.load(database)
-      sql = <<-SQL
-     SELECT columns.table_name,
+    SQL_QUERY = <<-SQL
+      SELECT columns.table_name,
             tables.table_type,
             columns.table_schema,
             columns.table_catalog,
             columns.column_name,
             columns.is_nullable
-     FROM information_schema.columns as columns
-     JOIN information_schema.tables as tables
-       ON tables.table_name = columns.table_name
-       AND tables.table_catalog = columns.table_catalog
-       AND tables.table_schema = columns.table_schema
-     WHERE columns.table_schema='public';
-     SQL
-      column_infos = database.query(sql) { |rs| ColumnInfo.from_rs(rs) }
+      FROM information_schema.columns as columns
+      JOIN information_schema.tables as tables
+        ON tables.table_name = columns.table_name
+        AND tables.table_catalog = columns.table_catalog
+        AND tables.table_schema = columns.table_schema
+      WHERE columns.table_schema='public';
+    SQL
+
+    def self.load(database : Avram::Database.class)
+      column_infos = database.query(SQL_QUERY) { |rs| ColumnInfo.from_rs(rs) }
 
       grouped = column_infos.group_by(&.table)
       grouped.each do |table, columns|
@@ -39,7 +40,7 @@ module Avram
     end
 
     def table(name : String) : TableInfo?
-      table_infos.find { |table_info| table_info.table_name == name }
+      table_infos.find(&.table_name.==(name))
     end
   end
 end

--- a/src/avram/database/database_info.cr
+++ b/src/avram/database/database_info.cr
@@ -1,20 +1,20 @@
 module Avram
   struct Database::DatabaseInfo
     def self.load(database)
-      sql =  <<-SQL
-      SELECT columns.table_name,
-             tables.table_type,
-             columns.table_schema,
-             columns.table_catalog,
-             columns.column_name,
-             columns.is_nullable
-      FROM information_schema.columns as columns
-      JOIN information_schema.tables as tables
-        ON tables.table_name = columns.table_name
-        AND tables.table_catalog = columns.table_catalog
-        AND tables.table_schema = columns.table_schema
-      WHERE columns.table_schema='public';
-      SQL
+      sql = <<-SQL
+     SELECT columns.table_name,
+            tables.table_type,
+            columns.table_schema,
+            columns.table_catalog,
+            columns.column_name,
+            columns.is_nullable
+     FROM information_schema.columns as columns
+     JOIN information_schema.tables as tables
+       ON tables.table_name = columns.table_name
+       AND tables.table_catalog = columns.table_catalog
+       AND tables.table_schema = columns.table_schema
+     WHERE columns.table_schema='public';
+     SQL
       columns = database.query(sql) { |rs| ColumnInfo.from_rs(rs) }
 
       grouped = columns.group_by(&.table)

--- a/src/avram/database/table_info.cr
+++ b/src/avram/database/table_info.cr
@@ -1,6 +1,5 @@
 module Avram
   struct Database::TableInfo
-
     getter table_name : String
     getter table_type : String
     getter table_schema : String
@@ -9,7 +8,8 @@ module Avram
     def initialize(
       @table_name,
       @table_type,
-      @table_schema)
+      @table_schema
+    )
     end
 
     def table?

--- a/src/avram/database/table_info.cr
+++ b/src/avram/database/table_info.cr
@@ -1,0 +1,35 @@
+module Avram
+  struct Database::TableInfo
+
+    getter table_name : String
+    getter table_type : String
+    getter table_schema : String
+    getter columns = [] of ColumnInfo
+
+    def initialize(
+      @table_name,
+      @table_type,
+      @table_schema)
+    end
+
+    def table?
+      table_type == "BASE TABLE"
+    end
+
+    def view?
+      table_type == "VIEW"
+    end
+
+    def column?(name : String)
+      column_names.includes?(name)
+    end
+
+    def column_names
+      columns.map(&.column_name)
+    end
+
+    def column(name : String) : ColumnInfo?
+      columns.find(&.column_name.==(name))
+    end
+  end
+end


### PR DESCRIPTION
Connected #462 

This is part 1 of refactoring `SchemaEnforcer`. This adds `Avram::Database::DatabaseInfo` to every `Avram::Database` which pulls all of the tables and columns from that database for application use and memoizes it. This means that we only run one query for all the database information instead of a query each time we need the information.

It also opens up the query to pull more than just the most basic information. It now has all view table information as well as regular tables so that views can be handled. Future schema enforcers could be added to check data types of columns, as well.

table and column table info:
- https://www.postgresql.org/docs/11/infoschema-tables.html
- https://www.postgresql.org/docs/11/infoschema-columns.html