### PR TITLE
Model association updates

### DIFF
--- a/db/migrations/20201111220713_create_customers.cr
+++ b/db/migrations/20201111220713_create_customers.cr
@@ -1,0 +1,15 @@
+class CreateCustomers::V20201111220713 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(Customer) do
+      primary_key id : Int64
+      add_timestamps
+
+      add name : String
+      add_belongs_to employee : Employee, on_delete: :cascade
+    end
+  end
+
+  def rollback
+    drop table_for(Customer)
+  end
+end

--- a/spec/preloading_spec.cr
+++ b/spec/preloading_spec.cr
@@ -120,7 +120,7 @@ describe "Preloading" do
     end
   end
 
-  it "preloads has_many through" do
+  it "preloads has_many through a has_many that points to a belongs_to relationship" do
     with_lazy_load(enabled: false) do
       tag = TagBox.create
       TagBox.create # unused tag
@@ -136,6 +136,32 @@ describe "Preloading" do
     end
   end
 
+  it "preloads has_many through a has_many that points to a has_many relationship" do
+    with_lazy_load(enabled: false) do
+      manager = ManagerBox.create
+      employee = EmployeeBox.new.manager_id(manager.id).create
+      customer = CustomerBox.new.employee_id(employee.id).create
+
+      customers = Manager::BaseQuery.new.preload_customers.find(manager.id).customers
+
+      customers.size.should eq(1)
+      customers.should eq([customer])
+    end
+  end
+
+  it "preloads has_many through a belongs_to that points to a belongs_to relationship" do
+    with_lazy_load(enabled: false) do
+      manager = ManagerBox.create
+      employee = EmployeeBox.new.manager_id(manager.id).create
+      customer = CustomerBox.new.employee_id(employee.id).create
+
+      managers = Customer::BaseQuery.new.preload_managers.find(customer.id).managers
+
+      managers.size.should eq(1)
+      managers.should eq([manager])
+    end
+  end
+
   it "preloads has_many through with uuids" do
     with_lazy_load(enabled: false) do
       item = LineItemBox.create
@@ -145,7 +171,7 @@ describe "Preloading" do
       LineItemProductBox.create &.line_item_id(item.id).product_id(product.id)
       LineItemProductBox.create &.line_item_id(other_item.id).product_id(product.id)
 
-      item_products = LineItemQuery.new.preload_products.results.first.products
+      item_products = LineItemQuery.new.preload_associated_products.results.first.associated_products
 
       item_products.size.should eq(1)
       item_products.should eq([product])

--- a/spec/query_associations_spec.cr
+++ b/spec/query_associations_spec.cr
@@ -154,9 +154,9 @@ describe "Query associations" do
 
     line_item_query = LineItemQuery.new
       .id(item.id)
-      .where_products(ProductQuery.new.id(product.id))
+      .where_associated_products(ProductQuery.new.id(product.id))
     result = LineItemProductQuery.new
-      .where_line_items(line_item_query)
+      .where_line_item(line_item_query)
       .find(line_item_product.id)
 
     result.should eq(line_item_product)

--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -801,7 +801,7 @@ describe Avram::Queryable do
       post = PostBox.create
       CommentBox.new.post_id(post.id).create
 
-      query = Comment::BaseQuery.new.join_posts
+      query = Comment::BaseQuery.new.join_post
       query.to_sql.should eq ["SELECT comments.custom_id, comments.created_at, comments.updated_at, comments.body, comments.post_id FROM comments INNER JOIN posts ON comments.post_id = posts.custom_id"]
 
       result = query.first
@@ -812,7 +812,7 @@ describe Avram::Queryable do
       query = Comment::BaseQuery.new
       original_query_sql = query.to_sql
 
-      query.join_posts
+      query.join_post
 
       query.to_sql.should eq original_query_sql
     end
@@ -863,7 +863,7 @@ describe Avram::Queryable do
     it "left join on belongs to" do
       employee = EmployeeBox.create
 
-      query = Employee::BaseQuery.new.left_join_managers
+      query = Employee::BaseQuery.new.left_join_manager
       query.to_sql.should eq ["SELECT employees.id, employees.created_at, employees.updated_at, employees.name, employees.manager_id FROM employees LEFT JOIN managers ON employees.manager_id = managers.id"]
 
       result = query.first
@@ -874,7 +874,7 @@ describe Avram::Queryable do
       query = Employee::BaseQuery.new
       original_query_sql = query.to_sql
 
-      query.left_join_managers
+      query.left_join_manager
 
       query.to_sql.should eq original_query_sql
     end
