### PR TITLE
migrator can handle Int64

### DIFF
--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -62,7 +62,7 @@ abstract class Avram::Migrator::Migration::V1
 
   def migrated?
     DB.open(Avram::Migrator::Runner.database_url) do |db|
-      db.query_one? "SELECT id FROM migrations WHERE version = $1", version, as: Int32
+      db.query_one? "SELECT id FROM migrations WHERE version = $1", version, as: Int
     end
   end
 


### PR DESCRIPTION
This is because coachroachdb stores the version as an Int64.

This seems to me it should be an int64 because it should be a bigint.
https://github.com/luckyframework/avram/blob/master/src/avram/migrator/runner.cr#L114
