### PR TITLE
Update to latest PG and DB shards.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -19,7 +19,7 @@ dependencies:
     version: ~> 0.24.0
   pg:
     github: will/crystal-pg
-    version: ~> 0.21.0
+    version: ~> 0.22.0
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4.4

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -158,15 +158,14 @@ describe Avram::Model do
   describe "models with uuids" do
     it "sets up initializers accepting uuid strings" do
       uuid = UUID.new("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
-      LineItem.new(uuid.to_s, Time.utc, Time.utc, "hello")
+      LineItem.new(uuid, Time.utc, Time.utc, "hello")
     end
 
     it "can be saved" do
-      uuid_regexp = /\w+/
       LineItemBox.create
 
       item = LineItemQuery.new.first
-      item.id.to_s.should match(uuid_regexp)
+      item.id.should be_a UUID
     end
 
     it "can be deleted" do

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -4,7 +4,7 @@ struct UUID
   end
 
   module Lucky
-    alias ColumnType = String
+    alias ColumnType = UUID
     include Avram::Type
 
     def parse(value : UUID)


### PR DESCRIPTION
Fixes #476

With the latest crystal-db and pg shards, UUID is supported more natively. This means that UUID columns can now be treated as UUID and not be faked with String.