@@ -1226,7 +1226,7 @@ describe Avram::Queryable do
         line_item = LineItemBox.create &.name("Thing 1")
         price = PriceBox.create &.in_cents(100).line_item_id(line_item.id)
 
-        query = PriceQuery.new.where_line_items(LineItemQuery.new.name("Thing 1"))
+        query = PriceQuery.new.where_line_item(LineItemQuery.new.name("Thing 1"))
         query.first.should eq price
       end
     end

--- a/spec/support/boxes/customer_box.cr
+++ b/spec/support/boxes/customer_box.cr
@@ -1,0 +1,5 @@
+class CustomerBox < Avram::Box
+  def initialize
+    name sequence("test-customer")
+  end
+end

--- a/spec/support/models/customer.cr
+++ b/spec/support/models/customer.cr
@@ -1,0 +1,7 @@
+class Customer < BaseModel
+  table do
+    column name : String
+    belongs_to employee : Employee
+    has_many managers : Manager, through: [:employee, :manager]
+  end
+end

--- a/spec/support/models/employee.cr
+++ b/spec/support/models/employee.cr
@@ -2,5 +2,6 @@ class Employee < BaseModel
   table do
     column name : String
     belongs_to manager : Manager?
+    has_many customers : Customer
   end
 end

--- a/spec/support/models/line_item.cr
+++ b/spec/support/models/line_item.cr
@@ -8,7 +8,7 @@ class LineItem < BaseModel
     has_one price : Price?
     has_many scans : Scan
     has_many line_items_products : LineItemProduct
-    has_many products : Product, through: :line_items_products
+    has_many associated_products : Product, through: [:line_items_products, :product]
   end
 end
 

--- a/spec/support/models/manager.cr
+++ b/spec/support/models/manager.cr
@@ -2,5 +2,6 @@ class Manager < BaseModel
   table do
     column name : String
     has_many employees : Employee
+    has_many customers : Customer, through: [:employees, :customers]
   end
 end

--- a/spec/support/models/post.cr
+++ b/spec/support/models/post.cr
@@ -9,7 +9,7 @@ class Post < BaseModel
     column published_at : Time?
     has_many comments : Comment
     has_many taggings : Tagging
-    has_many tags : Tag, through: :taggings
+    has_many tags : Tag, through: [:taggings, :tag]
   end
 end
 
@@ -25,5 +25,6 @@ class PostWithCustomTable < BaseModel
 
     column title : String
     column published_at : Time?
+    has_many comments_for_custom_post : CommentForCustomPost, foreign_key: :post_id
   end
 end

--- a/spec/support/models/product.cr
+++ b/spec/support/models/product.cr
@@ -4,7 +4,7 @@ class Product < BaseModel
   table do
     primary_key id : UUID
     has_many line_items_products : LineItemProduct
-    has_many line_items : LineItem, through: :line_items_products
+    has_many line_items : LineItem, through: [:line_items_products, :line_item]
     timestamps
   end
 end

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -1,10 +1,28 @@
 module Avram::Associations::HasMany
   macro has_many(type_declaration, through = nil, foreign_key = nil)
     {% if !through.is_a?(NilLiteral) && (!through.is_a?(ArrayLiteral) || through.any? { |item| !item.is_a?(SymbolLiteral) }) %}
-      {% through.raise "'through' must be given an Array of Symbols. Instead, got: #{through}" %}
+      {% through.raise <<-ERROR
+      'through' on #{@type.name} must be given an Array(Symbol). Instead, got: #{through}
+
+      Example...
+         has_many comments : Comment
+         has_many related_authors : User, through: [:comments, :author]
+
+      Learn more about associations: https://luckyframework.org/guides/database/models#model-associations
+      ERROR
+      %}
     {% end %}
     {% if !through.is_a?(NilLiteral) && through.size < 2 %}
-      {% through.raise "'through' must have at least two items. Instead, got: #{through}" %}
+      {% through.raise <<-ERROR
+      'through' on #{@type.name} must be given at least two items. Instead, got: #{through}
+
+      Example...
+         has_many comments : Comment
+         has_many related_authors : User, through: [:comments, :author]
+
+      Learn more about associations: https://luckyframework.org/guides/database/models#model-associations
+      ERROR
+      %}
     {% end %}
     {% assoc_name = type_declaration.var %}
 

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -1,7 +1,10 @@
 module Avram::Associations::HasMany
   macro has_many(type_declaration, through = nil, foreign_key = nil)
