### PR TITLE
Add Avram::Type module directly to base types

### DIFF
--- a/spec/support/custom_email.cr
+++ b/spec/support/custom_email.cr
@@ -1,4 +1,22 @@
 class CustomEmail
+  extend Avram::Type
+
+  def self._parse_attribute(value : CustomEmail)
+    Avram::Type::SuccessfulCast(CustomEmail).new(value)
+  end
+
+  def self._parse_attribute(value : String)
+    Avram::Type::SuccessfulCast(CustomEmail).new(CustomEmail.new(value))
+  end
+
+  def self._to_db(value : String)
+    CustomEmail.new(value).to_s
+  end
+
+  def self._to_db(value : CustomEmail)
+    value.to_s
+  end
+
   def initialize(@email : String)
   end
 
@@ -16,23 +34,6 @@ class CustomEmail
 
   module Lucky
     alias ColumnType = String
-    extend Avram::Type
-
-    def self._parse_attribute(value : CustomEmail)
-      Avram::Type::SuccessfulCast(CustomEmail).new(value)
-    end
-
-    def self._parse_attribute(value : String)
-      Avram::Type::SuccessfulCast(CustomEmail).new(CustomEmail.new(value))
-    end
-
-    def self._to_db(value : String)
-      CustomEmail.new(value).to_s
-    end
-
-    def self._to_db(value : CustomEmail)
-      value.to_s
-    end
 
     class Criteria(T, V) < String::Lucky::Criteria(T, V)
       @upper = false

--- a/spec/support/custom_email.cr
+++ b/spec/support/custom_email.cr
@@ -16,21 +16,21 @@ class CustomEmail
 
   module Lucky
     alias ColumnType = String
-    include Avram::Type
+    extend Avram::Type
 
-    def parse(value : CustomEmail)
-      SuccessfulCast(CustomEmail).new(value)
+    def self.parse(value : CustomEmail)
+      Avram::Type::SuccessfulCast(CustomEmail).new(value)
     end
 
-    def parse(value : String)
-      SuccessfulCast(CustomEmail).new(CustomEmail.new(value))
+    def self.parse(value : String)
+      Avram::Type::SuccessfulCast(CustomEmail).new(CustomEmail.new(value))
     end
 
-    def to_db(value : String)
+    def self.to_db(value : String)
       CustomEmail.new(value).to_s
     end
 
-    def to_db(value : CustomEmail)
+    def self.to_db(value : CustomEmail)
       value.to_s
     end
 

--- a/spec/support/custom_email.cr
+++ b/spec/support/custom_email.cr
@@ -1,10 +1,6 @@
 class CustomEmail
   extend Avram::Type
 
-  def self._parse_attribute(value : CustomEmail)
-    Avram::Type::SuccessfulCast(CustomEmail).new(value)
-  end
-
   def self._parse_attribute(value : String)
     Avram::Type::SuccessfulCast(CustomEmail).new(CustomEmail.new(value))
   end

--- a/spec/support/custom_email.cr
+++ b/spec/support/custom_email.cr
@@ -18,11 +18,11 @@ class CustomEmail
     alias ColumnType = String
     extend Avram::Type
 
-    def self.parse(value : CustomEmail)
+    def self._parse_attribute(value : CustomEmail)
       Avram::Type::SuccessfulCast(CustomEmail).new(value)
     end
 
-    def self.parse(value : String)
+    def self._parse_attribute(value : String)
       Avram::Type::SuccessfulCast(CustomEmail).new(CustomEmail.new(value))
     end
 

--- a/spec/support/custom_email.cr
+++ b/spec/support/custom_email.cr
@@ -9,10 +9,6 @@ class CustomEmail
     CustomEmail.new(value).to_s
   end
 
-  def self._to_db(value : CustomEmail)
-    value.to_s
-  end
-
   def initialize(@email : String)
   end
 

--- a/spec/support/custom_email.cr
+++ b/spec/support/custom_email.cr
@@ -26,11 +26,11 @@ class CustomEmail
       Avram::Type::SuccessfulCast(CustomEmail).new(CustomEmail.new(value))
     end
 
-    def self.to_db(value : String)
+    def self._to_db(value : String)
       CustomEmail.new(value).to_s
     end
 
-    def self.to_db(value : CustomEmail)
+    def self._to_db(value : CustomEmail)
       value.to_s
     end
 

--- a/spec/type_extensions/array_spec.cr
+++ b/spec/type_extensions/array_spec.cr
@@ -2,32 +2,32 @@ require "../spec_helper"
 
 describe "Array" do
   it "parses Array(Bool) from Array(String)" do
-    result = Bool::Lucky.parse(["true"])
+    result = Bool::Lucky._parse_attribute(["true"])
     result.value.should eq([true])
   end
 
   it "parses Array(String)" do
-    result = String::Lucky.parse(["test"])
+    result = String::Lucky._parse_attribute(["test"])
     result.value.should eq(["test"])
   end
 
   it "parses Array(Int32) from Array(String)" do
-    result = Int32::Lucky.parse(["10"])
+    result = Int32::Lucky._parse_attribute(["10"])
     result.value.should eq([10])
   end
 
   it "parses Array(Int16) from Array(String)" do
-    result = Int16::Lucky.parse(["1"])
+    result = Int16::Lucky._parse_attribute(["1"])
     result.value.should eq([1_i16])
   end
 
   it "parses Array(Int64) from Array(String)" do
-    result = Int64::Lucky.parse(["1000"])
+    result = Int64::Lucky._parse_attribute(["1000"])
     result.value.should eq([1000_i64])
   end
 
   it "parses Array(Float64) from Array(String)" do
-    result = Float64::Lucky.parse(["3.1415"])
+    result = Float64::Lucky._parse_attribute(["3.1415"])
     result.value.should eq([3.1415])
   end
 end

--- a/spec/type_extensions/array_spec.cr
+++ b/spec/type_extensions/array_spec.cr
@@ -2,32 +2,32 @@ require "../spec_helper"
 
 describe "Array" do
   it "parses Array(Bool) from Array(String)" do
-    result = Bool::Lucky._parse_attribute(["true"])
+    result = Bool._parse_attribute(["true"])
     result.value.should eq([true])
   end
 
   it "parses Array(String)" do
-    result = String::Lucky._parse_attribute(["test"])
+    result = String._parse_attribute(["test"])
     result.value.should eq(["test"])
   end
 
   it "parses Array(Int32) from Array(String)" do
-    result = Int32::Lucky._parse_attribute(["10"])
+    result = Int32._parse_attribute(["10"])
     result.value.should eq([10])
   end
 
   it "parses Array(Int16) from Array(String)" do
-    result = Int16::Lucky._parse_attribute(["1"])
+    result = Int16._parse_attribute(["1"])
     result.value.should eq([1_i16])
   end
 
   it "parses Array(Int64) from Array(String)" do
-    result = Int64::Lucky._parse_attribute(["1000"])
+    result = Int64._parse_attribute(["1000"])
     result.value.should eq([1000_i64])
   end
 
   it "parses Array(Float64) from Array(String)" do
-    result = Float64::Lucky._parse_attribute(["3.1415"])
+    result = Float64._parse_attribute(["3.1415"])
     result.value.should eq([3.1415])
   end
 end

--- a/spec/type_extensions/int32_spec.cr
+++ b/spec/type_extensions/int32_spec.cr
@@ -2,17 +2,17 @@ require "../spec_helper"
 
 describe "Int32" do
   it "parses Int32 from String" do
-    result = Int32::Lucky._parse_attribute("10")
+    result = Int32._parse_attribute("10")
     result.value.should eq(10)
   end
 
   it "parses Int32 from Int64" do
-    result = Int32::Lucky._parse_attribute(400_i64)
+    result = Int32._parse_attribute(400_i64)
     result.value.should eq(400)
   end
 
   it "returns FailedCast when overflow from Int64 to Int32" do
-    result = Int32::Lucky._parse_attribute(2147483648)
+    result = Int32._parse_attribute(2147483648)
     result.value.should eq(nil)
     result.should be_a(Avram::Type::FailedCast)
   end

--- a/spec/type_extensions/int32_spec.cr
+++ b/spec/type_extensions/int32_spec.cr
@@ -2,17 +2,17 @@ require "../spec_helper"
 
 describe "Int32" do
   it "parses Int32 from String" do
-    result = Int32::Lucky.parse("10")
+    result = Int32::Lucky._parse_attribute("10")
     result.value.should eq(10)
   end
 
   it "parses Int32 from Int64" do
-    result = Int32::Lucky.parse(400_i64)
+    result = Int32::Lucky._parse_attribute(400_i64)
     result.value.should eq(400)
   end
 
   it "returns FailedCast when overflow from Int64 to Int32" do
-    result = Int32::Lucky.parse(2147483648)
+    result = Int32::Lucky._parse_attribute(2147483648)
     result.value.should eq(nil)
     result.should be_a(Avram::Type::FailedCast)
   end

--- a/spec/type_extensions/time_spec.cr
+++ b/spec/type_extensions/time_spec.cr
@@ -12,14 +12,14 @@ describe "Time column type" do
         http_date:            "Sun, 14 Feb 2016 21:00:00 GMT",
       }
       times.each do |_format, item|
-        result = Time::Lucky._parse_attribute(item)
+        result = Time._parse_attribute(item)
         result.should be_a(Avram::Type::SuccessfulCast(Time))
       end
     end
 
     it "allows adding other formats" do
       Avram.temp_config(time_formats: ["%Y-%B-%-d"]) do
-        result = Time::Lucky._parse_attribute("2017-January-30")
+        result = Time._parse_attribute("2017-January-30")
 
         result.should be_a(Avram::Type::SuccessfulCast(Time))
         value = result.as(Avram::Type::SuccessfulCast(Time)).value
@@ -32,13 +32,13 @@ describe "Time column type" do
     it "casts a Time successfully" do
       time = Time.local
 
-      result = Time::Lucky._parse_attribute(time)
+      result = Time._parse_attribute(time)
 
       result.value.should eq(time)
     end
 
     it "can't cast an invalid value" do
-      result = Time::Lucky._parse_attribute("oh no")
+      result = Time._parse_attribute("oh no")
 
       result.should be_a(Avram::Type::FailedCast)
     end

--- a/spec/type_extensions/time_spec.cr
+++ b/spec/type_extensions/time_spec.cr
@@ -12,14 +12,14 @@ describe "Time column type" do
         http_date:            "Sun, 14 Feb 2016 21:00:00 GMT",
       }
       times.each do |_format, item|
-        result = Time::Lucky.parse(item)
+        result = Time::Lucky._parse_attribute(item)
         result.should be_a(Avram::Type::SuccessfulCast(Time))
       end
     end
 
     it "allows adding other formats" do
       Avram.temp_config(time_formats: ["%Y-%B-%-d"]) do
-        result = Time::Lucky.parse("2017-January-30")
+        result = Time::Lucky._parse_attribute("2017-January-30")
 
         result.should be_a(Avram::Type::SuccessfulCast(Time))
         value = result.as(Avram::Type::SuccessfulCast(Time)).value
@@ -32,13 +32,13 @@ describe "Time column type" do
     it "casts a Time successfully" do
       time = Time.local
 
-      result = Time::Lucky.parse(time)
+      result = Time::Lucky._parse_attribute(time)
 
       result.value.should eq(time)
     end
 
     it "can't cast an invalid value" do
-      result = Time::Lucky.parse("oh no")
+      result = Time::Lucky._parse_attribute("oh no")
 
       result.should be_a(Avram::Type::FailedCast)
     end

