### PR TITLE
Remove unique filter of where clauses

### DIFF
--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -1,22 +1,25 @@
 require "./spec_helper"
 
 describe Avram::QueryBuilder do
-  it "ensures uniqueness for where, orders, and joins" do
+  it "ensures uniqueness for orders, and joins" do
     query = new_query
-      .where(Avram::Where::Equal.new(:name, "Paul"))
-      .where(Avram::Where::Equal.new(:name, "Paul"))
-      .where(Avram::Where::Raw.new("name = ?", "Mikias"))
-      .where(Avram::Where::Raw.new("name = ?", "Mikias"))
-      .where(Avram::Where::Raw.new("name = ?", args: ["Mikias"]))
       .join(Avram::Join::Inner.new(:users, :posts))
       .join(Avram::Join::Inner.new(:users, :posts))
       .order_by(Avram::OrderBy.new(:my_column, :asc))
       .order_by(Avram::OrderBy.new(:my_column, :asc))
 
-    query.wheres.size.should eq(2)
     query.joins.size.should eq(1)
-    query.statement.should eq "SELECT * FROM users INNER JOIN posts ON users.id = posts.user_id WHERE name = $1 AND name = 'Mikias' ORDER BY my_column ASC"
-    query.args.should eq ["Paul"]
+    query.statement.should eq "SELECT * FROM users INNER JOIN posts ON users.id = posts.user_id ORDER BY my_column ASC"
+  end
+
+  it "does not remove potentially duplicate where clauses" do
+    query = new_query
+      .where(Avram::Where::Equal.new(:name, "Paul"))
+      .where(Avram::Where::Equal.new(:age, "18"))
+      .or(&.where(Avram::Where::Equal.new(:name, "Paul"))
+            .where(Avram::Where::Equal.new(:age, "100")))
+
+    query.statement.should eq "SELECT * FROM users WHERE name = $1 AND age = $2 OR name = $3 AND age = $4"
   end
 
   it "can reset order" do

--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -17,7 +17,7 @@ describe Avram::QueryBuilder do
       .where(Avram::Where::Equal.new(:name, "Paul"))
       .where(Avram::Where::Equal.new(:age, "18"))
       .or(&.where(Avram::Where::Equal.new(:name, "Paul"))
-            .where(Avram::Where::Equal.new(:age, "100")))
+        .where(Avram::Where::Equal.new(:age, "100")))
 
     query.statement.should eq "SELECT * FROM users WHERE name = $1 AND age = $2 OR name = $3 AND age = $4"
   end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -330,7 +330,7 @@ class Avram::QueryBuilder
   end
 
   def wheres
-    @wheres.uniq
+    @wheres
   end
 
   @[Deprecated("Use `#wheres` instead. Raw wheres are included.")]

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -18,14 +18,6 @@ module Avram::Where
 
     abstract def prepare(placeholder_supplier : Proc(String)) : String
 
-    def ==(other : Condition)
-      prepare(->{ "unused" }) == other.prepare(->{ "unused" })
-    end
-
-    def ==(other)
-      false
-    end
-
     def clone
       self
     end
@@ -49,14 +41,6 @@ module Avram::Where
     getter value : String | Array(String) | Array(Int32)
 
     def initialize(@column, @value)
-    end
-
-    def ==(other : ValueHoldingSqlClause)
-      (prepare(->{ "unused" }) + value.to_s) == (other.prepare(->{ "unused" }) + other.value.to_s)
-    end
-
-    def ==(other : Condition)
-      false
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/luckyframework/avram/issues/487

With the addition of `OR` to the query builder, where clauses can no longer be uniquely filtered because two clauses are not equal just because they have they same condition, they could be separated by an `OR` and affect the outcome if removed. For example, these two clauses are not the same but the current query builder would turn the first into the second because of the way it checks for uniqueness:
```sql
SELECT *
FROM users
WHERE name = 'Paul'
    AND age = 18
    OR name = 'Paul'
    AND age = 100;
```

```sql
SELECT *
FROM users
WHERE name = 'Paul'
    AND age = 18
    OR age = 100;
```

This will not affect any queries negatively as truly duplicate conditions are handled as expected by Postgres.