### PR TITLE
Add ability to use custom association names

### DIFF
--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -102,6 +102,9 @@ describe Avram::Model do
         post = PostWithCustomTable::SaveOperation.create!(title: "foo")
         comment = CommentForCustomPost::SaveOperation.create!(body: "bar", post_id: post.id)
         comment.post_with_custom_table.should eq(post)
+
+        CommentForCustomPost::BaseQuery.new.where_post_with_custom_table(PostWithCustomTable::BaseQuery.new.id(post.id)).first.should eq(comment)
+        PostWithCustomTable::BaseQuery.new.where_comments_for_custom_post(CommentForCustomPost::BaseQuery.new.id(comment.id)).first.should eq(post)
       end
     end
 

--- a/spec/preloading_spec.cr
+++ b/spec/preloading_spec.cr
@@ -145,10 +145,10 @@ describe "Preloading" do
       LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)
       LineItemProductBox.create &.line_item_id(other_item.id).product_id(product.id)
 
-      item_products = LineItemQuery.new.preload_products.results.first.products
+      associated_products = LineItemQuery.new.preload_associated_products.results.first.associated_products
 
-      item_products.size.should eq(1)
-      item_products.should eq([product])
+      associated_products.size.should eq(1)
+      associated_products.should eq([product])
     end
   end
 

--- a/spec/query_associations_spec.cr
+++ b/spec/query_associations_spec.cr
@@ -156,7 +156,7 @@ describe "Query associations" do
       .id(item.id)
       .where_products(ProductQuery.new.id(product.id))
     result = LineItemProductQuery.new
-      .where_line_items(line_item_query)
+      .where_line_item(line_item_query)
       .find(line_item_product.id)
 
     result.should eq(line_item_product)

--- a/spec/query_associations_spec.cr
+++ b/spec/query_associations_spec.cr
@@ -154,7 +154,7 @@ describe "Query associations" do
 
     line_item_query = LineItemQuery.new
       .id(item.id)
-      .where_products(ProductQuery.new.id(product.id))
+      .where_associated_products(ProductQuery.new.id(product.id))
     result = LineItemProductQuery.new
       .where_line_item(line_item_query)
       .find(line_item_product.id)

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -801,7 +801,7 @@ describe Avram::Query do
       post = PostBox.create
       CommentBox.new.post_id(post.id).create
 
-      query = Comment::BaseQuery.new.join_posts
+      query = Comment::BaseQuery.new.join_post
       query.to_sql.should eq ["SELECT comments.custom_id, comments.created_at, comments.updated_at, comments.body, comments.post_id FROM comments INNER JOIN posts ON comments.post_id = posts.custom_id"]
 
       result = query.first
@@ -812,7 +812,7 @@ describe Avram::Query do
       query = Comment::BaseQuery.new
       original_query_sql = query.to_sql
 
-      query.join_posts
+      query.join_post
 
       query.to_sql.should eq original_query_sql
     end
@@ -863,7 +863,7 @@ describe Avram::Query do
     it "left join on belongs to" do
       employee = EmployeeBox.create
 
-      query = Employee::BaseQuery.new.left_join_managers
+      query = Employee::BaseQuery.new.left_join_manager
       query.to_sql.should eq ["SELECT employees.id, employees.created_at, employees.updated_at, employees.name, employees.manager_id FROM employees LEFT JOIN managers ON employees.manager_id = managers.id"]
 
       result = query.first
@@ -874,7 +874,7 @@ describe Avram::Query do
       query = Employee::BaseQuery.new
       original_query_sql = query.to_sql
 
-      query.left_join_managers
+      query.left_join_manager
 
       query.to_sql.should eq original_query_sql
     end
@@ -1226,7 +1226,7 @@ describe Avram::Query do
         line_item = LineItemBox.create &.name("Thing 1")
         price = PriceBox.create &.in_cents(100).line_item_id(line_item.id)
 
-        query = PriceQuery.new.where_line_items(LineItemQuery.new.name("Thing 1"))
+        query = PriceQuery.new.where_line_item(LineItemQuery.new.name("Thing 1"))
         query.first.should eq price
       end
     end

--- a/spec/support/comment.cr
+++ b/spec/support/comment.cr
@@ -16,9 +16,7 @@ class CommentForCustomPost < BaseModel
     primary_key custom_id : Int64
     timestamps
     column body : String
-    belongs_to post_with_custom_table : PostWithCustomTable,
-      table: :posts,
-      foreign_key: :post_id
+    belongs_to post_with_custom_table : PostWithCustomTable, foreign_key: :post_id
   end
 end
 

--- a/spec/support/line_item.cr
+++ b/spec/support/line_item.cr
@@ -8,7 +8,7 @@ class LineItem < BaseModel
     has_one price : Price?
     has_many scans : Scan
     has_many line_items_products : LineItemProduct
-    has_many products : Product, through: :line_items_products
+    has_many associated_products : Product, through: :line_items_products, source: :product
   end
 end
 

--- a/spec/support/post.cr
+++ b/spec/support/post.cr
@@ -25,5 +25,6 @@ class PostWithCustomTable < BaseModel
 
     column title : String
     column published_at : Time?
