### PR TITLE
Clarify which method is preferred + fix update example

### DIFF
--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -86,8 +86,8 @@ module Avram::NeedyInitializerAndSaveMethods
 
       Try this...
 
-        * Pass named arguments - #{@type}.#{method.id}(title: "My Title")
-        * Convert hash to params - Avram::Params.new({"title" => "My Title"})
+        * Use named arguments (recommended)  - #{@type}.#{method.id}(title: "My Title")
+        * Convert hash to params (not as safe) - Avram::Params.new({"title" => "My Title"})
 
       ERROR
     %}

--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -80,13 +80,13 @@ module Avram::NeedyInitializerAndSaveMethods
     generate_save_methods({{ attribute_method_args }}, {{ attribute_params }})
   end
 
-  macro hash_is_not_allowed_helpful_error(method)
+  macro hash_is_not_allowed_helpful_error(method, additional_args = nil)
     {% raise <<-ERROR
       You can't pass a Hash directly to #{method.id}. Instead pass named arguments, or convert the hash to params.
 
       Try this...
 
-        * Use named arguments (recommended)  - #{@type}.#{method.id}(title: "My Title")
+        * Use named arguments (recommended) - #{@type}.#{method.id}(#{additional_args.id if additional_args}title: "My Title")
         * Convert hash to params (not as safe) - Avram::Params.new({"title" => "My Title"})
 
       ERROR
@@ -142,7 +142,7 @@ module Avram::NeedyInitializerAndSaveMethods
       {% else %}
         yield nil, nil
       {% end %}
-      hash_is_not_allowed_helpful_error(:update{% if with_bang %}!{% end %})
+      hash_is_not_allowed_helpful_error(:update{% if with_bang %}!{% end %}, additional_args: "record, ")
     end
 
     def self.update{% if with_bang %}!{% end %}(


### PR DESCRIPTION
Make it clearer which one is preferred. The hash conversion may be useful in some spots but named args are better in the vast majority of cases because it can catch errors with column names, or value types. The hash on the other hand can have incorrect keys or values

Also adds `record` to the update example

<img width="1019" alt="Screen Shot 2020-10-21 at 3 26 26 PM" src="https://user-images.githubusercontent.com/22394/96772960-e0684100-13b1-11eb-80a5-105a49289a56.png">
