### PR TITLE
Add helpful error when using belongs_to in migration

### DIFF
--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -133,4 +133,16 @@ class Avram::Migrator::CreateTableStatement
 
     add_index :{{ foreign_key_name }}
   end
+
+  macro belongs_to(type_declaration, *args, **named_args)
+    {% raise <<-ERROR
+      Unexpected call to `belongs_to` in a migration.
+      Found in #{type_declaration.filename.id}:#{type_declaration.line_number}:#{type_declaration.column_number}.
+
+      Did you mean to use 'add_belongs_to'?
+
+      'add_belongs_to #{type_declaration}, ...'
+      ERROR
+    %}
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/luckyframework/avram/issues/501

The error looks like:

```
Error: Unexpected call to `belongs_to` in a migration.

Found in /Users/matthew/workspace/crystal/avram/db/migrations/20201110211223_bad_migration.cr:7:18.

Did you mean to use 'add_belongs_to'?

'add_belongs_to foo : Foo, ...'
```