### PR TITLE
Add compile-time error when passing a raw Hash in to SaveOperation.create/update

### DIFF
--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -80,7 +80,30 @@ module Avram::NeedyInitializerAndSaveMethods
     generate_save_methods({{ attribute_method_args }}, {{ attribute_params }})
   end
 
+  macro hash_is_not_allowed_helpful_error(method)
+    {% raise <<-ERROR
+      You can't pass a Hash directly to #{method.id}. Instead pass named arguments, or convert the hash to params.
+
+      Try this...
+
+        * Pass named arguments - #{@type}.#{method.id}(title: "My Title")
+        * Convert hash to params - Avram::Params.new({"title" => "My Title"})
+
+      ERROR
+    %}
+  end
+
   macro generate_create(attribute_method_args, attribute_params, with_params, with_bang)
+    def self.create{% if with_bang %}!{% end %}(
+      params : Hash, **named_args
+    )
+      {% if with_bang %}
+      {% else %}
+        yield nil, nil
+      {% end %}
+      hash_is_not_allowed_helpful_error(:create{% if with_bang %}!{% end %})
+    end
+
     def self.create{% if with_bang %}!{% end %}(
       {% if with_params %}params,{% end %}
       {% for type_declaration in OPERATION_NEEDS %}
@@ -110,6 +133,18 @@ module Avram::NeedyInitializerAndSaveMethods
   end
 
   macro generate_update(attribute_method_args, attribute_params, with_params, with_bang)
+    def self.update{% if with_bang %}!{% end %}(
+      record : T,
+      params : Hash,
+      **named_args
+    )
+      {% if with_bang %}
+      {% else %}
+        yield nil, nil
+      {% end %}
+      hash_is_not_allowed_helpful_error(:update{% if with_bang %}!{% end %})
+    end
+
     def self.update{% if with_bang %}!{% end %}(
         record : T,
         {% if with_params %}with params,{% end %}


### PR DESCRIPTION
Fixes #313 

A part of the https://github.com/luckyframework/avram/pull/369 series. This is just an extra development level catch in case you pass a raw hash in to a SaveOperation create or update. I tested this by adding a spec that does it. 

On a side note, testing compile-time errors is impossible. I wonder if we should create a spec directory with commented out tests that would be designed for just having a way to make sure they work the way we think... 🤔  it would be a little weird and messy, but something to think about.