### PR TITLE
Adding conditional callbacks

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -39,7 +39,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13.1
+    branch: master
 
 scripts:
   postinstall: script/precompile_tasks

--- a/spec/operations/save_operation_callbacks_spec.cr
+++ b/spec/operations/save_operation_callbacks_spec.cr
@@ -128,16 +128,16 @@ end
 private class UpdateOperationWithSkipCallbacks < SaveOperationWithCallbacks
   permit_columns :title
 
-  before_save(unless: :skip_callback) { mark_callback("before_save_in_a_block2") }
-  after_save(unless: :skip_callback) do |saved_post|
+  before_save(unless: :skip_callback?) { mark_callback("before_save_in_a_block2") }
+  after_save(unless: :skip_callback?) do |saved_post|
     mark_callback("after_save_in_a_block with #{saved_post.title}2")
   end
-  after_commit(unless: :skip_callback) do |saved_post|
+  after_commit(unless: :skip_callback?) do |saved_post|
     mark_callback("after_commit_in_a_block with #{saved_post.title}2")
   end
 
   # skip all the blocks
-  private def skip_callback
+  private def skip_callback?
     true
   end
 

--- a/spec/operations/save_operation_callbacks_spec.cr
+++ b/spec/operations/save_operation_callbacks_spec.cr
@@ -86,17 +86,29 @@ end
 private class SaveOperationWithCallbacks < Post::SaveOperation
   include TestableOperation
 
-  before_save :set_title
+  before_save :set_title, if: :title_is_needed?
   before_save { mark_callback("before_save_in_a_block") }
 
-  after_save :notify_save_complete
+  after_save :notify_save_complete, unless: :already_notified?
   after_save do |saved_post|
     mark_callback("after_save_in_a_block with #{saved_post.title}")
   end
 
-  after_commit :notify_commit_complete
+  after_commit :notify_commit_complete, if: :finalize_commit?
   after_commit do |saved_post|
     mark_callback("after_commit_in_a_block with #{saved_post.title}")
+  end
+
+  private def title_is_needed?
+    true
+  end
+
+  private def already_notified?
+    false
+  end
+
+  private def finalize_commit?
+    true
   end
 
   private def set_title
@@ -115,6 +127,34 @@ end
 
 private class UpdateOperationWithSkipCallbacks < SaveOperationWithCallbacks
   permit_columns :title
+
+  before_save(unless: :skip_callback) { mark_callback("before_save_in_a_block2") }
+  after_save(unless: :skip_callback) do |saved_post|
+    mark_callback("after_save_in_a_block with #{saved_post.title}2")
+  end
+  after_commit(unless: :skip_callback) do |saved_post|
+    mark_callback("after_commit_in_a_block with #{saved_post.title}2")
+  end
+
+  # skip all the blocks
+  private def skip_callback
+    true
+  end
+
+  # skip before_save :set_title
+  private def title_is_needed?
+    false
+  end
+
+  # skip after_save :notify_save_complete
+  private def already_notified?
+    true
+  end
+
+  # skip after_commit :notify_commit_complete
+  private def finalize_commit?
+    false
+  end
 end
 
 describe "Avram::SaveOperation callbacks" do

--- a/spec/operations/save_operation_callbacks_spec.cr
+++ b/spec/operations/save_operation_callbacks_spec.cr
@@ -115,9 +115,6 @@ end
 
 private class UpdateOperationWithSkipCallbacks < SaveOperationWithCallbacks
   permit_columns :title
-  skip_before_save :set_title
-  skip_after_save :notify_save_complete
-  skip_after_commit :notify_commit_complete
 end
 
 describe "Avram::SaveOperation callbacks" do

--- a/spec/preloading_spec.cr
+++ b/spec/preloading_spec.cr
@@ -232,6 +232,18 @@ describe "Preloading" do
       2.times { posts.results }
     end
 
+    it "does not fail for has_many with custom query" do
+      post = PostBox.create
+      _another_post = PostBox.create
+      comment = CommentBox.create &.post_id(post.id)
+
+      posts = Post::BaseQuery.new.preload_comments(
+        Comment::BaseQuery.new.id.not.eq(comment.id)
+      )
+
+      2.times { posts.results }
+    end
+
     it "does not fail for has_one" do
       AdminBox.create
 

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -18,12 +18,6 @@ module Avram::Callbacks
     end
   end
 
-  # Redefines the given `method_name` to do nothing
-  macro skip_before_save(method_name)
-    def {{ method_name.id }}
-    end
-  end
-
   # Run the given method before `run` is called on an `Operation`.
   #
   # ```
@@ -105,12 +99,6 @@ module Avram::Callbacks
   macro after_save(method_name)
     after_save do |object|
       {{ method_name.id }}(object)
-    end
-  end
-
-  # Redefines the given `method_name` method to do nothing
-  macro skip_after_save(method_name)
-    def {{ method_name.id }}(_object)
     end
   end
 
@@ -227,12 +215,6 @@ module Avram::Callbacks
   macro after_commit(method_name)
     after_commit do |object|
       {{ method_name.id }}(object)
-    end
-  end
-
-  # Redefines the given `method_name` method to do nothing
-  macro skip_after_commit(method_name)
-    def {{ method_name.id }}(_object)
     end
   end
 


### PR DESCRIPTION
Fixes #483 

This PR does 2 things.
* It removes the `skip_*` macros that I just put in the other day
* It adds in the ability to conditionally run callbacks

You can read through the issue for more info, but a quick TL;DR: You can still skip callbacks, it's just done by override a method yourself instead of a macro doing it for you.

This allows us to now do things like this:

```crystal
abstract class SaveTransaction < Transaction::SaveOperation
  before_save :validate_card_number, if: :new_transaction?
  def validate_card_number
    card_number.value == 42
  end
end

class CreateTransaction < SaveTransaction
  permit_columns :card_number, :exp_date
  private def new_transaction?
    true
  end
end

class UpdateTransaction < SaveTransaction
  permit_columns :exp_date
  private def new_transaction?
    false
  end
end
```