### PR TITLE
Update association property to assoc_name instead of table_name

### DIFF
--- a/spec/support/models/comment.cr
+++ b/spec/support/models/comment.cr
@@ -16,9 +16,7 @@ class CommentForCustomPost < BaseModel
     primary_key custom_id : Int64
     timestamps
     column body : String
-    belongs_to post_with_custom_table : PostWithCustomTable,
-      table: :posts,
-      foreign_key: :post_id
+    belongs_to post_with_custom_table : PostWithCustomTable, foreign_key: :post_id
   end
 end
 

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -21,7 +21,7 @@ module Avram::Associations::BelongsTo
     column {{ foreign_key.id }} : {{ model }}::PrimaryKeyType{% if nilable %}?{% end %}
 
     association \
-      table_name: :{{ table.id }},
+      assoc_name: :{{ table.id }},
       type: {{ model }},
       foreign_key: :{{ foreign_key.id }},
       relationship_type: :belongs_to

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -12,7 +12,7 @@ module Avram::Associations::HasMany
     {% foreign_key = foreign_key.id %}
 
     association \
-      table_name: :{{ assoc_name }},
+      assoc_name: :{{ assoc_name }},
       type: {{ type_declaration.type }},
       foreign_key: :{{ foreign_key }},
       through: {{ through }},

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -17,7 +17,7 @@ module Avram::Associations::HasOne
     {% foreign_key = foreign_key.id %}
 
     association \
-      table_name: :{{ type_declaration.var }},
+      assoc_name: :{{ type_declaration.var }},
       type: {{ model }},
       foreign_key: {{ foreign_key }},
       relationship_type: :has_one

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -70,17 +70,17 @@ class Avram::BaseQueryTemplate
       {% end %}
 
       {% for assoc in associations %}
-        def join_{{ assoc[:table_name] }}
-          inner_join_{{ assoc[:table_name] }}
+        def join_{{ assoc[:assoc_name] }}
+          inner_join_{{ assoc[:assoc_name] }}
         end
 
         {% for join_type in ["Inner", "Left", "Right", "Full"] %}
-          def {{ join_type.downcase.id }}_join_{{ assoc[:table_name] }}
+          def {{ join_type.downcase.id }}_join_{{ assoc[:assoc_name] }}
             {% if assoc[:relationship_type] == :belongs_to %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: table_name,
-                  to: :{{ assoc[:table_name] }},
+                  to: :{{ assoc[:assoc_name] }},
                   primary_key: {{ assoc[:foreign_key] }},
                   foreign_key: {{ assoc[:type] }}::PRIMARY_KEY_NAME
                 )
@@ -97,13 +97,13 @@ class Avram::BaseQueryTemplate
             {% elsif assoc[:through] %}
               {{ join_type.downcase.id }}_join_{{ assoc[:through].id }}
                 .__yield_where_{{ assoc[:through].id }} do |join_query|
-                  join_query.{{ join_type.downcase.id }}_join_{{ assoc[:table_name] }}
+                  join_query.{{ join_type.downcase.id }}_join_{{ assoc[:assoc_name] }}
                 end
             {% else %}
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: table_name,
-                  to: :{{ assoc[:table_name] }},
+                  to: :{{ assoc[:assoc_name] }},
                   foreign_key: {{ assoc[:foreign_key] }},
                   primary_key: primary_key_name
                 )
@@ -113,9 +113,9 @@ class Avram::BaseQueryTemplate
         {% end %}
 
 
-        def where_{{ assoc[:table_name] }}(assoc_query : {{ assoc[:type] }}::BaseQuery, auto_inner_join : Bool = true)
+        def where_{{ assoc[:assoc_name] }}(assoc_query : {{ assoc[:type] }}::BaseQuery, auto_inner_join : Bool = true)
           if auto_inner_join
-            join_{{ assoc[:table_name] }}.merge_query(assoc_query.query)
+            join_{{ assoc[:assoc_name] }}.merge_query(assoc_query.query)
           else
             merge_query(assoc_query.query)
           end
@@ -123,12 +123,12 @@ class Avram::BaseQueryTemplate
 
         # :nodoc:
         # Used internally for has_many through queries
-        def __yield_where_{{ assoc[:table_name] }}
+        def __yield_where_{{ assoc[:assoc_name] }}
           assoc_query = yield {{ assoc[:type] }}::BaseQuery.new
           merge_query(assoc_query.query)
         end
 
-        def {{ assoc[:table_name] }}
+        def {{ assoc[:assoc_name] }}
           \{% raise <<-ERROR
             The methods for querying associations have changed
 
@@ -137,7 +137,7 @@ class Avram::BaseQueryTemplate
 
             Example:
 
-              where_{{ assoc[:table_name] }}({{ assoc[:type] }}Query.new.some_condition)
+              where_{{ assoc[:assoc_name] }}({{ assoc[:type] }}Query.new.some_condition)
             ERROR
           %}
           yield # This is not used. Just there so it works with blocks.

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -271,7 +271,7 @@ abstract class Avram::Model
     end
   end
 
-  macro association(table_name, type, relationship_type, foreign_key = nil, through = nil)
-    {% ASSOCIATIONS << {type: type, table_name: table_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through} %}
+  macro association(assoc_name, type, relationship_type, foreign_key = nil, through = nil)
+    {% ASSOCIATIONS << {type: type, assoc_name: assoc_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through} %}
   end
 end


### PR DESCRIPTION
Breaking out changes from https://github.com/luckyframework/avram/pull/525 to reduce its size.

## Why make this change?

In all places except belongs_to, we are using the association name instead of trying to infer the table name. It isn't necessary to make this inference though. Anywhere we access the table name from the association, we can use the constant `::TABLE_NAME` or the class method `.table_name`. The belongs to macro is still inferring the table name for now because replacing it with the association name takes it from plural to singular and that leads to all the changes made in the PR this is coming from.