-    {% if !through.is_a?(NilLiteral) && !through.is_a?(SymbolLiteral) %}
-      {% through.raise "The association name for 'through' must be a Symbol. Instead, got: #{through}" %}
+    {% if !through.is_a?(NilLiteral) && (!through.is_a?(ArrayLiteral) || through.any? { |item| !item.is_a?(SymbolLiteral) }) %}
+      {% through.raise "'through' must be given an Array of Symbols. Instead, got: #{through}" %}
+    {% end %}
+    {% if !through.is_a?(NilLiteral) && through.size < 2 %}
+      {% through.raise "'through' must have at least two items. Instead, got: #{through}" %}
     {% end %}
     {% assoc_name = type_declaration.var %}
 
@@ -21,7 +24,7 @@ module Avram::Associations::HasMany
     {% model = type_declaration.type %}
 
     define_has_many_lazy_loading({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ through }})
-    define_has_many_base_query({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{through}})
+    define_has_many_base_query({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ through }})
   end
 
   private macro define_has_many_base_query(assoc_name, model, foreign_key, through)
@@ -30,29 +33,24 @@ module Avram::Associations::HasMany
         preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end
 
+      def preload_{{ assoc_name }}
+        modified_query = yield {{ model }}::BaseQuery.new
+        preload_{{ assoc_name }}(modified_query)
+      end
+
       {% if through %}
         def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery)
+          preload_{{ through.first.id }} do |through_query|
+            through_query.preload_{{ through[1].id }}(preload_query)
+          end
           add_preload do |records|
-            ids = records.map(&.id)
-            {{ assoc_name }} = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
-            if ids.any?
-              all_{{ assoc_name }} = preload_query
-                .join_{{ through.id }}
-                .__yield_where_{{ through.id }} do |through_query|
-                  through_query.{{ foreign_key.id }}.in(ids)
-                end
-                .preload_{{ through.id }}
-                .distinct
-
-              all_{{ assoc_name }}.each do |item|
-                item.{{ through.id }}.each do |item_through|
-                  {{ assoc_name }}[item_through.{{ foreign_key }}] ||= Array({{ model }}).new
-                  {{ assoc_name }}[item_through.{{ foreign_key }}] << item
-                end
-              end
-            end
             records.each do |record|
-              record._preloaded_{{ assoc_name }} = {{ assoc_name }}[record.id]? || [] of {{ model }}
+              throughs = record.{{ through.first.id }}
+              throughs = throughs.is_a?(Array) ? throughs : [throughs]
+              record._preloaded_{{ assoc_name }} = throughs.compact.flat_map do |through|
+                throughs1 = through.{{ through[1].id }}
+                throughs1.is_a?(Array) ? throughs1 : [throughs1]
+              end.compact
             end
           end
           self
@@ -94,13 +92,9 @@ module Avram::Associations::HasMany
 
     def {{ assoc_name.id }}_count : Int64
       {% if through %}
-        {{ model }}::BaseQuery
-          .new
-          .join_{{ through.id }}
-          .__yield_where_{{ through.id }} do |through_query|
-            through_query.{{ foreign_key.id }}(id)
-          end
-          .select_count
+        {{ through.first.id }}_query
+          .map(&.{{ through[1].id }}_count)
+          .sum
       {% else %}
         {{ model }}::BaseQuery
           .new
@@ -117,14 +111,12 @@ module Avram::Associations::HasMany
 
     private def lazy_load_{{ assoc_name }} : Array({{ model }})
       {% if through %}
-        {{ model }}::BaseQuery
-          .new
-          .join_{{ through.id }}
-          .__yield_where_{{ through.id }} do |through_query|
-            through_query.{{ foreign_key.id }}(id)
-          end
-          .preload_{{ through.id }}
-          .results
+        through_results = {{ through.first.id }}_query.preload_{{ through[1].id }}.results
+        through_results = through_results.is_a?(Array) ? through_results : [through_results]
+        through_results.compact.flat_map do |through_result|
+          assoc_results = through_result.{{ through[1].id }}
+          assoc_results.is_a?(Array) ? assoc_results : [assoc_results]
+        end.compact
       {% else %}
         {{ model }}::BaseQuery
           .new

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -17,9 +17,9 @@ module Avram::Associations::HasOne
     {% foreign_key = foreign_key.id %}
 
     association \
-      assoc_name: :{{ type_declaration.var }},
+      assoc_name: :{{ assoc_name.id }},
       type: {{ model }},