+    has_many comments_for_custom_post : CommentForCustomPost, foreign_key: "post_id"
   end
 end

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -1,5 +1,5 @@
 module Avram::Associations::BelongsTo
-  macro belongs_to(type_declaration, foreign_key = nil, table = nil)
+  macro belongs_to(type_declaration, foreign_key = nil)
     {% assoc_name = type_declaration.var %}
 
     {% if type_declaration.type.is_a?(Union) %}
@@ -14,14 +14,10 @@ module Avram::Associations::BelongsTo
       {% foreign_key = "#{assoc_name}_id".id %}
     {% end %}
 
-    {% if !table %}
-      {% table = run("../../run_macros/infer_table_name.cr", model.id) %}
-    {% end %}
-
     column {{ foreign_key.id }} : {{ model }}::PrimaryKeyType{% if nilable %}?{% end %}
 
     association \
-      table_name: :{{ table.id }},
+      assoc_name: :{{ assoc_name.id }},
       type: {{ model }},
       foreign_key: :{{ foreign_key.id }},
       relationship_type: :belongs_to

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -1,7 +1,13 @@
 module Avram::Associations::HasMany
-  macro has_many(type_declaration, through = nil, foreign_key = nil)
+  macro has_many(type_declaration, through = nil, source = nil, foreign_key = nil)
     {% if !through.is_a?(NilLiteral) && !through.is_a?(SymbolLiteral) %}
       {% through.raise "The association name for 'through' must be a Symbol. Instead, got: #{through}" %}
+    {% end %}
+    {% if !source.is_a?(NilLiteral) && !source.is_a?(SymbolLiteral) %}
+      {% source.raise "The value for 'source' must be a Symbol. Instead, got: #{source}" %}
+    {% end %}
+    {% if !source.is_a?(NilLiteral) && through.is_a?(NilLiteral) %}
+      {% source.raise "Source must only be specified when defining a has many through relationship." %}
     {% end %}
     {% assoc_name = type_declaration.var %}
 
@@ -16,6 +22,7 @@ module Avram::Associations::HasMany
       type: {{ type_declaration.type }},
       foreign_key: :{{ foreign_key }},
       through: {{ through }},
+      source: {{ source }},
       relationship_type: :has_many
 
     {% model = type_declaration.type %}

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -12,7 +12,7 @@ module Avram::Associations::HasMany
     {% foreign_key = foreign_key.id %}
 
     association \
-      table_name: :{{ assoc_name }},
+      assoc_name: :{{ assoc_name }},
       type: {{ type_declaration.type }},
       foreign_key: :{{ foreign_key }},
       through: {{ through }},

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -17,7 +17,7 @@ module Avram::Associations::HasOne
     {% foreign_key = foreign_key.id %}
 
     association \
