### PR TITLE
Improve alter migrations error msg

### DIFF
--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -175,12 +175,20 @@ class Avram::Migrator::AlterTableStatement
     @fill_existing_with_statements << "ALTER TABLE #{@table_name} ALTER COLUMN #{column} SET NOT NULL;" unless nilable
   end
 
-  {% symbol_expected_message = "%s expected a symbol like ':user', instead got: '%s'" %}
-
   macro rename(old_name, new_name)
     {% for name in {old_name, new_name} %}
       {% unless name.is_a?(SymbolLiteral) %}
-        {% raise symbol_expected_message % {"rename", name} %}
+        {% raise <<-ERROR
+
+        rename expected a symbol like ':user', instead got: '#{name}'.
+
+        in: #{name.filename}:#{name.line_number}:#{name.column_number}
+
+        Try replacing...
+
+          ▸ '#{name}' with '#{name.var}'
+        ERROR
+        %}
       {% end %}
     {% end %}
     renamed_rows << "RENAME COLUMN #{{{old_name}}} TO #{{{new_name}}}"
@@ -189,7 +197,17 @@ class Avram::Migrator::AlterTableStatement
   macro rename_belongs_to(old_association_name, new_association_name)
     {% for association_name in {old_association_name, new_association_name} %}
       {% unless association_name.is_a?(SymbolLiteral) %}
-        {% raise symbol_expected_message % {"rename_belongs_to", association_name} %}
+        {% raise <<-ERROR
+
+        rename_belongs_to expected a symbol like ':user', instead got: '#{name}'.
+
+        in: #{name.filename}:#{name.line_number}:#{name.column_number}
+
+        Try replacing...
+
+          ▸ '#{name}' with '#{name.var}'
+        ERROR
+        %}
       {% end %}
     {% end %}
     rename {{old_association_name}}_id, {{new_association_name}}_id
@@ -197,14 +215,34 @@ class Avram::Migrator::AlterTableStatement
 
   macro remove(name)
     {% unless name.is_a?(SymbolLiteral) %}
-      {% raise symbol_expected_message % {"remove", name} %}
+      {% raise <<-ERROR
+
+        remove expected a symbol like ':user', instead got: '#{name}'.
+
+        in: #{name.filename}:#{name.line_number}:#{name.column_number}
+
+        Try replacing...
+
+          ▸ '#{name}' with '#{name.var}'
+        ERROR
+      %}
     {% end %}
     dropped_rows << "  DROP #{{{name}}}"
   end
 
   macro remove_belongs_to(association_name)
     {% unless association_name.is_a?(SymbolLiteral) %}
-      {% raise symbol_expected_message % {"remove_belongs_to", association_name} %}
+      {% raise <<-ERROR
+
+      remove_belongs_to expected a symbol like ':user', instead got: '#{name}'.
+
+      in: #{name.filename}:#{name.line_number}:#{name.column_number}
+
+      Try replacing...
+
+        ▸ '#{name}' with '#{name.var}'
+      ERROR
+      %}
     {% end %}
     remove {{ association_name }}_id
   end

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -175,20 +175,25 @@ class Avram::Migrator::AlterTableStatement
     @fill_existing_with_statements << "ALTER TABLE #{@table_name} ALTER COLUMN #{column} SET NOT NULL;" unless nilable
   end
 
+  macro symbol_expected_error(action, name)
+
+    {% raise <<-ERROR
+
+    #{action} expected a symbol like ':user', instead got: '#{name}'.
+
+    in: #{name.filename}:#{name.line_number}:#{name.column_number}
+
+    Try replacing...
+
+      ▸ '#{name}' with '#{name.var}'
+    ERROR
+    %}
+  end
+
   macro rename(old_name, new_name)
     {% for name in {old_name, new_name} %}
       {% unless name.is_a?(SymbolLiteral) %}
