### PR TITLE
Better callbacks for SaveOperation

### DIFF
--- a/spec/save_operation_callbacks_spec.cr
+++ b/spec/save_operation_callbacks_spec.cr
@@ -1,11 +1,20 @@
 require "./spec_helper"
 
+module TestableOperation
+  macro included
+    @callbacks_that_ran = [] of String
+    getter callbacks_that_ran
+
+    def mark_callback(callback_name : String)
+      @callbacks_that_ran << callback_name
+    end
+  end
+end
+
 private class CallbacksSaveOperation < Post::SaveOperation
+  include TestableOperation
   needs rollback : Bool = false
   needs skip_set_required : Bool = false
-
-  @callbacks_that_ran = [] of String
-  getter callbacks_that_ran
 
   before_save setup_required_attributes
 
@@ -74,14 +83,49 @@ private class SaveLineItemSub < SaveLineItemBase
   end
 end
 
-describe "Avram::SaveOperation callbacks" do
-  it "does not run after_* callbacks if just validating" do
-    operation = CallbacksSaveOperation.new
-    operation.callbacks_that_ran.should eq([] of String)
+private class SaveOperationWithCallbacks < Post::SaveOperation
+  include TestableOperation
 
+  before_save :set_title
+  before_save { mark_callback("before_save_in_a_block") }
+
+  after_save :notify_save_complete
+  after_save do |saved_post|
+    mark_callback("after_save_in_a_block with #{saved_post.title}")
+  end
+
+  after_commit :notify_commit_complete
+  after_commit do |saved_post|
+    mark_callback("after_commit_in_a_block with #{saved_post.title}")
+  end
+
+  private def set_title
+    mark_callback("before_save_update_title")
+    title.value = "Saved Post"
+  end
+
+  private def notify_save_complete(saved_post)
+    mark_callback("after_save_notify_save_complete with #{saved_post.title}")
+  end
+
+  private def notify_commit_complete(saved_post)
+    mark_callback("after_commit_notify_commit_complete with #{saved_post.title}")
+  end
+end
+
+private class UpdateOperationWithSkipCallbacks < SaveOperationWithCallbacks
+  permit_columns :title
+  skip_before_save :set_title
+  skip_after_save :notify_save_complete
+  skip_after_commit :notify_commit_complete
+end
+
+describe "Avram::SaveOperation callbacks" do
+  it "does not run any callbacks if just validating" do
+    operation = CallbacksSaveOperation.new
     operation.valid?
 
-    operation.callbacks_that_ran.should eq(["before_save", "before_save_again"])
+    operation.callbacks_that_ran.should eq([] of String)
   end
 
   it "runs all callbacks when saving successfully" do
@@ -115,12 +159,13 @@ describe "Avram::SaveOperation callbacks" do
     ])
   end
 
-  it "runs before_save validations on required fields" do
+  it "runs before_save when validations fail" do
     operation = CallbacksSaveOperation.new(skip_set_required: true)
     operation.callbacks_that_ran.should eq([] of String)
 
-    operation.valid?.should eq false
+    operation.save
 
+    operation.valid?.should eq false
     operation.callbacks_that_ran.should eq(["before_save", "before_save_again"])
   end
 
@@ -131,6 +176,22 @@ describe "Avram::SaveOperation callbacks" do
       operation.loaded.should be_true
       operation.saved?.should be_true
       record.should be_a(LineItem)
+    end
+  end
+
+  it "skips running specified callbacks" do
+    post = PostBox.create &.title("Existing Post")
+    params = Avram::Params.new({"title" => "A fancy post"})
+
+    UpdateOperationWithSkipCallbacks.update(post, params) do |operation, updated_post|
+      updated_post.should_not eq nil
+      updated_post.not_nil!.title.should eq "A fancy post"
+
+      operation.callbacks_that_ran.should eq([
+        "before_save_in_a_block",
+        "after_save_in_a_block with A fancy post",
+        "after_commit_in_a_block with A fancy post",
+      ])
     end
   end
 end

