### PR TITLE
Operation cleanup

### DIFF
--- a/spec/operations/define_attribute_spec.cr
+++ b/spec/operations/define_attribute_spec.cr
@@ -1,4 +1,4 @@
-require "./spec_helper"
+require "../spec_helper"
 
 private class OperationWithAttributes < Avram::Operation
   param_key :data

--- a/spec/operations/nested_save_operation_spec.cr
+++ b/spec/operations/nested_save_operation_spec.cr
@@ -1,4 +1,4 @@
-require "./spec_helper"
+require "../spec_helper"
 
 private class SaveBusiness < Business::SaveOperation
   permit_columns name

--- a/spec/operations/operation_callbacks_spec.cr
+++ b/spec/operations/operation_callbacks_spec.cr
@@ -1,4 +1,4 @@
-require "./spec_helper"
+require "../spec_helper"
 
 module TestableOperation
   macro included

--- a/spec/operations/operation_needs_spec.cr
+++ b/spec/operations/operation_needs_spec.cr
@@ -1,4 +1,4 @@
-require "./spec_helper"
+require "../spec_helper"
 
 private class OperationWithNeeds < Avram::Operation
   needs tags : Array(String)

--- a/spec/operations/operation_spec.cr
+++ b/spec/operations/operation_spec.cr
@@ -1,4 +1,4 @@
-require "./spec_helper"
+require "../spec_helper"
 
 private class TestOperation < Avram::Operation
   attribute name : String

--- a/spec/operations/save_operation_callbacks_spec.cr
+++ b/spec/operations/save_operation_callbacks_spec.cr
@@ -1,4 +1,4 @@
-require "./spec_helper"
+require "../spec_helper"
 
 module TestableOperation
   macro included

--- a/spec/operations/save_operation_spec.cr
+++ b/spec/operations/save_operation_spec.cr
@@ -1,4 +1,4 @@
-require "./spec_helper"
+require "../spec_helper"
 
 private class SaveUser < User::SaveOperation
   # There was a bug where adding a non-database attribute would make it so

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -271,18 +271,6 @@ module Avram::Callbacks
     end
   end
 
-  {% for removed_callback in [:create, :update] %}
-    # :nodoc:
-    macro after_{{ removed_callback.id }}(method_name)
-      \{% raise "'after_{{removed_callback.id}}' has been removed" %}
-    end
-
-    # :nodoc:
-    macro before_{{ removed_callback.id }}(method_name)
-      \{% raise "'before_{{removed_callback.id}}' has been removed" %}
-    end
-  {% end %}
-
   # :nodoc:
   macro before(callback_method)
     {% raise <<-ERROR

--- a/src/avram/define_attribute.cr
+++ b/src/avram/define_attribute.cr
@@ -34,14 +34,6 @@ module Avram::DefineAttribute
 
   ensure_base_attributes_method_is_present
 
-  macro allow_virtual(*args, **named_args)
-    {% raise "'allow_virtual' has been renamed to 'attribute'" %}
-  end
-
-  macro virtual(*args, **named_args)
-    {% raise "'virtual' has been renamed to 'attribute'" %}
-  end
-
   macro attribute(type_declaration)
     {% if type_declaration.type.is_a?(Union) %}
       {% raise "attribute must use just one type" %}

--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -13,10 +13,6 @@ module Avram::NeedyInitializerAndSaveMethods
     property {{ type_declaration.var }}
   end
 
-  macro needs(type_declaration, on)
-    {% on.raise "The 'on' option is no longer supported. Please use needs without 'on' instead." %}
-  end
-
   macro inherit_needs
     \{% if !@type.constant(:OPERATION_NEEDS) %}
       OPERATION_NEEDS = [] of Nil

--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -1,10 +1,5 @@
 class Avram::SaveOperationTemplate
   macro setup(type, columns, table_name, primary_key_type, primary_key_name, *args, **named_args)
-    class ::{{ type }}::BaseForm
-      macro inherited
-        \{% raise "BaseForm has been renamed to SaveOperation. Please inherit from {{ type }}::SaveOperation." %}
-      end
-    end
 
     # This makes it easy for plugins and extensions to use the base SaveOperation
     def base_query_class : ::{{ type }}::BaseQuery.class


### PR DESCRIPTION
This PR is the next in the series for https://github.com/luckyframework/avram/pull/369 which doesn't really add anything. This is more of a general cleanup start. I didn't want to get too crazy.

* Remove all the remnants of the old Forms and past Operation stuff that's been gone for a few versions now
* Moved all the operation related specs to its own folder for a bit of organization.

I didn't move the attribute or the validation specs. I was on the fence, but If anyone has a preference I could go either way. 

On a side note, this is just related to Operations, but I'd eventually like to do this for all sections (i.e. models, queries, etc...)