--- a/spec/type_extensions/uuid_spec.cr
+++ b/spec/type_extensions/uuid_spec.cr
@@ -20,7 +20,7 @@ describe "UUID column type" do
   describe ".to_db" do
     it "turns the uuid into a string" do
       uuid = UUID.new("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
-      UUID::Lucky.to_db(uuid).should eq "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+      UUID::Lucky._to_db(uuid).should eq "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
     end
   end
 end

--- a/spec/type_extensions/uuid_spec.cr
+++ b/spec/type_extensions/uuid_spec.cr
@@ -4,16 +4,16 @@ describe "UUID column type" do
   describe ".parse" do
     it "casts a UUID successfully" do
       uuid = UUID.new("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
-      UUID::Lucky.parse(uuid).value.should eq uuid
+      UUID::Lucky._parse_attribute(uuid).value.should eq uuid
     end
 
     it "casts a string successfully" do
-      UUID::Lucky.parse("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+      UUID::Lucky._parse_attribute("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
         .should be_a(Avram::Type::SuccessfulCast(UUID))
     end
 
     it "cannot cast a non-uuid string" do
-      UUID::Lucky.parse("not a uuid").should be_a(Avram::Type::FailedCast)
+      UUID::Lucky._parse_attribute("not a uuid").should be_a(Avram::Type::FailedCast)
     end
   end
 

--- a/spec/type_extensions/uuid_spec.cr
+++ b/spec/type_extensions/uuid_spec.cr
@@ -4,23 +4,23 @@ describe "UUID column type" do
   describe ".parse" do
     it "casts a UUID successfully" do
       uuid = UUID.new("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
-      UUID::Lucky._parse_attribute(uuid).value.should eq uuid
+      UUID._parse_attribute(uuid).value.should eq uuid
     end
 
     it "casts a string successfully" do
-      UUID::Lucky._parse_attribute("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+      UUID._parse_attribute("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
         .should be_a(Avram::Type::SuccessfulCast(UUID))
     end
 
     it "cannot cast a non-uuid string" do
-      UUID::Lucky._parse_attribute("not a uuid").should be_a(Avram::Type::FailedCast)
+      UUID._parse_attribute("not a uuid").should be_a(Avram::Type::FailedCast)
     end
   end
 
   describe ".to_db" do
     it "turns the uuid into a string" do
       uuid = UUID.new("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
-      UUID::Lucky._to_db(uuid).should eq "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+      UUID._to_db(uuid).should eq "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
     end
   end
 end

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -52,7 +52,7 @@ class Avram::BaseQueryTemplate
           elsif {{ column[:name] }}.is_a?(Nothing)
             nil
           else
-            value = {{ column[:name] }}.not_nil!.class.adapter.to_db({{ column[:name] }}).to_s
+            value = {{ column[:name] }}.not_nil!.class.adapter._to_db({{ column[:name] }}).to_s
             _changes[:{{ column[:name] }}] = value
           end
         {% end %}

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -52,7 +52,7 @@ class Avram::BaseQueryTemplate
           elsif {{ column[:name] }}.is_a?(Nothing)
             nil
           else
-            value = {{ column[:name] }}.not_nil!.class.adapter._to_db({{ column[:name] }}).to_s
+            value = {{ column[:name] }}.not_nil!.class._to_db({{ column[:name] }}).to_s
             _changes[:{{ column[:name] }}] = value
           end
         {% end %}

--- a/src/avram/between_criteria.cr
+++ b/src/avram/between_criteria.cr
@@ -3,8 +3,8 @@ module Avram::BetweenCriteria(T, V)
     # WHERE @column >= `low_value` AND @column <= `high_value`
     def between(low_value : V, high_value : V)
       add_clauses([
-        Avram::Where::GreaterThanOrEqualTo.new(@column, V::Lucky.to_db!(low_value)),
-        Avram::Where::LessThanOrEqualTo.new(@column, V::Lucky.to_db!(high_value))
+        Avram::Where::GreaterThanOrEqualTo.new(@column, V::Lucky._to_db!(low_value)),
+        Avram::Where::LessThanOrEqualTo.new(@column, V::Lucky._to_db!(high_value))
       ])
     end
   end

--- a/src/avram/between_criteria.cr
+++ b/src/avram/between_criteria.cr
@@ -3,8 +3,8 @@ module Avram::BetweenCriteria(T, V)
     # WHERE @column >= `low_value` AND @column <= `high_value`
     def between(low_value : V, high_value : V)
       add_clauses([
-        Avram::Where::GreaterThanOrEqualTo.new(@column, V::Lucky._to_db!(low_value)),
-        Avram::Where::LessThanOrEqualTo.new(@column, V::Lucky._to_db!(high_value))
+        Avram::Where::GreaterThanOrEqualTo.new(@column, V._to_db!(low_value)),
+        Avram::Where::LessThanOrEqualTo.new(@column, V._to_db!(high_value))
       ])
     end
   end

--- a/src/avram/charms/array_extensions.cr
+++ b/src/avram/charms/array_extensions.cr
@@ -1,7 +1,7 @@
 class Array(T)
   # Proxy to the `T`'s adapter so we can call methods like
   # `Array(String).adapter._to_db(["test"])`
-  def self.adapter
-    T
+  def self._to_db(values : Array(T))
+    T._to_db(values)
   end
 end

--- a/src/avram/charms/array_extensions.cr
+++ b/src/avram/charms/array_extensions.cr
@@ -2,6 +2,6 @@ class Array(T)
   # Proxy to the `T`'s adapter so we can call methods like
   # `Array(String).adapter._to_db(["test"])`
   def self.adapter
-    T::Lucky
+    T
   end
 end

--- a/src/avram/charms/array_extensions.cr
+++ b/src/avram/charms/array_extensions.cr
@@ -2,6 +2,6 @@ class Array(T)
   # Proxy to the `T`'s adapter so we can call methods like
   # `Array(String).adapter._to_db(["test"])`
   def self._to_db(values : Array(T))
-    T._to_db(values)
+    PQ::Param.encode_array(values)
   end
 end

--- a/src/avram/charms/array_extensions.cr
+++ b/src/avram/charms/array_extensions.cr
@@ -1,6 +1,6 @@
 class Array(T)
   # Proxy to the `T`'s adapter so we can call methods like
-  # `Array(String).adapter.to_db(["test"])`
+  # `Array(String).adapter._to_db(["test"])`
   def self.adapter
     T::Lucky
   end

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -11,14 +11,6 @@ struct Bool
     end
   end
 
-  def self._parse_attribute(value : Bool)
-    Avram::Type::SuccessfulCast(Bool).new value
-  end
-
-  def self._parse_attribute(values : Array(Bool))
-    Avram::Type::SuccessfulCast(Array(Bool)).new values
-  end
-
   def self._to_db(value : Bool)
     value.to_s
   end

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -11,10 +11,6 @@ struct Bool
     end
   end
 
-  def self._to_db(values : Array(Bool))
-    PQ::Param.encode_array(values)
-  end
-
   module Lucky
     alias ColumnType = Bool
 

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -5,31 +5,31 @@ struct Bool
 
   module Lucky
     alias ColumnType = Bool
-    include Avram::Type
+    extend Avram::Type
 
-    def parse(value : String)
+    def self.parse(value : String)
       if %w(true 1).includes? value
-        SuccessfulCast(Bool).new true
+       Avram::Type::SuccessfulCast(Bool).new true
       elsif %w(false 0).includes? value
-        SuccessfulCast(Bool).new false
+       Avram::Type::SuccessfulCast(Bool).new false
       else
-        FailedCast.new
+       Avram::Type::FailedCast.new
       end
     end
 
-    def parse(value : Bool)
-      SuccessfulCast(Bool).new value
+    def self.parse(value : Bool)
+     Avram::Type::SuccessfulCast(Bool).new value
     end
 
-    def parse(values : Array(Bool))
-      SuccessfulCast(Array(Bool)).new values
+    def self.parse(values : Array(Bool))
+     Avram::Type::SuccessfulCast(Array(Bool)).new values
     end
 
-    def to_db(value : Bool)
+    def self.to_db(value : Bool)
       value.to_s
     end
 
-    def to_db(values : Array(Bool))
+    def self.to_db(values : Array(Bool))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -1,37 +1,38 @@
 struct Bool
+  extend Avram::Type
+
+  def self._parse_attribute(value : String)
+    if %w(true 1).includes? value
+      Avram::Type::SuccessfulCast(Bool).new true
+    elsif %w(false 0).includes? value
+      Avram::Type::SuccessfulCast(Bool).new false
+    else
+      Avram::Type::FailedCast.new
+    end
+  end
+
+  def self._parse_attribute(value : Bool)
+    Avram::Type::SuccessfulCast(Bool).new value
+  end
+
+  def self._parse_attribute(values : Array(Bool))
+    Avram::Type::SuccessfulCast(Array(Bool)).new values
+  end
+
+  def self._to_db(value : Bool)
+    value.to_s
+  end
+
+  def self._to_db(values : Array(Bool))
+    PQ::Param.encode_array(values)
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = Bool
-    extend Avram::Type
-
-    def self._parse_attribute(value : String)
-      if %w(true 1).includes? value
-       Avram::Type::SuccessfulCast(Bool).new true
-      elsif %w(false 0).includes? value
-       Avram::Type::SuccessfulCast(Bool).new false
-      else
-       Avram::Type::FailedCast.new
-      end
-    end
-
-    def self._parse_attribute(value : Bool)
-     Avram::Type::SuccessfulCast(Bool).new value
-    end
-
-    def self._parse_attribute(values : Array(Bool))
-     Avram::Type::SuccessfulCast(Array(Bool)).new values
-    end
-
-    def self._to_db(value : Bool)
-      value.to_s
-    end
-
-    def self._to_db(values : Array(Bool))
-      PQ::Param.encode_array(values)
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
     end

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -7,7 +7,7 @@ struct Bool
     alias ColumnType = Bool
     extend Avram::Type
 
-    def self.parse(value : String)
+    def self._parse_attribute(value : String)
       if %w(true 1).includes? value
        Avram::Type::SuccessfulCast(Bool).new true
       elsif %w(false 0).includes? value
@@ -17,11 +17,11 @@ struct Bool
       end
     end
 
-    def self.parse(value : Bool)
+    def self._parse_attribute(value : Bool)
      Avram::Type::SuccessfulCast(Bool).new value
     end
 
-    def self.parse(values : Array(Bool))
+    def self._parse_attribute(values : Array(Bool))
      Avram::Type::SuccessfulCast(Array(Bool)).new values
     end
 

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -27,10 +27,6 @@ struct Bool
     PQ::Param.encode_array(values)
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = Bool
 

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -25,11 +25,11 @@ struct Bool
      Avram::Type::SuccessfulCast(Array(Bool)).new values
     end
 
-    def self.to_db(value : Bool)
+    def self._to_db(value : Bool)
       value.to_s
     end
 
-    def self.to_db(values : Array(Bool))
+    def self._to_db(values : Array(Bool))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -11,10 +11,6 @@ struct Bool
     end
   end
 
-  def self._to_db(value : Bool)
-    value.to_s
-  end
-
   def self._to_db(values : Array(Bool))
     PQ::Param.encode_array(values)
   end

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -28,29 +28,29 @@ macro avram_enum(enum_name, &block)
 
     module Lucky
       alias ColumnType = Int32
-      include Avram::Type
+      extend Avram::Type
 
-      def from_db!(value : Int32)
+      def self.from_db!(value : Int32)
         {{ enum_name }}.new(value)
       end
 
-      def parse(value : Avram{{ enum_name }})
-        SuccessfulCast({{ enum_name }}).new(value)
+      def self.parse(value : Avram{{ enum_name }})
+       Avram::Type::SuccessfulCast({{ enum_name }}).new(value)
       end
 
-      def parse(value : String)
-        SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
+      def self.parse(value : String)
+       Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
       end
 
-      def parse(value : Int32)
-        SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
+      def self.parse(value : Int32)
+       Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
       end
 
-      def to_db(value : Int32)
+      def self.to_db(value : Int32)
         value.to_s
       end
 
-      def to_db(value : {{ enum_name }})
+      def self.to_db(value : {{ enum_name }})
         value.value.to_s
       end
 

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -30,10 +30,6 @@ macro avram_enum(enum_name, &block)
       value.value.to_s
     end
 
-    def self.adapter
-      self
-    end
-
     getter :enum
 
     # You may need to prefix with {{ @type }}

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -4,8 +4,34 @@ macro avram_enum(enum_name, &block)
   end
 
   class {{ enum_name }}
+    extend Avram::Type
+
+    def self._from_db!(value : Int32)
+      {{ enum_name }}.new(value)
+    end
+
+    def self._parse_attribute(value : Avram{{ enum_name }})
+    Avram::Type::SuccessfulCast({{ enum_name }}).new(value)
+    end
+
+    def self._parse_attribute(value : String)
+    Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
+    end
+
+    def self._parse_attribute(value : Int32)
+    Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
+    end
+
+    def self._to_db(value : Int32)
+      value.to_s
+    end
+
+    def self._to_db(value : {{ enum_name }})
+      value.value.to_s
+    end
+
     def self.adapter
-      Lucky
+      self
     end
 
     getter :enum
@@ -28,31 +54,6 @@ macro avram_enum(enum_name, &block)
 
     module Lucky
       alias ColumnType = Int32
-      extend Avram::Type
-
-      def self._from_db!(value : Int32)
-        {{ enum_name }}.new(value)
-      end
-
-      def self._parse_attribute(value : Avram{{ enum_name }})
-       Avram::Type::SuccessfulCast({{ enum_name }}).new(value)
-      end
-
-      def self._parse_attribute(value : String)
-       Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
-      end
-
-      def self._parse_attribute(value : Int32)
-       Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
-      end
-
-      def self._to_db(value : Int32)
-        value.to_s
-      end
-
-      def self._to_db(value : {{ enum_name }})
-        value.value.to_s
-      end
 
       class Criteria(T, V) < Int32::Lucky::Criteria(T, V)
       end

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -30,7 +30,7 @@ macro avram_enum(enum_name, &block)
       alias ColumnType = Int32
       extend Avram::Type
 
-      def self.from_db!(value : Int32)
+      def self._from_db!(value : Int32)
         {{ enum_name }}.new(value)
       end
 
@@ -46,11 +46,11 @@ macro avram_enum(enum_name, &block)
        Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
       end
 
-      def self.to_db(value : Int32)
+      def self._to_db(value : Int32)
         value.to_s
       end
 
-      def self.to_db(value : {{ enum_name }})
+      def self._to_db(value : {{ enum_name }})
         value.value.to_s
       end
 

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -11,15 +11,15 @@ macro avram_enum(enum_name, &block)
     end
 
     def self._parse_attribute(value : Avram{{ enum_name }})
-    Avram::Type::SuccessfulCast({{ enum_name }}).new(value)
+      Avram::Type::SuccessfulCast({{ enum_name }}).new(value)
     end
 
     def self._parse_attribute(value : String)
-    Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
+      Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
     end
 
     def self._parse_attribute(value : Int32)
-    Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
+      Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
     end
 
     def self._to_db(value : Int32)

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -34,15 +34,15 @@ macro avram_enum(enum_name, &block)
         {{ enum_name }}.new(value)
       end
 
-      def self.parse(value : Avram{{ enum_name }})
+      def self._parse_attribute(value : Avram{{ enum_name }})
        Avram::Type::SuccessfulCast({{ enum_name }}).new(value)
       end
 
-      def self.parse(value : String)
+      def self._parse_attribute(value : String)
        Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
       end
 
-      def self.parse(value : Int32)
+      def self._parse_attribute(value : Int32)
        Avram::Type::SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
       end
 

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -47,10 +47,6 @@ struct Float64
     PQ::Param.encode_array(values)
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = Float64
 

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -1,10 +1,6 @@
 struct Float64
   extend Avram::Type
 
-  def self._from_db!(value : Float64)
-    value
-  end
-
   def self._from_db!(value : PG::Numeric)
     value.to_f
   end

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -7,11 +7,11 @@ struct Float64
     alias ColumnType = Float64
     extend Avram::Type
 
-    def self.from_db!(value : Float64)
+    def self._from_db!(value : Float64)
       value
     end
 
-    def self.from_db!(value : PG::Numeric)
+    def self._from_db!(value : PG::Numeric)
       value.to_f
     end
 
@@ -45,11 +45,11 @@ struct Float64
      Avram::Type::SuccessfulCast(Float64).new value.to_f64
     end
 
-    def self.to_db(value : Float64)
+    def self._to_db(value : Float64)
       value.to_s
     end
 
-    def self.to_db(values : Array(Float64))
+    def self._to_db(values : Array(Float64))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -9,14 +9,6 @@ struct Float64
     value.to_f
   end
 
-  def self._parse_attribute(value : Float64)
-    Avram::Type::SuccessfulCast(Float64).new(value)
-  end
-
-  def self._parse_attribute(values : Array(Float64))
-    Avram::Type::SuccessfulCast(Array(Float64)).new values
-  end
-
   def self._parse_attribute(value : PG::Numeric)
     Avram::Type::SuccessfulCast(Float64).new(value.to_f)
   end

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -1,57 +1,58 @@
 struct Float64
+  extend Avram::Type
+
+  def self._from_db!(value : Float64)
+    value
+  end
+
+  def self._from_db!(value : PG::Numeric)
+    value.to_f
+  end
+
+  def self._parse_attribute(value : Float64)
+    Avram::Type::SuccessfulCast(Float64).new(value)
+  end
+
+  def self._parse_attribute(values : Array(Float64))
+    Avram::Type::SuccessfulCast(Array(Float64)).new values
+  end
+
+  def self._parse_attribute(value : PG::Numeric)
+    Avram::Type::SuccessfulCast(Float64).new(value.to_f)
+  end
+
+  def self._parse_attribute(values : Array(PG::Numeric))
+    Avram::Type::SuccessfulCast(Array(Float64)).new values.map(&.to_f)
+  end
+
+  def self._parse_attribute(value : String)
+    Avram::Type::SuccessfulCast(Float64).new value.to_f64
+  rescue ArgumentError
+    Avram::Type::FailedCast.new
+  end
+
+  def self._parse_attribute(value : Int32)
+    Avram::Type::SuccessfulCast(Float64).new value.to_f64
+  end
+
+  def self._parse_attribute(value : Int64)
+    Avram::Type::SuccessfulCast(Float64).new value.to_f64
+  end
+
+  def self._to_db(value : Float64)
+    value.to_s
+  end
+
+  def self._to_db(values : Array(Float64))
+    PQ::Param.encode_array(values)
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = Float64
-    extend Avram::Type
-
-    def self._from_db!(value : Float64)
-      value
-    end
-
-    def self._from_db!(value : PG::Numeric)
-      value.to_f
-    end
-
-    def self._parse_attribute(value : Float64)
-     Avram::Type::SuccessfulCast(Float64).new(value)
-    end
-
-    def self._parse_attribute(values : Array(Float64))
-     Avram::Type::SuccessfulCast(Array(Float64)).new values
-    end
-
-    def self._parse_attribute(value : PG::Numeric)
-     Avram::Type::SuccessfulCast(Float64).new(value.to_f)
-    end
-
-    def self._parse_attribute(values : Array(PG::Numeric))
-     Avram::Type::SuccessfulCast(Array(Float64)).new values.map(&.to_f)
-    end
-
-    def self._parse_attribute(value : String)
-     Avram::Type::SuccessfulCast(Float64).new value.to_f64
-    rescue ArgumentError
-     Avram::Type::FailedCast.new
-    end
-
-    def self._parse_attribute(value : Int32)
-     Avram::Type::SuccessfulCast(Float64).new value.to_f64
-    end
-
-    def self._parse_attribute(value : Int64)
-     Avram::Type::SuccessfulCast(Float64).new value.to_f64
-    end
-
-    def self._to_db(value : Float64)
-      value.to_s
-    end
-
-    def self._to_db(values : Array(Float64))
-      PQ::Param.encode_array(values)
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -31,10 +31,6 @@ struct Float64
     Avram::Type::SuccessfulCast(Float64).new value.to_f64
   end
 
-  def self._to_db(value : Float64)
-    value.to_s
-  end
-
   def self._to_db(values : Array(Float64))
     PQ::Param.encode_array(values)
   end

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -5,51 +5,51 @@ struct Float64
 
   module Lucky
     alias ColumnType = Float64
-    include Avram::Type
+    extend Avram::Type
 
-    def from_db!(value : Float64)
+    def self.from_db!(value : Float64)
       value
     end
 
-    def from_db!(value : PG::Numeric)
+    def self.from_db!(value : PG::Numeric)
       value.to_f
     end
 
-    def parse(value : Float64)
-      SuccessfulCast(Float64).new(value)
+    def self.parse(value : Float64)
+     Avram::Type::SuccessfulCast(Float64).new(value)
     end
 
-    def parse(values : Array(Float64))
-      SuccessfulCast(Array(Float64)).new values
+    def self.parse(values : Array(Float64))
+     Avram::Type::SuccessfulCast(Array(Float64)).new values
     end
 
-    def parse(value : PG::Numeric)
-      SuccessfulCast(Float64).new(value.to_f)
+    def self.parse(value : PG::Numeric)
+     Avram::Type::SuccessfulCast(Float64).new(value.to_f)
     end
 
-    def parse(values : Array(PG::Numeric))
-      SuccessfulCast(Array(Float64)).new values.map(&.to_f)
+    def self.parse(values : Array(PG::Numeric))
+     Avram::Type::SuccessfulCast(Array(Float64)).new values.map(&.to_f)
     end
 
-    def parse(value : String)
-      SuccessfulCast(Float64).new value.to_f64
+    def self.parse(value : String)
+     Avram::Type::SuccessfulCast(Float64).new value.to_f64
     rescue ArgumentError
-      FailedCast.new
+     Avram::Type::FailedCast.new
     end
 
-    def parse(value : Int32)
-      SuccessfulCast(Float64).new value.to_f64
+    def self.parse(value : Int32)
+     Avram::Type::SuccessfulCast(Float64).new value.to_f64
     end
 
-    def parse(value : Int64)
-      SuccessfulCast(Float64).new value.to_f64
+    def self.parse(value : Int64)
+     Avram::Type::SuccessfulCast(Float64).new value.to_f64
     end
 
-    def to_db(value : Float64)
+    def self.to_db(value : Float64)
       value.to_s
     end
 
-    def to_db(values : Array(Float64))
+    def self.to_db(values : Array(Float64))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -31,10 +31,6 @@ struct Float64
     Avram::Type::SuccessfulCast(Float64).new value.to_f64
   end
 
-  def self._to_db(values : Array(Float64))
-    PQ::Param.encode_array(values)
-  end
-
   module Lucky
     alias ColumnType = Float64
 

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -15,33 +15,33 @@ struct Float64
       value.to_f
     end
 
-    def self.parse(value : Float64)
+    def self._parse_attribute(value : Float64)
      Avram::Type::SuccessfulCast(Float64).new(value)
     end
 
-    def self.parse(values : Array(Float64))
+    def self._parse_attribute(values : Array(Float64))
      Avram::Type::SuccessfulCast(Array(Float64)).new values
     end
 
-    def self.parse(value : PG::Numeric)
+    def self._parse_attribute(value : PG::Numeric)
      Avram::Type::SuccessfulCast(Float64).new(value.to_f)
     end
 
-    def self.parse(values : Array(PG::Numeric))
+    def self._parse_attribute(values : Array(PG::Numeric))
      Avram::Type::SuccessfulCast(Array(Float64)).new values.map(&.to_f)
     end
 
-    def self.parse(value : String)
+    def self._parse_attribute(value : String)
      Avram::Type::SuccessfulCast(Float64).new value.to_f64
     rescue ArgumentError
      Avram::Type::FailedCast.new
     end
 
-    def self.parse(value : Int32)
+    def self._parse_attribute(value : Int32)
      Avram::Type::SuccessfulCast(Float64).new value.to_f64
     end
 
-    def self.parse(value : Int64)
+    def self._parse_attribute(value : Int64)
      Avram::Type::SuccessfulCast(Float64).new value.to_f64
     end
 

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -33,10 +33,6 @@ struct Int16
     PQ::Param.encode_array(values)
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = Int16
 

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -5,14 +5,6 @@ struct Int16
     value
   end
 
-  def self._parse_attribute(value : Int16)
-    Avram::Type::SuccessfulCast(Int16).new(value)
-  end
-
-  def self._parse_attribute(values : Array(Int16))
-    Avram::Type::SuccessfulCast(Array(Int16)).new values
-  end
-
   def self._parse_attribute(value : String)
     Avram::Type::SuccessfulCast(Int16).new value.to_i16
   rescue ArgumentError

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -17,10 +17,6 @@ struct Int16
     Avram::Type::FailedCast.new
   end
 
-  def self._to_db(value : Int16)
-    value.to_s
-  end
-
   def self._to_db(values : Array(Int16))
     PQ::Param.encode_array(values)
   end

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -7,7 +7,7 @@ struct Int16
     alias ColumnType = Int16
     extend Avram::Type
 
-    def self.from_db!(value : Int16)
+    def self._from_db!(value : Int16)
       value
     end
 
@@ -31,11 +31,11 @@ struct Int16
      Avram::Type::FailedCast.new
     end
 
-    def self.to_db(value : Int16)
+    def self._to_db(value : Int16)
       value.to_s
     end
 
-    def self.to_db(values : Array(Int16))
+    def self._to_db(values : Array(Int16))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -1,43 +1,44 @@
 struct Int16
+  extend Avram::Type
+
+  def self._from_db!(value : Int16)
+    value
+  end
+
+  def self._parse_attribute(value : Int16)
+    Avram::Type::SuccessfulCast(Int16).new(value)
+  end
+
+  def self._parse_attribute(values : Array(Int16))
+    Avram::Type::SuccessfulCast(Array(Int16)).new values
+  end
+
+  def self._parse_attribute(value : String)
+    Avram::Type::SuccessfulCast(Int16).new value.to_i16
+  rescue ArgumentError
+    Avram::Type::FailedCast.new
+  end
+
+  def self._parse_attribute(value : Int32)
+    Avram::Type::SuccessfulCast(Int16).new value.to_i16
+  rescue OverflowError
+    Avram::Type::FailedCast.new
+  end
+
+  def self._to_db(value : Int16)
+    value.to_s
+  end
+
+  def self._to_db(values : Array(Int16))
+    PQ::Param.encode_array(values)
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = Int16
-    extend Avram::Type
-
-    def self._from_db!(value : Int16)
-      value
-    end
-
-    def self._parse_attribute(value : Int16)
-     Avram::Type::SuccessfulCast(Int16).new(value)
-    end
-
-    def self._parse_attribute(values : Array(Int16))
-     Avram::Type::SuccessfulCast(Array(Int16)).new values
-    end
-
-    def self._parse_attribute(value : String)
-     Avram::Type::SuccessfulCast(Int16).new value.to_i16
-    rescue ArgumentError
-     Avram::Type::FailedCast.new
-    end
-
-    def self._parse_attribute(value : Int32)
-     Avram::Type::SuccessfulCast(Int16).new value.to_i16
-    rescue OverflowError
-     Avram::Type::FailedCast.new
-    end
-
-    def self._to_db(value : Int16)
-      value.to_s
-    end
-
-    def self._to_db(values : Array(Int16))
-      PQ::Param.encode_array(values)
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -1,10 +1,6 @@
 struct Int16
   extend Avram::Type
 
-  def self._from_db!(value : Int16)
-    value
-  end
-
   def self._parse_attribute(value : String)
     Avram::Type::SuccessfulCast(Int16).new value.to_i16
   rescue ArgumentError

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -17,10 +17,6 @@ struct Int16
     Avram::Type::FailedCast.new
   end
 
-  def self._to_db(values : Array(Int16))
-    PQ::Param.encode_array(values)
-  end
-
   module Lucky
     alias ColumnType = Int16
 

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -5,37 +5,37 @@ struct Int16
 
   module Lucky
     alias ColumnType = Int16
-    include Avram::Type
+    extend Avram::Type
 
-    def from_db!(value : Int16)
+    def self.from_db!(value : Int16)
       value
     end
 
-    def parse(value : Int16)
-      SuccessfulCast(Int16).new(value)
+    def self.parse(value : Int16)
+     Avram::Type::SuccessfulCast(Int16).new(value)
     end
 
-    def parse(values : Array(Int16))
-      SuccessfulCast(Array(Int16)).new values
+    def self.parse(values : Array(Int16))
+     Avram::Type::SuccessfulCast(Array(Int16)).new values
     end
 
-    def parse(value : String)
-      SuccessfulCast(Int16).new value.to_i16
+    def self.parse(value : String)
+     Avram::Type::SuccessfulCast(Int16).new value.to_i16
     rescue ArgumentError
-      FailedCast.new
+     Avram::Type::FailedCast.new
     end
 
-    def parse(value : Int32)
-      SuccessfulCast(Int16).new value.to_i16
+    def self.parse(value : Int32)
+     Avram::Type::SuccessfulCast(Int16).new value.to_i16
     rescue OverflowError
-      FailedCast.new
+     Avram::Type::FailedCast.new
     end
 
-    def to_db(value : Int16)
+    def self.to_db(value : Int16)
       value.to_s
     end
 
-    def to_db(values : Array(Int16))
+    def self.to_db(values : Array(Int16))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -11,21 +11,21 @@ struct Int16
       value
     end
 
-    def self.parse(value : Int16)
+    def self._parse_attribute(value : Int16)
      Avram::Type::SuccessfulCast(Int16).new(value)
     end
 
-    def self.parse(values : Array(Int16))
+    def self._parse_attribute(values : Array(Int16))
      Avram::Type::SuccessfulCast(Array(Int16)).new values
     end
 
-    def self.parse(value : String)
+    def self._parse_attribute(value : String)
      Avram::Type::SuccessfulCast(Int16).new value.to_i16
     rescue ArgumentError
      Avram::Type::FailedCast.new
     end
 
-    def self.parse(value : Int32)
+    def self._parse_attribute(value : Int32)
      Avram::Type::SuccessfulCast(Int16).new value.to_i16
     rescue OverflowError
      Avram::Type::FailedCast.new

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -11,18 +11,10 @@ struct Int32
     Avram::Type::FailedCast.new
   end
 
-  def self._parse_attribute(value : Int32)
-    Avram::Type::SuccessfulCast(Int32).new(value)
-  end
-
   def self._parse_attribute(value : Int64)
     Avram::Type::SuccessfulCast(Int32).new value.to_i32
   rescue OverflowError
     Avram::Type::FailedCast.new
-  end
-
-  def self._parse_attribute(values : Array(Int32))
-    Avram::Type::SuccessfulCast(Array(Int32)).new values
   end
 
   def self._to_db(value : Int32)

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -11,23 +11,23 @@ struct Int32
       value
     end
 
-    def self.parse(value : String)
+    def self._parse_attribute(value : String)
      Avram::Type::SuccessfulCast(Int32).new value.to_i
     rescue ArgumentError
      Avram::Type::FailedCast.new
     end
 
-    def self.parse(value : Int32)
+    def self._parse_attribute(value : Int32)
      Avram::Type::SuccessfulCast(Int32).new(value)
     end
 
-    def self.parse(value : Int64)
+    def self._parse_attribute(value : Int64)
      Avram::Type::SuccessfulCast(Int32).new value.to_i32
     rescue OverflowError
      Avram::Type::FailedCast.new
     end
 
-    def self.parse(values : Array(Int32))
+    def self._parse_attribute(values : Array(Int32))
      Avram::Type::SuccessfulCast(Array(Int32)).new values
     end
 

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -1,43 +1,44 @@
 struct Int32
+  extend Avram::Type
+
+  def self._from_db!(value : Int32)
+    value
+  end
+
+  def self._parse_attribute(value : String)
+    Avram::Type::SuccessfulCast(Int32).new value.to_i
+  rescue ArgumentError
+    Avram::Type::FailedCast.new
+  end
+
+  def self._parse_attribute(value : Int32)
+    Avram::Type::SuccessfulCast(Int32).new(value)
+  end
+
+  def self._parse_attribute(value : Int64)
+    Avram::Type::SuccessfulCast(Int32).new value.to_i32
+  rescue OverflowError
+    Avram::Type::FailedCast.new
+  end
+
+  def self._parse_attribute(values : Array(Int32))
+    Avram::Type::SuccessfulCast(Array(Int32)).new values
+  end
+
+  def self._to_db(value : Int32)
+    value.to_s
+  end
+
+  def self._to_db(values : Array(Int32))
+    PQ::Param.encode_array(values)
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = Int32
-    extend Avram::Type
-
-    def self._from_db!(value : Int32)
-      value
-    end
-
-    def self._parse_attribute(value : String)
-     Avram::Type::SuccessfulCast(Int32).new value.to_i
-    rescue ArgumentError
-     Avram::Type::FailedCast.new
-    end
-
-    def self._parse_attribute(value : Int32)
-     Avram::Type::SuccessfulCast(Int32).new(value)
-    end
-
-    def self._parse_attribute(value : Int64)
-     Avram::Type::SuccessfulCast(Int32).new value.to_i32
-    rescue OverflowError
-     Avram::Type::FailedCast.new
-    end
-
-    def self._parse_attribute(values : Array(Int32))
-     Avram::Type::SuccessfulCast(Array(Int32)).new values
-    end
-
-    def self._to_db(value : Int32)
-      value.to_s
-    end
-
-    def self._to_db(values : Array(Int32))
-      PQ::Param.encode_array(values)
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -33,10 +33,6 @@ struct Int32
     PQ::Param.encode_array(values)
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = Int32
 

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -7,7 +7,7 @@ struct Int32
     alias ColumnType = Int32
     extend Avram::Type
 
-    def self.from_db!(value : Int32)
+    def self._from_db!(value : Int32)
       value
     end
 
@@ -31,11 +31,11 @@ struct Int32
      Avram::Type::SuccessfulCast(Array(Int32)).new values
     end
 
-    def self.to_db(value : Int32)
+    def self._to_db(value : Int32)
       value.to_s
     end
 
-    def self.to_db(values : Array(Int32))
+    def self._to_db(values : Array(Int32))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -1,10 +1,6 @@
 struct Int32
   extend Avram::Type
 
-  def self._from_db!(value : Int32)
-    value
-  end
-
   def self._parse_attribute(value : String)
     Avram::Type::SuccessfulCast(Int32).new value.to_i
   rescue ArgumentError

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -17,10 +17,6 @@ struct Int32
     Avram::Type::FailedCast.new
   end
 
-  def self._to_db(values : Array(Int32))
-    PQ::Param.encode_array(values)
-  end
-
   module Lucky
     alias ColumnType = Int32
 

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -17,10 +17,6 @@ struct Int32
     Avram::Type::FailedCast.new
   end
 
-  def self._to_db(value : Int32)
-    value.to_s
-  end
-
   def self._to_db(values : Array(Int32))
     PQ::Param.encode_array(values)
   end

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -5,37 +5,37 @@ struct Int32
 
   module Lucky
     alias ColumnType = Int32
-    include Avram::Type
+    extend Avram::Type
 
-    def from_db!(value : Int32)
+    def self.from_db!(value : Int32)
       value
     end
 
-    def parse(value : String)
-      SuccessfulCast(Int32).new value.to_i
+    def self.parse(value : String)
+     Avram::Type::SuccessfulCast(Int32).new value.to_i
     rescue ArgumentError
-      FailedCast.new
+     Avram::Type::FailedCast.new
     end
 
-    def parse(value : Int32)
-      SuccessfulCast(Int32).new(value)
+    def self.parse(value : Int32)
+     Avram::Type::SuccessfulCast(Int32).new(value)
     end
 
-    def parse(value : Int64)
-      SuccessfulCast(Int32).new value.to_i32
+    def self.parse(value : Int64)
+     Avram::Type::SuccessfulCast(Int32).new value.to_i32
     rescue OverflowError
-      FailedCast.new
+     Avram::Type::FailedCast.new
     end
 
-    def parse(values : Array(Int32))
-      SuccessfulCast(Array(Int32)).new values
+    def self.parse(values : Array(Int32))
+     Avram::Type::SuccessfulCast(Array(Int32)).new values
     end
 
-    def to_db(value : Int32)
+    def self.to_db(value : Int32)
       value.to_s
     end
 
-    def to_db(values : Array(Int32))
+    def self.to_db(values : Array(Int32))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -31,10 +31,6 @@ struct Int64
     PQ::Param.encode_array(values)
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = Int64
 

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -5,14 +5,6 @@ struct Int64
     value
   end
 
-  def self._parse_attribute(value : Int64)
-    Avram::Type::SuccessfulCast(Int64).new(value)
-  end
-
-  def self._parse_attribute(values : Array(Int64))
-    Avram::Type::SuccessfulCast(Array(Int64)).new values
-  end
-
   def self._parse_attribute(value : String)
     Avram::Type::SuccessfulCast(Int64).new value.to_i64
   rescue ArgumentError

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -15,10 +15,6 @@ struct Int64
     Avram::Type::SuccessfulCast(Int64).new value.to_i64
   end
 
-  def self._to_db(values : Array(Int64))
-    PQ::Param.encode_array(values)
-  end
-
   module Lucky
     alias ColumnType = Int64
 

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -7,7 +7,7 @@ struct Int64
     alias ColumnType = Int64
     extend Avram::Type
 
-    def self.from_db!(value : Int64)
+    def self._from_db!(value : Int64)
       value
     end
 
@@ -29,11 +29,11 @@ struct Int64
      Avram::Type::SuccessfulCast(Int64).new value.to_i64
     end
 
-    def self.to_db(value : Int64)
+    def self._to_db(value : Int64)
       value.to_s
     end
 
-    def self.to_db(values : Array(Int64))
+    def self._to_db(values : Array(Int64))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -15,10 +15,6 @@ struct Int64
     Avram::Type::SuccessfulCast(Int64).new value.to_i64
   end
 
-  def self._to_db(value : Int64)
-    value.to_s
-  end
-
   def self._to_db(values : Array(Int64))
     PQ::Param.encode_array(values)
   end

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -1,41 +1,42 @@
 struct Int64
+  extend Avram::Type
+
+  def self._from_db!(value : Int64)
+    value
+  end
+
+  def self._parse_attribute(value : Int64)
+    Avram::Type::SuccessfulCast(Int64).new(value)
+  end
+
+  def self._parse_attribute(values : Array(Int64))
+    Avram::Type::SuccessfulCast(Array(Int64)).new values
+  end
+
+  def self._parse_attribute(value : String)
+    Avram::Type::SuccessfulCast(Int64).new value.to_i64
+  rescue ArgumentError
+    Avram::Type::FailedCast.new
+  end
+
+  def self._parse_attribute(value : Int32)
+    Avram::Type::SuccessfulCast(Int64).new value.to_i64
+  end
+
+  def self._to_db(value : Int64)
+    value.to_s
+  end
+
+  def self._to_db(values : Array(Int64))
+    PQ::Param.encode_array(values)
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = Int64
-    extend Avram::Type
-
-    def self._from_db!(value : Int64)
-      value
-    end
-
-    def self._parse_attribute(value : Int64)
-     Avram::Type::SuccessfulCast(Int64).new(value)
-    end
-
-    def self._parse_attribute(values : Array(Int64))
-     Avram::Type::SuccessfulCast(Array(Int64)).new values
-    end
-
-    def self._parse_attribute(value : String)
-     Avram::Type::SuccessfulCast(Int64).new value.to_i64
-    rescue ArgumentError
-     Avram::Type::FailedCast.new
-    end
-
-    def self._parse_attribute(value : Int32)
-     Avram::Type::SuccessfulCast(Int64).new value.to_i64
-    end
-
-    def self._to_db(value : Int64)
-      value.to_s
-    end
-
-    def self._to_db(values : Array(Int64))
-      PQ::Param.encode_array(values)
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -5,35 +5,35 @@ struct Int64
 
   module Lucky
     alias ColumnType = Int64
-    include Avram::Type
+    extend Avram::Type
 
-    def from_db!(value : Int64)
+    def self.from_db!(value : Int64)
       value
     end
 
-    def parse(value : Int64)
-      SuccessfulCast(Int64).new(value)
+    def self.parse(value : Int64)
+     Avram::Type::SuccessfulCast(Int64).new(value)
     end
 
-    def parse(values : Array(Int64))
-      SuccessfulCast(Array(Int64)).new values
+    def self.parse(values : Array(Int64))
+     Avram::Type::SuccessfulCast(Array(Int64)).new values
     end
 
-    def parse(value : String)
-      SuccessfulCast(Int64).new value.to_i64
+    def self.parse(value : String)
+     Avram::Type::SuccessfulCast(Int64).new value.to_i64
     rescue ArgumentError
-      FailedCast.new
+     Avram::Type::FailedCast.new
     end
 
-    def parse(value : Int32)
-      SuccessfulCast(Int64).new value.to_i64
+    def self.parse(value : Int32)
+     Avram::Type::SuccessfulCast(Int64).new value.to_i64
     end
 
-    def to_db(value : Int64)
+    def self.to_db(value : Int64)
       value.to_s
     end
 
-    def to_db(values : Array(Int64))
+    def self.to_db(values : Array(Int64))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -1,10 +1,6 @@
 struct Int64
   extend Avram::Type
 
-  def self._from_db!(value : Int64)
-    value
-  end
-
   def self._parse_attribute(value : String)
     Avram::Type::SuccessfulCast(Int64).new value.to_i64
   rescue ArgumentError

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -11,21 +11,21 @@ struct Int64
       value
     end
 
-    def self.parse(value : Int64)
+    def self._parse_attribute(value : Int64)
      Avram::Type::SuccessfulCast(Int64).new(value)
     end
 
-    def self.parse(values : Array(Int64))
+    def self._parse_attribute(values : Array(Int64))
      Avram::Type::SuccessfulCast(Array(Int64)).new values
     end
 
-    def self.parse(value : String)
+    def self._parse_attribute(value : String)
      Avram::Type::SuccessfulCast(Int64).new value.to_i64
     rescue ArgumentError
      Avram::Type::FailedCast.new
     end
 
-    def self.parse(value : Int32)
+    def self._parse_attribute(value : Int32)
      Avram::Type::SuccessfulCast(Int64).new value.to_i64
     end
 

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -11,11 +11,11 @@ struct JSON::Any
       value
     end
 
-    def self.parse(value : JSON::Any)
+    def self._parse_attribute(value : JSON::Any)
      Avram::Type::SuccessfulCast(JSON::Any).new value
     end
 
-    def self.parse(value)
+    def self._parse_attribute(value)
      Avram::Type::SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
     end
 

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -5,21 +5,21 @@ struct JSON::Any
 
   module Lucky
     alias ColumnType = JSON::Any
-    include Avram::Type
+    extend Avram::Type
 
-    def from_db!(value : JSON::Any)
+    def self.from_db!(value : JSON::Any)
       value
     end
 
-    def parse(value : JSON::Any)
-      SuccessfulCast(JSON::Any).new value
+    def self.parse(value : JSON::Any)
+     Avram::Type::SuccessfulCast(JSON::Any).new value
     end
 
-    def parse(value)
-      SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
+    def self.parse(value)
+     Avram::Type::SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
     end
 
-    def to_db(value)
+    def self.to_db(value)
       value.to_json
     end
 

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -17,10 +17,6 @@ struct JSON::Any
     value.to_json
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = JSON::Any
 

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -1,10 +1,6 @@
 struct JSON::Any
   extend Avram::Type
 
-  def self._from_db!(value : JSON::Any)
-    value
-  end
-
   def self._parse_attribute(value)
     Avram::Type::SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
   end

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -1,27 +1,28 @@
 struct JSON::Any
+  extend Avram::Type
+
+  def self._from_db!(value : JSON::Any)
+    value
+  end
+
+  def self._parse_attribute(value : JSON::Any)
+    Avram::Type::SuccessfulCast(JSON::Any).new value
+  end
+
+  def self._parse_attribute(value)
+    Avram::Type::SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
+  end
+
+  def self._to_db(value)
+    value.to_json
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = JSON::Any
-    extend Avram::Type
-
-    def self._from_db!(value : JSON::Any)
-      value
-    end
-
-    def self._parse_attribute(value : JSON::Any)
-     Avram::Type::SuccessfulCast(JSON::Any).new value
-    end
-
-    def self._parse_attribute(value)
-     Avram::Type::SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
-    end
-
-    def self._to_db(value)
-      value.to_json
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
     end

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -5,10 +5,6 @@ struct JSON::Any
     value
   end
 
-  def self._parse_attribute(value : JSON::Any)
-    Avram::Type::SuccessfulCast(JSON::Any).new value
-  end
-
   def self._parse_attribute(value)
     Avram::Type::SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
   end

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -7,7 +7,7 @@ struct JSON::Any
     alias ColumnType = JSON::Any
     extend Avram::Type
 
-    def self.from_db!(value : JSON::Any)
+    def self._from_db!(value : JSON::Any)
       value
     end
 
@@ -19,7 +19,7 @@ struct JSON::Any
      Avram::Type::SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
     end
 
-    def self.to_db(value)
+    def self._to_db(value)
       value.to_json
     end
 

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -1,14 +1,6 @@
 class String
   extend Avram::Type
 
-  def self._parse_attribute(value : String)
-    Avram::Type::SuccessfulCast(String).new(value)
-  end
-
-  def self._parse_attribute(values : Array(String))
-    Avram::Type::SuccessfulCast(Array(String)).new(values)
-  end
-
   def self._to_db(value : String)
     value
   end

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -5,21 +5,21 @@ class String
 
   module Lucky
     alias ColumnType = String
-    include Avram::Type
+    extend Avram::Type
 
-    def parse(value : String)
-      SuccessfulCast(String).new(value)
+    def self.parse(value : String)
+     Avram::Type::SuccessfulCast(String).new(value)
     end
 
-    def parse(values : Array(String))
-      SuccessfulCast(Array(String)).new(values)
+    def self.parse(values : Array(String))
+     Avram::Type::SuccessfulCast(Array(String)).new(values)
     end
 
-    def to_db(value : String)
+    def self.to_db(value : String)
       value
     end
 
-    def to_db(values : Array(String))
+    def self.to_db(values : Array(String))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -1,10 +1,6 @@
 class String
   extend Avram::Type
 
-  def self._to_db(values : Array(String))
-    PQ::Param.encode_array(values)
-  end
-
   module Lucky
     alias ColumnType = String
 

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -17,10 +17,6 @@ class String
     PQ::Param.encode_array(values)
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = String
 

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -7,11 +7,11 @@ class String
     alias ColumnType = String
     extend Avram::Type
 
-    def self.parse(value : String)
+    def self._parse_attribute(value : String)
      Avram::Type::SuccessfulCast(String).new(value)
     end
 
-    def self.parse(values : Array(String))
+    def self._parse_attribute(values : Array(String))
      Avram::Type::SuccessfulCast(Array(String)).new(values)
     end
 

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -15,11 +15,11 @@ class String
      Avram::Type::SuccessfulCast(Array(String)).new(values)
     end
 
-    def self.to_db(value : String)
+    def self._to_db(value : String)
       value
     end
 
-    def self.to_db(values : Array(String))
+    def self._to_db(values : Array(String))
       PQ::Param.encode_array(values)
     end
 

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -1,10 +1,6 @@
 class String
   extend Avram::Type
 
-  def self._to_db(value : String)
-    value
-  end
-
   def self._to_db(values : Array(String))
     PQ::Param.encode_array(values)
   end

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -1,27 +1,28 @@
 class String
+  extend Avram::Type
+
+  def self._parse_attribute(value : String)
+    Avram::Type::SuccessfulCast(String).new(value)
+  end
+
+  def self._parse_attribute(values : Array(String))
+    Avram::Type::SuccessfulCast(Array(String)).new(values)
+  end
+
+  def self._to_db(value : String)
+    value
+  end
+
+  def self._to_db(values : Array(String))
+    PQ::Param.encode_array(values)
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = String
-    extend Avram::Type
-
-    def self._parse_attribute(value : String)
-     Avram::Type::SuccessfulCast(String).new(value)
-    end
-
-    def self._parse_attribute(values : Array(String))
-     Avram::Type::SuccessfulCast(Array(String)).new(values)
-    end
-
-    def self._to_db(value : String)
-      value
-    end
-
-    def self._to_db(values : Array(String))
-      PQ::Param.encode_array(values)
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       @upper = false

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -22,7 +22,7 @@ struct Time
       value
     end
 
-    def self.parse(value : String) : Avram::Type::SuccessfulCast(Time) |Avram::Type::FailedCast
+    def self._parse_attribute(value : String) : Avram::Type::SuccessfulCast(Time) |Avram::Type::FailedCast
       # Prefer user defined string formats
       try_parsing_with_string_formats(value) ||
         # Then try default formats
@@ -55,11 +55,11 @@ struct Time
       end
     end
 
-    def self.parse(value : Time)
+    def self._parse_attribute(value : Time)
      Avram::Type::SuccessfulCast(Time).new value
     end
 
-    def self.parse(values : Array(Time))
+    def self._parse_attribute(values : Array(Time))
      Avram::Type::SuccessfulCast(Array(Time)).new values
     end
 

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -18,7 +18,7 @@ struct Time
       Time::Format::ISO_8601_TIME,
     ]
 
-    def self.from_db!(value : Time)
+    def self._from_db!(value : Time)
       value
     end
 
@@ -63,7 +63,7 @@ struct Time
      Avram::Type::SuccessfulCast(Array(Time)).new values
     end
 
-    def self.to_db(value : Time)
+    def self._to_db(value : Time)
       value.to_s
     end
 

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -61,10 +61,6 @@ struct Time
     value.to_s
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = Time
 

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -5,7 +5,7 @@ struct Time
 
   module Lucky
     alias ColumnType = Time
-    include Avram::Type
+    extend Avram::Type
 
     TIME_FORMATS = [
       Time::Format::ISO_8601_DATE_TIME,
@@ -18,17 +18,17 @@ struct Time
       Time::Format::ISO_8601_TIME,
     ]
 
-    def from_db!(value : Time)
+    def self.from_db!(value : Time)
       value
     end
 
-    def parse(value : String) : SuccessfulCast(Time) | FailedCast
+    def self.parse(value : String) : Avram::Type::SuccessfulCast(Time) |Avram::Type::FailedCast
       # Prefer user defined string formats
       try_parsing_with_string_formats(value) ||
         # Then try default formats
         try_parsing_with_default_formatters(value) ||
         # Fail if none of them work
-        FailedCast.new
+       Avram::Type::FailedCast.new
     end
 
     def self.try_parsing_with_default_formatters(value : String)
@@ -39,7 +39,7 @@ struct Time
           nil
         end
       end.try do |format|
-        SuccessfulCast.new format.parse(value).to_utc
+       Avram::Type::SuccessfulCast.new format.parse(value).to_utc
       end
     end
 
@@ -51,19 +51,19 @@ struct Time
           nil
         end
       end.try do |format|
-        SuccessfulCast.new Time.parse(value, format, Time::Location.load("UTC")).to_utc
+       Avram::Type::SuccessfulCast.new Time.parse(value, format, Time::Location.load("UTC")).to_utc
       end
     end
 
-    def parse(value : Time)
-      SuccessfulCast(Time).new value
+    def self.parse(value : Time)
+     Avram::Type::SuccessfulCast(Time).new value
     end
 
-    def parse(values : Array(Time))
-      SuccessfulCast(Array(Time)).new values
+    def self.parse(values : Array(Time))
+     Avram::Type::SuccessfulCast(Array(Time)).new values
     end
 
-    def to_db(value : Time)
+    def self.to_db(value : Time)
       value.to_s
     end
 

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -49,14 +49,6 @@ struct Time
     end
   end
 
-  def self._parse_attribute(value : Time)
-    Avram::Type::SuccessfulCast(Time).new value
-  end
-
-  def self._parse_attribute(values : Array(Time))
-    Avram::Type::SuccessfulCast(Array(Time)).new values
-  end
-
   def self._to_db(value : Time)
     value.to_s
   end

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -1,71 +1,72 @@
 struct Time
+  extend Avram::Type
+
+  TIME_FORMATS = [
+    Time::Format::ISO_8601_DATE_TIME,
+    Time::Format::RFC_2822,
+    Time::Format::RFC_3339,
+    # Dates and times go last, otherwise it will parse strings with both
+    # dates *and* times incorrectly.
+    Time::Format::HTTP_DATE,
+    Time::Format::ISO_8601_DATE,
+    Time::Format::ISO_8601_TIME,
+  ]
+
+  def self._from_db!(value : Time)
+    value
+  end
+
+  def self._parse_attribute(value : String) : Avram::Type::SuccessfulCast(Time) |Avram::Type::FailedCast
+    # Prefer user defined string formats
+    _try_parsing_with_string_formats(value) ||
+      # Then try default formats
+      _try_parsing_with_default_formatters(value) ||
+      # Fail if none of them work
+      Avram::Type::FailedCast.new
+  end
+
+  def self._try_parsing_with_default_formatters(value : String)
+    TIME_FORMATS.find do |format|
+      begin
+        format.parse(value)
+      rescue e : Time::Format::Error
+        nil
+      end
+    end.try do |format|
+      Avram::Type::SuccessfulCast.new format.parse(value).to_utc
+    end
+  end
+
+  def self._try_parsing_with_string_formats(value)
+    Avram.settings.time_formats.find do |format|
+      begin
+        Time.parse(value, format, Time::Location.load("UTC"))
+      rescue e : Time::Format::Error
+        nil
+      end
+    end.try do |format|
+      Avram::Type::SuccessfulCast.new Time.parse(value, format, Time::Location.load("UTC")).to_utc
+    end
+  end
+
+  def self._parse_attribute(value : Time)
+    Avram::Type::SuccessfulCast(Time).new value
+  end
+
+  def self._parse_attribute(values : Array(Time))
+    Avram::Type::SuccessfulCast(Array(Time)).new values
+  end
+
+  def self._to_db(value : Time)
+    value.to_s
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = Time
-    extend Avram::Type
-
-    TIME_FORMATS = [
-      Time::Format::ISO_8601_DATE_TIME,
-      Time::Format::RFC_2822,
-      Time::Format::RFC_3339,
-      # Dates and times go last, otherwise it will parse strings with both
-      # dates *and* times incorrectly.
-      Time::Format::HTTP_DATE,
-      Time::Format::ISO_8601_DATE,
-      Time::Format::ISO_8601_TIME,
-    ]
-
-    def self._from_db!(value : Time)
-      value
-    end
-
-    def self._parse_attribute(value : String) : Avram::Type::SuccessfulCast(Time) |Avram::Type::FailedCast
-      # Prefer user defined string formats
-      try_parsing_with_string_formats(value) ||
-        # Then try default formats
-        try_parsing_with_default_formatters(value) ||
-        # Fail if none of them work
-       Avram::Type::FailedCast.new
-    end
-
-    def self.try_parsing_with_default_formatters(value : String)
-      TIME_FORMATS.find do |format|
-        begin
-          format.parse(value)
-        rescue e : Time::Format::Error
-          nil
-        end
-      end.try do |format|
-       Avram::Type::SuccessfulCast.new format.parse(value).to_utc
-      end
-    end
-
-    def self.try_parsing_with_string_formats(value)
-      Avram.settings.time_formats.find do |format|
-        begin
-          Time.parse(value, format, Time::Location.load("UTC"))
-        rescue e : Time::Format::Error
-          nil
-        end
-      end.try do |format|
-       Avram::Type::SuccessfulCast.new Time.parse(value, format, Time::Location.load("UTC")).to_utc
-      end
-    end
-
-    def self._parse_attribute(value : Time)
-     Avram::Type::SuccessfulCast(Time).new value
-    end
-
-    def self._parse_attribute(values : Array(Time))
-     Avram::Type::SuccessfulCast(Array(Time)).new values
-    end
-
-    def self._to_db(value : Time)
-      value.to_s
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -12,10 +12,6 @@ struct Time
     Time::Format::ISO_8601_TIME,
   ]
 
-  def self._from_db!(value : Time)
-    value
-  end
-
   def self._parse_attribute(value : String) : Avram::Type::SuccessfulCast(Time) | Avram::Type::FailedCast
     # Prefer user defined string formats
     _try_parsing_with_string_formats(value) ||

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -16,7 +16,7 @@ struct Time
     value
   end
 
-  def self._parse_attribute(value : String) : Avram::Type::SuccessfulCast(Time) |Avram::Type::FailedCast
+  def self._parse_attribute(value : String) : Avram::Type::SuccessfulCast(Time) | Avram::Type::FailedCast
     # Prefer user defined string formats
     _try_parsing_with_string_formats(value) ||
       # Then try default formats

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -49,10 +49,6 @@ struct Time
     end
   end
 
-  def self._to_db(value : Time)
-    value.to_s
-  end
-
   module Lucky
     alias ColumnType = Time
 

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -1,29 +1,30 @@
 struct UUID
+  extend Avram::Type
+
+  def self._parse_attribute(value : UUID)
+    Avram::Type::SuccessfulCast(UUID).new(value)
+  end
+
+  def self._parse_attribute(values : Array(UUID))
+    Avram::Type::SuccessfulCast(Array(UUID)).new values
+  end
+
+  def self._parse_attribute(value : String)
+    Avram::Type::SuccessfulCast(UUID).new(UUID.new(value))
+  rescue
+    Avram::Type::FailedCast.new
+  end
+
+  def self._to_db(value : UUID)
+    value.to_s
+  end
+
   def self.adapter
-    Lucky
+    self
   end
 
   module Lucky
     alias ColumnType = String
-    extend Avram::Type
-
-    def self._parse_attribute(value : UUID)
-     Avram::Type::SuccessfulCast(UUID).new(value)
-    end
-
-    def self._parse_attribute(values : Array(UUID))
-     Avram::Type::SuccessfulCast(Array(UUID)).new values
-    end
-
-    def self._parse_attribute(value : String)
-     Avram::Type::SuccessfulCast(UUID).new(UUID.new(value))
-    rescue
-     Avram::Type::FailedCast.new
-    end
-
-    def self._to_db(value : UUID)
-      value.to_s
-    end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
     end

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -21,7 +21,7 @@ struct UUID
      Avram::Type::FailedCast.new
     end
 
-    def self.to_db(value : UUID)
+    def self._to_db(value : UUID)
       value.to_s
     end
 

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -19,10 +19,6 @@ struct UUID
     value.to_s
   end
 
-  def self.adapter
-    self
-  end
-
   module Lucky
     alias ColumnType = String
 

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -1,14 +1,6 @@
 struct UUID
   extend Avram::Type
 
-  def self._parse_attribute(value : UUID)
-    Avram::Type::SuccessfulCast(UUID).new(value)
-  end
-
-  def self._parse_attribute(values : Array(UUID))
-    Avram::Type::SuccessfulCast(Array(UUID)).new values
-  end
-
   def self._parse_attribute(value : String)
     Avram::Type::SuccessfulCast(UUID).new(UUID.new(value))
   rescue

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -5,23 +5,23 @@ struct UUID
 
   module Lucky
     alias ColumnType = String
-    include Avram::Type
+    extend Avram::Type
 
-    def parse(value : UUID)
-      SuccessfulCast(UUID).new(value)
+    def self.parse(value : UUID)
+     Avram::Type::SuccessfulCast(UUID).new(value)
     end
 
-    def parse(values : Array(UUID))
-      SuccessfulCast(Array(UUID)).new values
+    def self.parse(values : Array(UUID))
+     Avram::Type::SuccessfulCast(Array(UUID)).new values
     end
 
-    def parse(value : String)
-      SuccessfulCast(UUID).new(UUID.new(value))
+    def self.parse(value : String)
+     Avram::Type::SuccessfulCast(UUID).new(UUID.new(value))
     rescue
-      FailedCast.new
+     Avram::Type::FailedCast.new
     end
 
-    def to_db(value : UUID)
+    def self.to_db(value : UUID)
       value.to_s
     end
 

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -7,10 +7,6 @@ struct UUID
     Avram::Type::FailedCast.new
   end
 
-  def self._to_db(value : UUID)
-    value.to_s
-  end
-
   module Lucky
     alias ColumnType = String
 

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -7,15 +7,15 @@ struct UUID
     alias ColumnType = String
     extend Avram::Type
 
-    def self.parse(value : UUID)
+    def self._parse_attribute(value : UUID)
      Avram::Type::SuccessfulCast(UUID).new(value)
     end
 
-    def self.parse(values : Array(UUID))
+    def self._parse_attribute(values : Array(UUID))
      Avram::Type::SuccessfulCast(Array(UUID)).new values
     end
 
-    def self.parse(value : String)
+    def self._parse_attribute(value : String)
      Avram::Type::SuccessfulCast(UUID).new(UUID.new(value))
     rescue
      Avram::Type::FailedCast.new

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -81,7 +81,7 @@ class Avram::Criteria(T, V)
   end
 
   private def perform_eq(value) : T
-    add_clause(Avram::Where::Equal.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::Equal.new(column, V::Lucky._to_db!(value)))
   end
 
   def nilable_eq(value) : T
@@ -109,19 +109,19 @@ class Avram::Criteria(T, V)
   end
 
   def gt(value) : T
-    add_clause(Avram::Where::GreaterThan.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::GreaterThan.new(column, V::Lucky._to_db!(value)))
   end
 
   def gte(value) : T
-    add_clause(Avram::Where::GreaterThanOrEqualTo.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::GreaterThanOrEqualTo.new(column, V::Lucky._to_db!(value)))
   end
 
   def lt(value) : T
-    add_clause(Avram::Where::LessThan.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::LessThan.new(column, V::Lucky._to_db!(value)))
   end
 
   def lte(value) : T
-    add_clause(Avram::Where::LessThanOrEqualTo.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::LessThanOrEqualTo.new(column, V::Lucky._to_db!(value)))
   end
 
   def select_min : V | Nil
@@ -145,7 +145,7 @@ class Avram::Criteria(T, V)
   end
 
   def in(values) : T
-    values = values.map { |value| V::Lucky.to_db!(value) }
+    values = values.map { |value| V::Lucky._to_db!(value) }
     add_clause(Avram::Where::In.new(column, values))
   end
 

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -81,7 +81,7 @@ class Avram::Criteria(T, V)
   end
 
   private def perform_eq(value) : T
-    add_clause(Avram::Where::Equal.new(column, V::Lucky._to_db!(value)))
+    add_clause(Avram::Where::Equal.new(column, V._to_db!(value)))
   end
 
   def nilable_eq(value) : T
@@ -109,19 +109,19 @@ class Avram::Criteria(T, V)
   end
 
   def gt(value) : T
-    add_clause(Avram::Where::GreaterThan.new(column, V::Lucky._to_db!(value)))
+    add_clause(Avram::Where::GreaterThan.new(column, V._to_db!(value)))
   end
 
   def gte(value) : T
-    add_clause(Avram::Where::GreaterThanOrEqualTo.new(column, V::Lucky._to_db!(value)))
+    add_clause(Avram::Where::GreaterThanOrEqualTo.new(column, V._to_db!(value)))
   end
 
   def lt(value) : T
-    add_clause(Avram::Where::LessThan.new(column, V::Lucky._to_db!(value)))
+    add_clause(Avram::Where::LessThan.new(column, V._to_db!(value)))
   end
 
   def lte(value) : T
-    add_clause(Avram::Where::LessThanOrEqualTo.new(column, V::Lucky._to_db!(value)))
+    add_clause(Avram::Where::LessThanOrEqualTo.new(column, V._to_db!(value)))
   end
 
   def select_min : V | Nil
@@ -145,7 +145,7 @@ class Avram::Criteria(T, V)
   end
 
   def in(values) : T
-    values = values.map { |value| V::Lucky._to_db!(value) }
+    values = values.map { |value| V._to_db!(value) }
     add_clause(Avram::Where::In.new(column, values))
   end
 

--- a/src/avram/define_attribute.cr
+++ b/src/avram/define_attribute.cr
@@ -92,7 +92,7 @@ module Avram::DefineAttribute
     end
 
     def set_{{ name }}_from_param(attribute : Avram::Attribute)
-      parse_result = {{ type }}::Lucky._parse_attribute({{ name }}_param)
+      parse_result = {{ type }}._parse_attribute({{ name }}_param)
       if parse_result.is_a? Avram::Type::SuccessfulCast
         attribute.value = parse_result.value
       else
@@ -145,7 +145,7 @@ module Avram::DefineAttribute
     end
 
     def set_{{ name }}_from_param(attribute : Avram::Attribute)
-      parse_result = Avram::Uploadable::Lucky._parse_attribute({{ name }}_param)
+      parse_result = Avram::Uploadable._parse_attribute({{ name }}_param)
       if parse_result.is_a? Avram::Type::SuccessfulCast
         attribute.value = parse_result.value
       else

--- a/src/avram/define_attribute.cr
+++ b/src/avram/define_attribute.cr
@@ -92,7 +92,7 @@ module Avram::DefineAttribute
     end
 
     def set_{{ name }}_from_param(attribute : Avram::Attribute)
-      parse_result = {{ type }}::Lucky.parse({{ name }}_param)
+      parse_result = {{ type }}::Lucky._parse_attribute({{ name }}_param)
       if parse_result.is_a? Avram::Type::SuccessfulCast
         attribute.value = parse_result.value
       else
@@ -145,7 +145,7 @@ module Avram::DefineAttribute
     end
 
     def set_{{ name }}_from_param(attribute : Avram::Attribute)
-      parse_result = Avram::Uploadable::Lucky.parse({{ name }}_param)
+      parse_result = Avram::Uploadable::Lucky._parse_attribute({{ name }}_param)
       if parse_result.is_a? Avram::Type::SuccessfulCast
         attribute.value = parse_result.value
       else

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -248,7 +248,7 @@ abstract class Avram::Model
     {% for column in columns %}
       {% db_type = column[:type].is_a?(Generic) ? column[:type].type_vars.first : column[:type] %}
       def {{column[:name]}} : {{column[:type]}}{{(column[:nilable] ? "?" : "").id}}
-        {{ db_type }}::Lucky.from_db!(@{{column[:name]}})
+        {{ db_type }}::Lucky._from_db!(@{{column[:name]}})
       end
       {% if column[:type].id == Bool.id %}
       def {{column[:name]}}? : Bool

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -248,7 +248,7 @@ abstract class Avram::Model
     {% for column in columns %}
       {% db_type = column[:type].is_a?(Generic) ? column[:type].type_vars.first : column[:type] %}
       def {{column[:name]}} : {{column[:type]}}{{(column[:nilable] ? "?" : "").id}}
-        {{ db_type }}::Lucky._from_db!(@{{column[:name]}})
+        {{ db_type }}._from_db!(@{{column[:name]}})
       end
       {% if column[:type].id == Bool.id %}
       def {{column[:name]}}? : Bool

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -133,9 +133,9 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
       private def default_value_for_{{ attribute[:name] }}
         {% if attribute[:value] || attribute[:value] == false %}
           {% if attribute[:type].is_a?(Generic) %}
-            parse_result = {{ attribute[:type].type_vars.first }}::Lucky._parse_attribute([{{ attribute[:value] }}])
+            parse_result = {{ attribute[:type].type_vars.first }}._parse_attribute([{{ attribute[:value] }}])
           {% else %}
-            parse_result = {{ attribute[:type] }}::Lucky._parse_attribute({{ attribute[:value] }})
+            parse_result = {{ attribute[:type] }}._parse_attribute({{ attribute[:value] }})
           {% end %}
           if parse_result.is_a? Avram::Type::SuccessfulCast
             parse_result.value.as({{ attribute[:type] }})
@@ -165,9 +165,9 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
         {% if attribute[:type].is_a?(Generic) %}
           # Pass `_value` in as an Array. Currently only single values are supported.
           # TODO: Update this once Lucky params support Arrays natively
-          parse_result = {{ attribute[:type].type_vars.first }}::Lucky._parse_attribute([_value])
+          parse_result = {{ attribute[:type].type_vars.first }}._parse_attribute([_value])
         {% else %}
-          parse_result = {{ attribute[:type] }}::Lucky._parse_attribute(_value)
+          parse_result = {{ attribute[:type] }}._parse_attribute(_value)
         {% end %}
         if parse_result.is_a? Avram::Type::SuccessfulCast
           {{ attribute[:name] }}.value = parse_result.value.as({{ attribute[:type] }})

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -133,9 +133,9 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
       private def default_value_for_{{ attribute[:name] }}
         {% if attribute[:value] || attribute[:value] == false %}
           {% if attribute[:type].is_a?(Generic) %}
-            parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse([{{ attribute[:value] }}])
+            parse_result = {{ attribute[:type].type_vars.first }}::Lucky._parse_attribute([{{ attribute[:value] }}])
           {% else %}
-            parse_result = {{ attribute[:type] }}::Lucky.parse({{ attribute[:value] }})
+            parse_result = {{ attribute[:type] }}::Lucky._parse_attribute({{ attribute[:value] }})
           {% end %}
           if parse_result.is_a? Avram::Type::SuccessfulCast
             parse_result.value.as({{ attribute[:type] }})
@@ -165,9 +165,9 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
         {% if attribute[:type].is_a?(Generic) %}
           # Pass `_value` in as an Array. Currently only single values are supported.
           # TODO: Update this once Lucky params support Arrays natively
-          parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse([_value])
+          parse_result = {{ attribute[:type].type_vars.first }}::Lucky._parse_attribute([_value])
         {% else %}
-          parse_result = {{ attribute[:type] }}::Lucky.parse(_value)
+          parse_result = {{ attribute[:type] }}::Lucky._parse_attribute(_value)
         {% end %}
         if parse_result.is_a? Avram::Type::SuccessfulCast
           {{ attribute[:name] }}.value = parse_result.value.as({{ attribute[:type] }})

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -294,7 +294,7 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
     # In most cases, that's just calling `to_s`, but in the case of an Array,
     # `value` is passed to `PQ::Param` to properly encode `[true]` to `{t}`, etc...
     private def cast_value(value : {{ column[:type] }})
-      value.not_nil!.class.adapter._to_db(value.as({{ column[:type] }}))
+      value.not_nil!.class._to_db(value)
     end
     {% end %}
   end

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -290,11 +290,11 @@ abstract class Avram::SaveOperation(T) < Avram::Operation
     end
 
     {% for column in columns %}
-    # pass `value` to it's `Lucky.to_db` for parsing.
+    # pass `value` to it's `Lucky._to_db` for parsing.
     # In most cases, that's just calling `to_s`, but in the case of an Array,
     # `value` is passed to `PQ::Param` to properly encode `[true]` to `{t}`, etc...
     private def cast_value(value : {{ column[:type] }})
-      value.not_nil!.class.adapter.to_db(value.as({{ column[:type] }}))
+      value.not_nil!.class.adapter._to_db(value.as({{ column[:type] }}))
     end
     {% end %}
   end

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -1,4 +1,8 @@
 module Avram::Type
+  def adapter
+    self
+  end
+
   def _from_db!(value)
     _parse_attribute!(value)
   end

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -1,24 +1,24 @@
 module Avram::Type
   def from_db!(value)
-    parse!(value)
+    _parse_attribute!(value)
   end
 
-  def parse(value : Nil)
+  def _parse_attribute(value : Nil)
     Avram::Type::SuccessfulCast(Nil).new(nil)
   end
 
-  def parse(values : Array(String))
-    casts = values.map { |value| parse(value) }
+  def _parse_attribute(values : Array(String))
+    casts = values.map { |value| _parse_attribute(value) }
     if casts.all?(&.is_a?(Avram::Type::SuccessfulCast))
       values = casts.map { |c| c.as(Avram::Type::SuccessfulCast).value }
-      parse(values)
+      _parse_attribute(values)
     else
      Avram::Type::FailedCast.new
     end
   end
 
-  def parse!(value)
-    parse(value).as(Avram::Type::SuccessfulCast).value
+  def _parse_attribute!(value)
+    _parse_attribute(value).as(Avram::Type::SuccessfulCast).value
   end
 
   def to_db(value : Nil)
@@ -26,7 +26,7 @@ module Avram::Type
   end
 
   def to_db!(value)
-    parsed_value = parse!(value)
+    parsed_value = _parse_attribute!(value)
     to_db(parsed_value)
   end
 

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -37,6 +37,11 @@ module Avram::Type
     value.to_s
   end
 
+  def _to_db!(value : Array(T)) forall T
+    parsed_value = _parse_attribute!(value)
+    Array._to_db(parsed_value)
+  end
+
   def _to_db!(value)
     parsed_value = _parse_attribute!(value)
     _to_db(parsed_value)

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -38,13 +38,11 @@ module Avram::Type
   end
 
   def _to_db!(value : Array(T)) forall T
-    parsed_value = _parse_attribute!(value)
-    Array._to_db(parsed_value)
+    Array._to_db(_parse_attribute!(value))
   end
 
   def _to_db!(value)
-    parsed_value = _parse_attribute!(value)
-    _to_db(parsed_value)
+    _to_db(_parse_attribute!(value))
   end
 
   class SuccessfulCast(T)

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -21,7 +21,7 @@ module Avram::Type
       values = casts.map { |c| c.as(Avram::Type::SuccessfulCast).value }
       _parse_attribute(values)
     else
-     Avram::Type::FailedCast.new
+      Avram::Type::FailedCast.new
     end
   end
 

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -7,6 +7,14 @@ module Avram::Type
     Avram::Type::SuccessfulCast(Nil).new(nil)
   end
 
+  def _parse_attribute(value : self)
+    Avram::Type::SuccessfulCast(self).new(value)
+  end
+
+  def _parse_attribute(values : Array(self))
+    Avram::Type::SuccessfulCast(Array(self)).new(values)
+  end
+
   def _parse_attribute(values : Array(String))
     casts = values.map { |value| _parse_attribute(value) }
     if casts.all?(&.is_a?(Avram::Type::SuccessfulCast))

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -33,6 +33,10 @@ module Avram::Type
     nil
   end
 
+  def _to_db(value : self)
+    value.to_s
+  end
+
   def _to_db!(value)
     parsed_value = _parse_attribute!(value)
     _to_db(parsed_value)

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -1,5 +1,5 @@
 module Avram::Type
-  def from_db!(value)
+  def _from_db!(value)
     _parse_attribute!(value)
   end
 
@@ -21,13 +21,13 @@ module Avram::Type
     _parse_attribute(value).as(Avram::Type::SuccessfulCast).value
   end
 
-  def to_db(value : Nil)
+  def _to_db(value : Nil)
     nil
   end
 
-  def to_db!(value)
+  def _to_db!(value)
     parsed_value = _parse_attribute!(value)
-    to_db(parsed_value)
+    _to_db(parsed_value)
   end
 
   class SuccessfulCast(T)

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -1,28 +1,24 @@
 module Avram::Type
-  macro included
-    extend self
-  end
-
   def from_db!(value)
     parse!(value)
   end
 
   def parse(value : Nil)
-    SuccessfulCast(Nil).new(nil)
+    Avram::Type::SuccessfulCast(Nil).new(nil)
   end
 
   def parse(values : Array(String))
     casts = values.map { |value| parse(value) }
-    if casts.all?(&.is_a?(SuccessfulCast))
-      values = casts.map { |c| c.as(SuccessfulCast).value }
+    if casts.all?(&.is_a?(Avram::Type::SuccessfulCast))
+      values = casts.map { |c| c.as(Avram::Type::SuccessfulCast).value }
       parse(values)
     else
-      FailedCast.new
+     Avram::Type::FailedCast.new
     end
   end
 
   def parse!(value)
-    parse(value).as(SuccessfulCast).value
+    parse(value).as(Avram::Type::SuccessfulCast).value
   end
 
   def to_db(value : Nil)

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -1,8 +1,4 @@
 module Avram::Type
-  def adapter
-    self
-  end
-
   def _from_db!(value)
     _parse_attribute!(value)
   end

--- a/src/avram/uploadable.cr
+++ b/src/avram/uploadable.cr
@@ -1,24 +1,22 @@
 module Avram::Uploadable
+  extend Avram::Type
+
+  def self._parse_attribute(value : Avram::Uploadable)
+    Avram::Type::SuccessfulCast(Avram::Uploadable).new(value)
+  end
+
+  def self._parse_attribute(values : Array(Avram::Uploadable))
+    Avram::Type::SuccessfulCast(Array(Avram::Uploadable)).new(values)
+  end
+
+  def self._parse_attribute(value : String?)
+    Avram::Type::FailedCast.new
+  end
+
   abstract def tempfile : File
   abstract def metadata : HTTP::FormData::FileMetadata
   # Typically, this should return the filename as found in the `metadata`.
   abstract def filename : String
   # This should test if the filename is a blank string.
   abstract def blank? : Bool
-
-  module Lucky
-    extend Avram::Type
-
-    def self._parse_attribute(value : Avram::Uploadable)
-     Avram::Type::SuccessfulCast(Avram::Uploadable).new(value)
-    end
-
-    def self._parse_attribute(values : Array(Avram::Uploadable))
-     Avram::Type::SuccessfulCast(Array(Avram::Uploadable)).new(values)
-    end
-
-    def self._parse_attribute(value : String?)
-     Avram::Type::FailedCast.new
-    end
-  end
 end

--- a/src/avram/uploadable.cr
+++ b/src/avram/uploadable.cr
@@ -1,14 +1,6 @@
 module Avram::Uploadable
   extend Avram::Type
 
-  def self._parse_attribute(value : Avram::Uploadable)
-    Avram::Type::SuccessfulCast(Avram::Uploadable).new(value)
-  end
-
-  def self._parse_attribute(values : Array(Avram::Uploadable))
-    Avram::Type::SuccessfulCast(Array(Avram::Uploadable)).new(values)
-  end
-
   def self._parse_attribute(value : String?)
     Avram::Type::FailedCast.new
   end

--- a/src/avram/uploadable.cr
+++ b/src/avram/uploadable.cr
@@ -9,15 +9,15 @@ module Avram::Uploadable
   module Lucky
     extend Avram::Type
 
-    def self.parse(value : Avram::Uploadable)
+    def self._parse_attribute(value : Avram::Uploadable)
      Avram::Type::SuccessfulCast(Avram::Uploadable).new(value)
     end
 
-    def self.parse(values : Array(Avram::Uploadable))
+    def self._parse_attribute(values : Array(Avram::Uploadable))
      Avram::Type::SuccessfulCast(Array(Avram::Uploadable)).new(values)
     end
 
-    def self.parse(value : String?)
+    def self._parse_attribute(value : String?)
      Avram::Type::FailedCast.new
     end
   end

--- a/src/avram/uploadable.cr
+++ b/src/avram/uploadable.cr
@@ -7,18 +7,18 @@ module Avram::Uploadable
   abstract def blank? : Bool
 
   module Lucky
-    include Avram::Type
+    extend Avram::Type
 
-    def parse(value : Avram::Uploadable)
-      SuccessfulCast(Avram::Uploadable).new(value)
+    def self.parse(value : Avram::Uploadable)
+     Avram::Type::SuccessfulCast(Avram::Uploadable).new(value)
     end
 
-    def parse(values : Array(Avram::Uploadable))
-      SuccessfulCast(Array(Avram::Uploadable)).new(values)
+    def self.parse(values : Array(Avram::Uploadable))
+     Avram::Type::SuccessfulCast(Array(Avram::Uploadable)).new(values)
     end
 
-    def parse(value : String?)
-      FailedCast.new
+    def self.parse(value : String?)
+     Avram::Type::FailedCast.new
     end
   end
 end


### PR DESCRIPTION
By monkey patching `Avram::Type` onto the base types instead of a nested `Lucky` module, we can take advantaged of the `self` type and remove a bunch of unnecessary methods.

This has the disadvantage of adding methods to Crystal (which is why I updated the methods to start with underscore) so feel free to say no. 