### PR TITLE
Fix bugs in has_many through has_many associations

### DIFF
--- a/db/migrations/20201023161820_create_business_sales.cr
+++ b/db/migrations/20201023161820_create_business_sales.cr
@@ -1,0 +1,15 @@
+class CreateBusinessSales::V20201023161820 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(BusinessSale) do
+      primary_key id : Int64
+      add_timestamps
+
+      add name : String
+      add_belongs_to employee : Employee, on_delete: :cascade
+    end
+  end
+
+  def rollback
+    drop table_for(BusinessSale)
+  end
+end

--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -51,7 +51,7 @@ describe Avram::Model do
       post.tags.should eq [tag]
     end
 
-    it "count has_many through belongs_to associations" do
+    it "counts has_many through belongs_to associations" do
       tag = TagBox.create
       post = PostBox.create
       TagBox.create
@@ -60,7 +60,7 @@ describe Avram::Model do
       post.tags_count.should eq 1
     end
 
-    it "count has_many through has_many associations" do
+    it "counts has_many through has_many associations" do
       manager = ManagerBox.create
       employee = EmployeeBox.new.manager_id(manager.id).create
       BusinessSaleBox.new.employee_id(employee.id).create

--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -15,11 +15,14 @@ describe Avram::Model do
     it "gets the related records for nilable association that exists" do
       manager = ManagerBox.create
       employee = EmployeeBox.new.manager_id(manager.id).create
+      business_sale = BusinessSaleBox.new.employee_id(employee.id).create
 
       manager = Manager::BaseQuery.new.find(manager.id)
 
       manager.employees.to_a.should eq [employee]
       employee.manager.should eq manager
+      employee.business_sales.should eq [business_sale]
+      manager.business_sales.should eq [business_sale]
     end
 
     it "returns nil for nilable association that doesn't exist" do
@@ -48,13 +51,21 @@ describe Avram::Model do
       post.tags.should eq [tag]
     end
 
-    it "count through associations" do
+    it "count has_many through belongs_to associations" do
       tag = TagBox.create
       post = PostBox.create
       TagBox.create
       TaggingBox.new.tag_id(tag.id).post_id(post.id).create
 
       post.tags_count.should eq 1
+    end
+
+    it "count has_many through has_many associations" do
+      manager = ManagerBox.create
+      employee = EmployeeBox.new.manager_id(manager.id).create
+      business_sale = BusinessSaleBox.new.employee_id(employee.id).create
+
+      manager.business_sales_count.should eq 1
     end
   end
 

--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -63,7 +63,7 @@ describe Avram::Model do
     it "count has_many through has_many associations" do
       manager = ManagerBox.create
       employee = EmployeeBox.new.manager_id(manager.id).create
-      business_sale = BusinessSaleBox.new.employee_id(employee.id).create
+      BusinessSaleBox.new.employee_id(employee.id).create
 
       manager.business_sales_count.should eq 1
     end

--- a/spec/preloading_spec.cr
+++ b/spec/preloading_spec.cr
@@ -120,7 +120,7 @@ describe "Preloading" do
     end
   end
 
-  it "preloads has_many through" do
+  it "preloads has_many through a belongs_to relationship" do
     with_lazy_load(enabled: false) do
       tag = TagBox.create
       TagBox.create # unused tag
@@ -133,6 +133,19 @@ describe "Preloading" do
 
       post_tags.size.should eq(1)
       post_tags.should eq([tag])
+    end
+  end
+
+  it "preloads has_many through a has_many relationship" do
+    with_lazy_load(enabled: false) do
+      manager = ManagerBox.create
+      employee = EmployeeBox.new.manager_id(manager.id).create
+      business_sale = BusinessSaleBox.new.employee_id(employee.id).create
+
+      business_sales = Manager::BaseQuery.new.preload_business_sales.find(manager.id).business_sales
+
+      business_sales.size.should eq(1)
+      business_sales.should eq([business_sale])
     end
   end
 

--- a/spec/support/boxes/business_sale_box.cr
+++ b/spec/support/boxes/business_sale_box.cr
@@ -1,0 +1,5 @@
+class BusinessSaleBox < BaseBox
+  def initialize
+    name "The Big One"
+  end
+end

--- a/spec/support/business_sale.cr
+++ b/spec/support/business_sale.cr
@@ -1,0 +1,7 @@
+class BusinessSale < BaseModel
+  table do
+    column name : String
+    belongs_to employee : Employee
+    has_many managers : Manager, through: :employee
+  end
+end

--- a/spec/support/models/employee.cr
+++ b/spec/support/models/employee.cr
@@ -2,5 +2,6 @@ class Employee < BaseModel
   table do
     column name : String
     belongs_to manager : Manager?
+    has_many business_sales : BusinessSale
   end
 end

--- a/spec/support/models/manager.cr
+++ b/spec/support/models/manager.cr
@@ -2,5 +2,6 @@ class Manager < BaseModel
   table do
     column name : String
     has_many employees : Employee
+    has_many business_sales : BusinessSale, through: :employees
   end
 end

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -142,7 +142,6 @@ module Avram::Associations::HasMany
           # assume that the association is a has_many through a has_many association
           temp_query.preload_{{ singular_through.id }}.results
         end
-          
       {% else %}
         {{ model }}::BaseQuery
           .new

--- a/src/run_macros/singularize_word.cr
+++ b/src/run_macros/singularize_word.cr
@@ -1,0 +1,3 @@
+require "wordsmith"
+
+print Wordsmith::Inflector.singularize(ARGV[0])


### PR DESCRIPTION
Fixes: #496
Related: #196
Related: #494

There were three places that using a `has_many` through a `has_many` relationship was broken.

1. When lazy loading was on, accessing the relationship resulted in a compilation error
2. When calling `preload_xxx`, it was only handling a `belongs_to` flow
3. When calling `xxx_count`, there was a compilation error

All 3 of these suffered the same issue while number 2 had an extra problem.  They were all assuming that the association pointed back to the intermediary "through" association in a `has_many` way because the intermediary belonged to the association. That would not be the case in a `has_many` through a `has_many` because the association would belong to the intermediary.

## Solution

The solution was to singularize the association ("products" becomes "product") and start using the `responds_to?` method. We have rarely used this method in the codebase because it means we are determining the appropriate method to call at run time instead of compile time, but I cannot find a better way to accomplish this.