### PR TITLE
General core cleanup

### DIFF
--- a/spec/preloading_spec.cr
+++ b/spec/preloading_spec.cr
@@ -10,7 +10,7 @@ module QuerySpy
 
     def database : Avram::Database.class
       self.class.times_called += 1
-      previous_def
+      super
     end
   end
 end

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -47,7 +47,7 @@ module Avram::Associations::BelongsTo
   end
 
   private macro define_belongs_to_base_query(assoc_name, model, foreign_key)
-    class BaseQuery < Avram::Query
+    class BaseQuery < Avram::Query({{ @type.id }})
       def preload_{{ assoc_name }}
         preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -25,7 +25,7 @@ module Avram::Associations::HasMany
   end
 
   private macro define_has_many_base_query(assoc_name, model, foreign_key, through)
-    class BaseQuery < Avram::Query
+    class BaseQuery < Avram::Query({{ @type.id }})
       def preload_{{ assoc_name }}
         preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -44,7 +44,7 @@ module Avram::Associations::HasOne
   end
 
   private macro define_has_one_base_query(assoc_name, model, foreign_key)
-    class BaseQuery < Avram::Query
+    class BaseQuery < Avram::Query({{ @type.id }})
       def preload_{{ assoc_name }}
         preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -12,11 +12,14 @@ class Avram::BaseQueryTemplate
         {{ type }}.database
       end
 
+      def table_name
+        {{ table_name.id.symbolize }}
+      end
+
       def query_class
 
       end
 
-      @@table_name = :{{ table_name }}
       @@schema_class = {{ type }}
 
       # If not using default 'id' primary key
@@ -33,7 +36,7 @@ class Avram::BaseQueryTemplate
 
       macro generate_criteria_method(query_class, name, type)
         def \{{ name }}
-          column_name = "#{@@table_name}.\{{ name }}"
+          column_name = "#{table_name}.\{{ name }}"
           \{{ type }}::Lucky::Criteria(\{{ query_class }}, \{{ type }}).new(self, column_name)
         end
       end
