### PR TITLE
Fix duplicate migration names

### DIFF
--- a/src/avram/tasks/gen/migration.cr
+++ b/src/avram/tasks/gen/migration.cr
@@ -72,7 +72,9 @@ class Avram::Migrator::MigrationGenerator
     d.each_child { |x|
       if x.starts_with?(/[0-9]{14}_#{name.underscore}.cr/)
         raise <<-ERROR
-          Duplicate migration name
+          Migration name must be unique
+
+          Migration name: #{name.underscore}.cr already exists as: #{x}.
         ERROR
       end
     }

--- a/src/avram/tasks/gen/migration.cr
+++ b/src/avram/tasks/gen/migration.cr
@@ -22,6 +22,7 @@ class Avram::Migrator::MigrationGenerator
   def generate(@_version = @_version)
     ensure_camelcase_name
     make_migrations_folder_if_missing
+    ensure_unique
     File.write(file_path, contents)
     io.puts "Created #{migration_class_name.colorize(:green)} in .#{relative_file_path.colorize(:green)}"
   end
@@ -64,6 +65,17 @@ class Avram::Migrator::MigrationGenerator
         #{green_arrow} Try this instead: #{"lucky gen.migration #{name.camelcase}".colorize(:green)}
       ERROR
     end
+  end
+
+  private def ensure_unique
+    d = Dir.new(Dir.current + "/db/migrations")
+    d.each_child { |x|
+      if x.starts_with?(/[0-9]{14}_#{name.underscore}.cr/)
+        raise <<-ERROR
+          Duplicate migration name
+        ERROR
+      end
+    }
   end
 
   private def migration_class_name


### PR DESCRIPTION
lucky gen.migrations now returns an error if the migration name already exists.

Fixes issues: https://github.com/luckyframework/avram/issues/521

Error message is:

        Migration name must be unique

         Migration name: repeat_migration.cr already exists as: 20201112200313_repeat_migration.cr.

Also added tests for the above and for camel case.