-      foreign_key: {{ foreign_key }},
+      foreign_key: :{{ foreign_key.id }},
       relationship_type: :has_one
 
     Avram::Associations.__define_public_preloaded_getters({{ assoc_name }}, {{ model }}, {{ nilable }})

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -80,8 +80,8 @@ class Avram::BaseQueryTemplate
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: table_name,
-                  to: :{{ assoc[:assoc_name] }},
-                  primary_key: {{ assoc[:foreign_key] }},
+                  to: {{ assoc[:type] }}::TABLE_NAME,
+                  primary_key: {{ assoc[:foreign_key].id.symbolize }},
                   foreign_key: {{ assoc[:type] }}::PRIMARY_KEY_NAME
                 )
               )
@@ -90,20 +90,20 @@ class Avram::BaseQueryTemplate
                 Avram::Join::{{ join_type.id }}.new(
                   from: table_name,
                   to: {{ assoc[:type] }}::TABLE_NAME,
-                  foreign_key: :{{ assoc[:foreign_key] }},
+                  foreign_key: {{ assoc[:foreign_key].id.symbolize }},
                   primary_key: primary_key_name
                 )
               )
             {% elsif assoc[:through] %}
-              {{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
-                .__yield_where_{{ assoc[:through].id }} do |join_query|
-                  join_query.{{ join_type.downcase.id }}_join_{{ assoc[:assoc_name] }}
+              {{ join_type.downcase.id }}_join_{{ assoc[:through].first.id }}
+                .__yield_where_{{ assoc[:through].first.id }} do |join_query|
+                  join_query.{{ join_type.downcase.id }}_join_{{ assoc[:through][1].id }}
                 end
             {% else %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: table_name,
-                  to: :{{ assoc[:assoc_name] }},
+                  to: {{ assoc[:type] }}::TABLE_NAME,
                   foreign_key: {{ assoc[:foreign_key] }},
                   primary_key: primary_key_name
                 )

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -103,6 +103,7 @@ abstract class Avram::Model
     setup(Avram::Model.setup_db_mapping)
     setup(Avram::Model.setup_getters)
     setup(Avram::Model.setup_column_info_methods)
+    setup(Avram::Model.setup_association_queries)
     setup(Avram::BaseQueryTemplate.setup)
     setup(Avram::SaveOperationTemplate.setup)
     setup(Avram::SchemaEnforcer.setup)
@@ -216,6 +217,20 @@ abstract class Avram::Model
         },
       {% end %}
     })
+  end
+
+  macro setup_association_queries(associations, *args, **named_args)
+    {% for assoc in associations %}
+      def {{ assoc[:assoc_name] }}_query
+        {% if assoc[:type] == :has_many %}
+          {{ assoc[:type] }}::BaseQuery.new.{{ assoc[:foreign_key].id }}(id)
+        {% elsif assoc[:type] == :belongs_to %}
+          {{ assoc[:type] }}::BaseQuery.new.id({{ assoc[:foreign_key].id }})
+        {% else %}
+          {{ assoc[:type] }}::BaseQuery.new
+        {% end %}
+      end
+    {% end %}
   end
 
   macro setup_getters(columns, *args, **named_args)


### PR DESCRIPTION
Fixes #523 
Fixes #473
Fixes: #496
Related (but does not fix): #196

Had to bring in the changes in #494 and #499 in order to get it working.

## Changes

- Updates "has many through"'s to take in an array in the `through` field.
- Belongs to associations now have singular "where_xxx" queries

## Has Many Through

### Old

```crystal
class Manager < BaseModel
  table do
    has_many employees : Employee
    has_many customers : Customer, through: :employees
  end
end
```

### New

```crystal
class Manager < BaseModel
  table do
    has_many employees : Employee
    has_many customers : Customer, through: [:employees, :customers]
  end
end
```

The array is the association route to get to the customers. So Manager will need to have an association with the name of `employees` and Employee is expected to have an association called `customers` that returns Customer.

## Belongs To

### Old

```crystal
class Employee < BaseModel
  table do
    belongs_to manager : Manager
  end
end

# notice the plural where, we were using the table name
Employee::BaseQuery.new.where_managers(...)
```

### New

```crystal
class Employee < BaseModel
  table do
    belongs_to manager : Manager
  end
end

# notice the singular where, we are using the association name now
Employee::BaseQuery.new.where_manager(...)
```

This also means that belongs to associations can now be named something other than the class and still work

```crystal
class Employee < BaseModel
  table do
    belongs_to boss : Manager
  end
end

Employee::BaseQuery.new.where_boss(...)
```