### PR TITLE
overwrite to_s and to_i for Enums

### DIFF
--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -25,7 +25,7 @@ describe "Enum" do
     issue.status.opened?.should eq(true)
     issue.status.value.should eq(0)
   end
-  
+
   it "access enum to_s and to_i" do
     issue = IssueBox.create
 

--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -25,4 +25,11 @@ describe "Enum" do
     issue.status.opened?.should eq(true)
     issue.status.value.should eq(0)
   end
+  
+  it "access enum to_s and to_i" do
+    issue = IssueBox.create
+
+    issue.status.to_s.should eq("Opened")
+    issue.status.to_i.should eq(0)
+  end
 end

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -23,7 +23,7 @@ macro avram_enum(enum_name, &block)
     def initialize(enum_value : String)
       @enum = Avram{{ enum_name }}.from_value(enum_value.to_i)
     end
-    
+
     delegate to_s, to_i, to: @enum
 
     forward_missing_to @enum

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -23,11 +23,11 @@ macro avram_enum(enum_name, &block)
     def initialize(enum_value : String)
       @enum = Avram{{ enum_name }}.from_value(enum_value.to_i)
     end
-    
+
     def to_s
       @enum.to_s
     end
-    
+
     def to_i
       @enum.to_i
     end

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -23,14 +23,8 @@ macro avram_enum(enum_name, &block)
     def initialize(enum_value : String)
       @enum = Avram{{ enum_name }}.from_value(enum_value.to_i)
     end
-
-    def to_s
-      @enum.to_s
-    end
-
-    def to_i
-      @enum.to_i
-    end
+    
+    delegate to_s, to_i, to: @enum
 
     forward_missing_to @enum
 

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -23,6 +23,14 @@ macro avram_enum(enum_name, &block)
     def initialize(enum_value : String)
       @enum = Avram{{ enum_name }}.from_value(enum_value.to_i)
     end
+    
+    def to_s
+      @enum.to_s
+    end
+    
+    def to_i
+      @enum.to_i
+    end
 
     forward_missing_to @enum
 


### PR DESCRIPTION
making it possible to get int and the string directly, good for showing the enum on pages and such.

Not it will return class instance on `to_s` and not work at all on `to_i`

now it will return say `Ongoing` on to_s and `0` on to_i

not sure if maybe this will work instead:
```
delegate :to_s, :to_i, to: @enum
```

I feel it is a personal taste that feels best. I can change to that if you want.