@@ -94,7 +97,7 @@ class Avram::BaseQueryTemplate
             {% if assoc[:relationship_type] == :belongs_to %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
-                  from: @@table_name,
+                  from: table_name,
                   to: :{{ assoc[:table_name] }},
                   primary_key: {{ assoc[:foreign_key] }},
                   foreign_key: {{ assoc[:type] }}::PRIMARY_KEY_NAME
@@ -103,7 +106,7 @@ class Avram::BaseQueryTemplate
             {% elsif assoc[:relationship_type] == :has_one %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
-                  from: @@table_name,
+                  from: table_name,
                   to: {{ assoc[:type] }}::TABLE_NAME,
                   foreign_key: :{{ assoc[:foreign_key] }},
                   primary_key: primary_key_name
@@ -117,7 +120,7 @@ class Avram::BaseQueryTemplate
             {% else %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
-                  from: @@table_name,
+                  from: table_name,
                   to: :{{ assoc[:table_name] }},
                   foreign_key: {{ assoc[:foreign_key] }},
                   primary_key: primary_key_name

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -16,7 +16,9 @@ class Avram::BaseQueryTemplate
         {{ table_name.id.symbolize }}
       end
 
-      @@schema_class = {{ type }}
+      def schema_class
+        {{ type }}
+      end
 
       # If not using default 'id' primary key
       {% if primary_key_name.id != "id".id %}

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -8,18 +8,6 @@ class Avram::BaseQueryTemplate
       include Avram::Queryable({{ type }})
       include Avram::PrimaryKeyQueryable({{ type }})
 
-      def database : Avram::Database.class
-        {{ type }}.database
-      end
-
-      def table_name
-        {{ table_name.id.symbolize }}
-      end
-
-      def schema_class
-        {{ type }}
-      end
-
       # If not using default 'id' primary key
       {% if primary_key_name.id != "id".id %}
         # Then point 'id' to the primary key
@@ -27,10 +15,6 @@ class Avram::BaseQueryTemplate
           {{ primary_key_name.id }}(*args, **named_args)
         end
       {% end %}
-
-      def primary_key_name
-        :{{ primary_key_name.id }}
-      end
 
       macro generate_criteria_method(query_class, name, type)
         def \{{ name }}

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -16,10 +16,6 @@ class Avram::BaseQueryTemplate
         {{ table_name.id.symbolize }}
       end
 
-      def query_class
-
-      end
-
       @@schema_class = {{ type }}
 
       # If not using default 'id' primary key

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -1,6 +1,6 @@
 class Avram::BaseQueryTemplate
   macro setup(type, columns, associations, table_name, primary_key_name, *args, **named_args)
-    class ::{{ type }}::BaseQuery < Avram::Query
+    class ::{{ type }}::BaseQuery < Avram::Query({{ type }})
       private class Nothing
       end
 

--- a/src/avram/primary_key_queryable.cr
+++ b/src/avram/primary_key_queryable.cr
@@ -7,7 +7,7 @@ module Avram::PrimaryKeyQueryable(T)
     end
 
     def find(id)
-      id(id).limit(1).first? || raise Avram::RecordNotFoundError.new(model: @@table_name, id: id.to_s)
+      id(id).limit(1).first? || raise Avram::RecordNotFoundError.new(model: table_name, id: id.to_s)
     end
 
     private def with_ordered_query : self

--- a/src/avram/query.cr
+++ b/src/avram/query.cr
@@ -2,10 +2,12 @@ require "./queryable"
 
 abstract class Avram::Query
   abstract def database : Avram::Database.class
+  abstract def table_name
 
   # runs a SQL `TRUNCATE` on the current table
   def self.truncate
-    new.database.exec "TRUNCATE TABLE #{@@table_name}"
+    query = new
+    query.database.exec "TRUNCATE TABLE #{query.table_name}"
   end
 
   private def escape_sql(value : Int32)

--- a/src/avram/query.cr
+++ b/src/avram/query.cr
@@ -7,20 +7,10 @@ abstract class Avram::Query(T)
     query.database.exec "TRUNCATE TABLE #{query.table_name}"
   end
 
+  delegate :database, :table_name, :primary_key_name, to: T
+
   def schema_class
     T
-  end
-
-  def database : Avram::Database.class
-    schema_class.database
-  end
-
-  def table_name
-    schema_class.table_name
-  end
-
-  def primary_key_name
-    schema_class.primary_key_name
   end
 
   private def escape_sql(value : Int32)

--- a/src/avram/query.cr
+++ b/src/avram/query.cr
@@ -1,13 +1,26 @@
 require "./queryable"
 
-abstract class Avram::Query
-  abstract def database : Avram::Database.class
-  abstract def table_name
-
+abstract class Avram::Query(T)
   # runs a SQL `TRUNCATE` on the current table
   def self.truncate
     query = new
     query.database.exec "TRUNCATE TABLE #{query.table_name}"
+  end
+
+  def schema_class
+    T
+  end
+
+  def database : Avram::Database.class
+    schema_class.database
+  end
+
+  def table_name
+    schema_class.table_name
+  end
+
+  def primary_key_name
+    schema_class.primary_key_name
   end
 
   private def escape_sql(value : Int32)

--- a/src/avram/query.cr
+++ b/src/avram/query.cr
@@ -3,7 +3,7 @@ require "./queryable"
 abstract class Avram::Query(T)
   # runs a SQL `TRUNCATE` on the current table
   def self.truncate
-    query = new
+    query = self.new
     query.database.exec "TRUNCATE TABLE #{query.table_name}"
   end
 

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -32,6 +32,22 @@ module Avram::Queryable(T)
     end
   end
 
+  def schema_class
+    T
+  end
+
+  def database : Avram::Database.class
+    schema_class.database
+  end
+
+  def table_name
+    schema_class.table_name
+  end
+
+  def primary_key_name
+    schema_class.primary_key_name
+  end
+
   def query
     @query ||= Avram::QueryBuilder
       .new(table: table_name)

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -35,7 +35,7 @@ module Avram::Queryable(T)
   def query
     @query ||= Avram::QueryBuilder
       .new(table: table_name)
-      .select(@@schema_class.column_names)
+      .select(schema_class.column_names)
   end
 
   def distinct : self
@@ -199,14 +199,14 @@ module Avram::Queryable(T)
   end
 
   private def exec_query
-    database.query query.statement, args: query.args, queryable: @@schema_class.name do |rs|
-      @@schema_class.from_rs(rs)
+    database.query query.statement, args: query.args, queryable: schema_class.name do |rs|
+      schema_class.from_rs(rs)
     end
   end
 
   def exec_scalar(&block)
     new_query = yield query.clone
-    database.scalar new_query.statement, args: new_query.args, queryable: @@schema_class.name
+    database.scalar new_query.statement, args: new_query.args, queryable: schema_class.name
   end
 
   private def with_ordered_query : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -34,7 +34,7 @@ module Avram::Queryable(T)
 
   def query
     @query ||= Avram::QueryBuilder
-      .new(table: @@table_name)
+      .new(table: table_name)
       .select(@@schema_class.column_names)
   end
 
@@ -158,7 +158,7 @@ module Avram::Queryable(T)
   end
 
   def first
-    first? || raise RecordNotFoundError.new(model: @@table_name, query: :first)
+    first? || raise RecordNotFoundError.new(model: table_name, query: :first)
   end
 
   def last?
@@ -171,7 +171,7 @@ module Avram::Queryable(T)
   end
 
   def last
-    last? || raise RecordNotFoundError.new(model: @@table_name, query: :last)
+    last? || raise RecordNotFoundError.new(model: table_name, query: :last)
   end
 
   def select_count : Int64

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -32,22 +32,6 @@ module Avram::Queryable(T)
     end
   end
 
-  def schema_class
-    T
-  end
-
-  def database : Avram::Database.class
-    schema_class.database
-  end
-
-  def table_name
-    schema_class.table_name
-  end
-
-  def primary_key_name
-    schema_class.primary_key_name
-  end
-
   def query
     @query ||= Avram::QueryBuilder
       .new(table: table_name)

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -29,18 +29,15 @@ abstract class Avram::SaveOperation(T)
     Unperformed
   end
 
-  @save_status = SaveStatus::Unperformed
-
   macro inherited
-    @valid : Bool = true
     @@permitted_param_keys = [] of String
   end
 
-  property save_status
-
+  @valid : Bool = true
   @record : T?
   @params : Avram::Paramable
   getter :record, :params
+  property save_status : SaveStatus = SaveStatus::Unperformed
 
   abstract def attributes
 

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -33,7 +33,6 @@ abstract class Avram::SaveOperation(T)
     @@permitted_param_keys = [] of String
   end
 
-  @valid : Bool = true
   @record : T?
   @params : Avram::Paramable
   getter :record, :params

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -51,17 +51,7 @@ abstract class Avram::SaveOperation(T)
     @params = Avram::Params.new
   end
 
-  def database
-    T.database
-  end
-
-  def table_name
-    T.table_name
-  end
-
-  def primary_key_name
-    T.primary_key_name
-  end
+  delegate :database, :table_name, :primary_key_name, to: T
 
   # :nodoc:
   def published_save_failed_event

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -34,7 +34,6 @@ abstract class Avram::SaveOperation(T)
   macro inherited
     @valid : Bool = true
     @@permitted_param_keys = [] of String
-    @@schema_class = T
   end
 
   property save_status
@@ -390,25 +389,25 @@ abstract class Avram::SaveOperation(T)
     self.created_at.value ||= Time.utc if responds_to?(:created_at)
     self.updated_at.value ||= Time.utc if responds_to?(:updated_at)
     @record = database.query insert_sql.statement, args: insert_sql.args do |rs|
-      @record = @@schema_class.from_rs(rs).first
+      @record = T.from_rs(rs).first
     end
   end
 
   private def update(id) : T
     self.updated_at.value = Time.utc if responds_to?(:updated_at)
     @record = database.query update_query(id).statement_for_update(changes), args: update_query(id).args_for_update(changes) do |rs|
-      @record = @@schema_class.from_rs(rs).first
+      @record = T.from_rs(rs).first
     end
   end
 
   private def update_query(id)
     Avram::QueryBuilder
       .new(table_name)
-      .select(@@schema_class.column_names)
+      .select(T.column_names)
       .where(Avram::Where::Equal.new(primary_key_name, id.to_s))
   end
 
   private def insert_sql
-    Avram::Insert.new(table_name, changes, @@schema_class.column_names)
+    Avram::Insert.new(table_name, changes, T.column_names)
   end
 end

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -43,10 +43,7 @@ abstract class Avram::SaveOperation(T)
   @params : Avram::Paramable
   getter :record, :params
 
-  abstract def table_name
   abstract def attributes
-  abstract def primary_key_name
-  abstract def database
 
   def self.param_key
     T.name.underscore
@@ -57,6 +54,18 @@ abstract class Avram::SaveOperation(T)
 
   def initialize
     @params = Avram::Params.new
+  end
+
+  def database
+    T.database
+  end
+
+  def table_name
+    T.table_name
+  end
+
+  def primary_key_name
+    T.primary_key_name
   end
 
   # :nodoc:

--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -19,20 +19,8 @@ class Avram::SaveOperationTemplate
         end
       {% end %}
 
-      def database
-        {{ type }}.database
-      end
-
       macro inherited
         FOREIGN_KEY = "{{ type.stringify.underscore.id }}_id"
-      end
-
-      def table_name
-        :{{ table_name }}
-      end
-
-      def primary_key_name
-        :{{ primary_key_name.id }}
       end
 
       add_column_attributes({{ columns }})


### PR DESCRIPTION
I've been doing some experiments and using the "core" of Avram to avoid having to start from scratch. There is quite a bit of code I've had to add that I realized I shouldn't have to. In a bunch of places we were setting things up in a macro when we could move it down into the abstract classes and modules because they (should) take in the generic class it's working with (the `Avram::Model`) and we can expect that to have a lot of helpful class methods. By doing this, we remove a fair bit of code from macros which I consider a win.