-      table_name: :{{ type_declaration.var }},
+      assoc_name: :{{ assoc_name.id }},
       type: {{ model }},
       foreign_key: {{ foreign_key }},
       relationship_type: :has_one

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -113,8 +113,15 @@ class Avram::BaseQueryTemplate
               {{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
                 .__yield_where_{{ assoc[:through].id }} do |join_query|
                   {% if assoc[:source].is_a?(NilLiteral) %}
-                    {% singular_association_name = run("../run_macros/singularize_word.cr", assoc[:assoc_name]) %}
-                    join_query.{{ join_type.downcase.id }}_join_{{ singular_association_name.id }}
+                    # check if the join query has a has_many joins method (default)
+                    if join_query.responds_to?(:{{ join_type.downcase.id }}_join_{{ assoc[:assoc_name].id }})
+                      # through a has_many association
+                      join_query.{{ join_type.downcase.id }}_join_{{ assoc[:assoc_name].id }}
+                    else
+                      # through a belongs_to association
+                      {% singular_association_name = run("../run_macros/singularize_word.cr", assoc[:assoc_name]) %}
+                      join_query.{{ join_type.downcase.id }}_join_{{ singular_association_name.id }}
+                    end
                   {% else %}
                     join_query.{{ join_type.downcase.id }}_join_{{ assoc[:source].id }}
                   {% end %}

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -85,17 +85,17 @@ class Avram::BaseQueryTemplate
       {% end %}
 
       {% for assoc in associations %}
-        def join_{{ assoc[:table_name] }}
-          inner_join_{{ assoc[:table_name] }}
+        def join_{{ assoc[:assoc_name] }}
+          inner_join_{{ assoc[:assoc_name] }}
         end
 
         {% for join_type in ["Inner", "Left", "Right", "Full"] %}
-          def {{ join_type.downcase.id }}_join_{{ assoc[:table_name] }}
+          def {{ join_type.downcase.id }}_join_{{ assoc[:assoc_name] }}
             {% if assoc[:relationship_type] == :belongs_to %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: @@table_name,
-                  to: :{{ assoc[:table_name] }},
+                  to: {{ assoc[:type] }}::TABLE_NAME,
                   primary_key: {{ assoc[:foreign_key] }},
                   foreign_key: {{ assoc[:type] }}::PRIMARY_KEY_NAME
                 )
@@ -112,13 +112,14 @@ class Avram::BaseQueryTemplate
             {% elsif assoc[:through] %}
               {{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
                 .__yield_where_{{ assoc[:through].id }} do |join_query|
-                  join_query.{{ join_type.downcase.id }}_join_{{ assoc[:table_name] }}
+                  {% singular_association_name = run("../run_macros/singularize_word.cr", assoc[:assoc_name]) %}
+                  join_query.{{ join_type.downcase.id }}_join_{{ singular_association_name.id }}
                 end
             {% else %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: @@table_name,
-                  to: :{{ assoc[:table_name] }},
+                  to: {{ assoc[:type] }}::TABLE_NAME,
                   foreign_key: {{ assoc[:foreign_key] }},
                   primary_key: primary_key_name
                 )
@@ -128,9 +129,9 @@ class Avram::BaseQueryTemplate
         {% end %}
 
 
-        def where_{{ assoc[:table_name] }}(assoc_query : {{ assoc[:type] }}::BaseQuery, auto_inner_join : Bool = true)
+        def where_{{ assoc[:assoc_name] }}(assoc_query : {{ assoc[:type] }}::BaseQuery, auto_inner_join : Bool = true)
           if auto_inner_join
-            join_{{ assoc[:table_name] }}.merge_query(assoc_query.query)
+            join_{{ assoc[:assoc_name] }}.merge_query(assoc_query.query)
           else
             merge_query(assoc_query.query)
           end
@@ -138,12 +139,12 @@ class Avram::BaseQueryTemplate
 
         # :nodoc:
         # Used internally for has_many through queries
-        def __yield_where_{{ assoc[:table_name] }}
+        def __yield_where_{{ assoc[:assoc_name] }}
           assoc_query = yield {{ assoc[:type] }}::BaseQuery.new
           merge_query(assoc_query.query)
         end
 
-        def {{ assoc[:table_name] }}
+        def {{ assoc[:assoc_name] }}
           \{% raise <<-ERROR
             The methods for querying associations have changed
 
@@ -152,7 +153,7 @@ class Avram::BaseQueryTemplate
 
             Example:
 
-              where_{{ assoc[:table_name] }}({{ assoc[:type] }}Query.new.some_condition)
+              where_{{ assoc[:assoc_name] }}({{ assoc[:type] }}Query.new.some_condition)
             ERROR
           %}
           yield # This is not used. Just there so it works with blocks.

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -112,8 +112,12 @@ class Avram::BaseQueryTemplate
             {% elsif assoc[:through] %}
               {{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
                 .__yield_where_{{ assoc[:through].id }} do |join_query|
-                  {% singular_association_name = run("../run_macros/singularize_word.cr", assoc[:assoc_name]) %}
-                  join_query.{{ join_type.downcase.id }}_join_{{ singular_association_name.id }}
+                  {% if assoc[:source].is_a?(NilLiteral) %}
+                    {% singular_association_name = run("../run_macros/singularize_word.cr", assoc[:assoc_name]) %}
+                    join_query.{{ join_type.downcase.id }}_join_{{ singular_association_name.id }}
+                  {% else %}
+                    join_query.{{ join_type.downcase.id }}_join_{{ assoc[:source].id }}
+                  {% end %}
                 end
             {% else %}
               join(

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -265,7 +265,7 @@ abstract class Avram::Model
     end
   end
 
-  macro association(table_name, type, relationship_type, foreign_key = nil, through = nil)
-    {% ASSOCIATIONS << {type: type, table_name: table_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through} %}
+  macro association(assoc_name, type, relationship_type, foreign_key = nil, through = nil)
+    {% ASSOCIATIONS << {type: type, assoc_name: assoc_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through} %}
   end
 end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -265,7 +265,7 @@ abstract class Avram::Model
     end
   end
 
-  macro association(assoc_name, type, relationship_type, foreign_key = nil, through = nil)
-    {% ASSOCIATIONS << {type: type, assoc_name: assoc_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through} %}
+  macro association(assoc_name, type, relationship_type, foreign_key = nil, through = nil, source = nil)
+    {% ASSOCIATIONS << {type: type, assoc_name: assoc_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through, source: source} %}
   end
 end

--- a/src/run_macros/singularize_word.cr
+++ b/src/run_macros/singularize_word.cr
@@ -1,0 +1,3 @@
+require "wordsmith"
+
+print Wordsmith::Inflector.singularize(ARGV[0])


### PR DESCRIPTION
Fixes #473 

This updates Avram associations to always use the given association name rather than the underlying types table name where ever possible.

## Breaking Changes

We always used the table name when generating `where_xxx` methods, now we always use the association name. The most common way this will break will be for `belongs_to` relationships.

With a model like

```crystal
class Book
  table do
    belongs_to user : User
  end
end
```

### Before

```crystal
# notice the pluralization because it used the table name
BookQuery.new.where_users(...)
```

### After

```crystal
# singular because it used the association name given in the model
BookQuery.new.where_user(...)
```