--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -107,7 +107,7 @@ describe Avram::Validations do
       operation.name.value = existing_user.name
       operation.nickname.value = existing_user.nickname.not_nil!.downcase
 
-      operation.valid?
+      operation.save
 
       operation.name.errors.should contain "is already taken"
       operation.nickname.errors.should contain "is already taken"

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -251,7 +251,7 @@ module Avram::Callbacks
     {%
       if block.args.size != 1
         raise <<-ERR
-        The 'after_commit' callback requires only 1 block arg to be passed.
+        The 'after_commit' callback requires exactly 1 block arg to be passed.
         Example:
           after_commit do |saved_user|
             some_method(saved_user)

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -18,6 +18,12 @@ module Avram::Callbacks
     end
   end
 
+  # Redefines the given `method_name` to do nothing
+  macro skip_before_save(method_name)
+    def {{ method_name.id }}
+    end
+  end
+
   # Run the given method before `run` is called on an `Operation`.
   #
   # ```
@@ -97,14 +103,57 @@ module Avram::Callbacks
   # > back the record may not be persisted to the database.
   # > Instead use `after_commit`
   macro after_save(method_name)
-    def after_save(object)
+    after_save do |object|
+      {{ method_name.id }}(object)
+    end
+  end
+
+  # Redefines the given `method_name` method to do nothing
+  macro skip_after_save(method_name)
+    def {{ method_name.id }}(_object)
+    end
+  end
+
+  # Run the given block after save, but before transaction is committed
+  #
+  # This is a great place to do other database saves because if something goes
+  # wrong the whole transaction would be rolled back.
+  #
+  # The newly saved record will be passed to the method.
+  #
+  # ```
+  # class SaveComment < Comment::SaveOperation
+  #   after_save do |comment|
+  #     SavePost.update!(comment.post!, updated_at: Time.utc)
+  #   end
+  # end
+  # ```
+  #
+  # > This is *not* a good place to do things like send messages, enqueue
+  # > background jobs, or charge payments. Since the transaction could be rolled
+  # > back the record may not be persisted to the database.
+  # > Instead use `after_commit`
+  macro after_save(&block)
+    {%
+      if block.args.size != 1
+        raise <<-ERR
+        The 'after_save' callback requires exactly 1 block arg to be passed.
+        Example:
+          after_save do |saved_user|
+            some_method(saved_user)
+          end
+        ERR
+      end
+    %}
+    def after_save(%object : T)
       {% if @type.methods.map(&.name).includes?(:after_save.id) %}
         previous_def
       {% else %}
         super
       {% end %}
 
-      {{ method_name.id }}(object)
+      {{ block.args.first }} = %object
+      {{ block.body }}
     end
   end
 
@@ -176,36 +225,51 @@ module Avram::Callbacks
   # ```
   #
   macro after_commit(method_name)
-    def after_commit(object)
+    after_commit do |object|
+      {{ method_name.id }}(object)
+    end
+  end
+
+  # Redefines the given `method_name` method to do nothing
+  macro skip_after_commit(method_name)
+    def {{ method_name.id }}(_object)
+    end
+  end
+
+  # Run the given block after save and after successful transaction commit
+  #
+  # The newly saved record will be passed to the method.
+  #
+  # ```
+  # class SaveComment < Comment::SaveOperation
+  #   after_commit do |comment|
+  #     NewCommentNotificationEmail.new(comment, to: comment.author!).deliver_now
+  #   end
+  # end
+  # ```
+  macro after_commit(&block)
+    {%
+      if block.args.size != 1
+        raise <<-ERR
+        The 'after_commit' callback requires only 1 block arg to be passed.
+        Example:
+          after_commit do |saved_user|
+            some_method(saved_user)
+          end
+        ERR
+      end
+    %}
+    def after_commit(%object : T)
       {% if @type.methods.map(&.name).includes?(:after_commit.id) %}
         previous_def
       {% else %}
         super
       {% end %}
 
-      {{ method_name.id }}(object)
+      {{ block.args.first }} = %object
+      {{ block.body }}
     end
   end
-
-  {% for callback_without_block in [:after_save, :after_commit] %}
-    # :nodoc:
-    macro {{ callback_without_block.id }}
-      \{% raise <<-ERROR
-        '{{callback_without_block.id}}' does not accept a block. Instead give it a method name to run.
-
-        Example:
-
-            {{callback_without_block.id}} run_something
-
-            def run_something(newly_saved_record)
-              # Do something
-            end
-        ERROR
-      %}
-      # Will never be called but must be there so that the macro accepts a block:
-      \{{ yield }}
-    end
-  {% end %}
 
   {% for removed_callback in [:create, :update] %}
     # :nodoc:

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -214,11 +214,9 @@ abstract class Avram::SaveOperation(T)
     end
   end
 
-  # Runs `before_save` steps,
-  # required validation, then returns `true` if all attributes are valid.
+  # Runs required validation,
+  # then returns `true` if all attributes are valid.
   def valid? : Bool
-    before_save
-
     # These validations must be ran after all `before_save` callbacks have completed
     # in the case that someone has set a required field in a `before_save`. If we run
     # this in a `before_save` ourselves, the ordering would cause this to be ran first.
@@ -314,6 +312,7 @@ abstract class Avram::SaveOperation(T)
   end
 
   def save : Bool
+    before_save
     if valid? && (!persisted? || changes.any?)
       transaction_committed = database.transaction do
         insert_or_update


### PR DESCRIPTION
This PR is the next in the series for https://github.com/luckyframework/avram/pull/369 which covers a few things related to callbacks.

Fixes #480 

* Fixes using `after_save` and `after_commit` with blocks which previously raised errors.
* Added new `skip_before_save`, `skip_after_save`, and `skip_after_commit` methods that allow for skipping named callbacks. Not able to skip block callbacks.
* Breaks calling the `valid?` method to run the `before_save` callbacks. 

For a little more info on that last item, the current implementation allows you to manually call `valid?` which will [run before_save callbacks](https://github.com/luckyframework/avram/blob/master/src/avram/save_operation.cr#L220). Right now it's possible that before_save could be called [here](https://github.com/luckyframework/avram/blob/master/src/avram/save_operation.cr#L317), and [here](https://github.com/luckyframework/avram/blob/master/src/avram/save_operation.cr#L338) if the first condition failed.

By moving the `before_save` to the actual `save` method, it now only runs once. We call `save` internally when calling `SaveOp.create` or `SaveOp.update`, and the `valid?` method is called by the `save` method. This means that as long as you use the SaveOperations like normal, then everything should be fine, but if you need to instantiate a SaveOperation, and call `valid?` manually, then things may get a little weird. 

Another one I wanted to fix was https://github.com/luckyframework/avram/issues/432 but there's a bit to discuss on this one as well. Currently if you call `SaveOp.update(thing)`, but the `thing` doesn't have any updates, then no SQL is ran. This is nice because it faster, and saves on query. The downside is that your `after_save` and `after_commit` callbacks will never run. As the issue indicates, some people may want these to run, but we document our `after_save` callback that it's save to run other saves since the whole thing could be rolled back. If no DB query is actually made, then there's no rollback that happens.

We have a few options that I can think of here:

* Run the `after_save` in that second branch, but wrap it in some catch to tell this parent SaveOp that it failed if the after_saves fail or whatever... Then if it succeeds we run the after_commit.
* Just add in the after_save and after_commit but let the user figure out their own specifics (this just sounds like asking for trouble)
* Technically, `SaveOperation` has access to `after_run`, it's just never called. We could add that in as a "hey, no DB stuff happened, but you can still run this other callback".
* Leave as is and just document that this is a side affect

The first option seems like the most plausible to me as far as fixing the issue, but it also makes me think things may get a bit more complicated with that conditional branch.