-        {% raise <<-ERROR
-
-        rename expected a symbol like ':user', instead got: '#{name}'.
-
-        in: #{name.filename}:#{name.line_number}:#{name.column_number}
-
-        Try replacing...
-
-          ▸ '#{name}' with '#{name.var}'
-        ERROR
-        %}
+        symbol_expected_error("rename", {{ name }})
       {% end %}
     {% end %}
     renamed_rows << "RENAME COLUMN #{{{old_name}}} TO #{{{new_name}}}"
@@ -197,17 +202,7 @@ class Avram::Migrator::AlterTableStatement
   macro rename_belongs_to(old_association_name, new_association_name)
     {% for association_name in {old_association_name, new_association_name} %}
       {% unless association_name.is_a?(SymbolLiteral) %}
-        {% raise <<-ERROR
-
-        rename_belongs_to expected a symbol like ':user', instead got: '#{name}'.
-
-        in: #{name.filename}:#{name.line_number}:#{name.column_number}
-
-        Try replacing...
-
-          ▸ '#{name}' with '#{name.var}'
-        ERROR
-        %}
+        symbol_expected_error("rename_belongs_to", {{ name }})
       {% end %}
     {% end %}
     rename {{old_association_name}}_id, {{new_association_name}}_id
@@ -215,34 +210,14 @@ class Avram::Migrator::AlterTableStatement
 
   macro remove(name)
     {% unless name.is_a?(SymbolLiteral) %}
-      {% raise <<-ERROR
-
-        remove expected a symbol like ':user', instead got: '#{name}'.
-
-        in: #{name.filename}:#{name.line_number}:#{name.column_number}
-
-        Try replacing...
-
-          ▸ '#{name}' with '#{name.var}'
-        ERROR
-      %}
+      symbol_expected_error("remove", {{ name }})
     {% end %}
     dropped_rows << "  DROP #{{{name}}}"
   end
 
   macro remove_belongs_to(association_name)
     {% unless association_name.is_a?(SymbolLiteral) %}
-      {% raise <<-ERROR
-
-      remove_belongs_to expected a symbol like ':user', instead got: '#{name}'.
-
-      in: #{name.filename}:#{name.line_number}:#{name.column_number}
-
-      Try replacing...
-
-        ▸ '#{name}' with '#{name.var}'
-      ERROR
-      %}
+      symbol_expected_error("remove_belongs_to", {{ name }})
     {% end %}
     remove {{ association_name }}_id
   end

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -177,15 +177,21 @@ class Avram::Migrator::AlterTableStatement
 
   macro symbol_expected_error(action, name)
 
+    {% if name.is_a?(TypeDeclaration) %}
+      {% example = name.var %}
+    {% else %}
+      {% example = name.id %}
+    {% end %}
+
     {% raise <<-ERROR
 
-    #{action} expected a symbol like ':user', instead got: '#{name}'.
+    #{action} expected a symbol like #{example}, instead got: #{name}.
 
     in: #{name.filename}:#{name.line_number}:#{name.column_number}
 
     Try replacing...
 
-      ▸ '#{name}' with ':#{name.var}'
+      ▸ #{name} with :#{example}
     ERROR
     %}
   end

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -185,7 +185,7 @@ class Avram::Migrator::AlterTableStatement
 
     {% raise <<-ERROR
 
-    #{action} expected a symbol like #{example}, instead got: #{name}.
+    #{action} expected a symbol like :#{example}, instead got: #{name}.
 
     in: #{name.filename}:#{name.line_number}:#{name.column_number}
 

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -185,7 +185,7 @@ class Avram::Migrator::AlterTableStatement
 
     Try replacing...
 
-      ▸ '#{name}' with '#{name.var}'
+      ▸ '#{name}' with ':#{name.var}'
     ERROR
     %}
   end


### PR DESCRIPTION
Improve error reporting for migration where a user accidently includes the type alongside the var name for rename, rename_belongs_to, remove, remove_belongs_to. 

For example:

      remove name : String

produces the following error:

    Error:

    "remove" expected a symbol like ':user', instead got: 'name : String'.

    in: "/data/db/migrations/20170127143149_create_users.cr":19:14

    Try replacing...

      ▸ 'name : String' with 'name'