### PR TITLE
Custom errors and valid property on Operations

### DIFF
--- a/spec/operations/operation_errors_spec.cr
+++ b/spec/operations/operation_errors_spec.cr
@@ -1,0 +1,45 @@
+require "../spec_helper"
+
+class SaveUserButNotReally < User::SaveOperation
+  needs failure : Bool = false
+
+  before_save do
+    if failure
+      self.valid = false
+      add_error(:failure, "This failed quick")
+      add_error(:failure, "Like, really quick")
+    end
+  end
+
+end
+
+class FailedOperation < Avram::Operation
+  needs failure : Bool = false
+
+  before_run do
+    if failure
+      self.valid = false
+      add_error(:oops, "this didn't work")
+      add_error(:failure, "move right along")
+    end
+  end
+
+  def run
+    "noop"
+  end
+end
+
+describe Avram::OperationErrors do
+  it "sets a custom error for Operation" do
+    FailedOperation.run(failure: true) do |op, _|
+      op.errors[:oops].should eq ["this didn't work"]
+      op.errors[:failure].should eq ["move right along"]
+    end
+  end
+
+  it "sets a custom error for SaveOperation" do
+    SaveUserButNotReally.create(failure: true) do |op, _|
+      op.errors[:failure].should eq ["This failed quick", "Like, really quick"]
+    end
+  end
+end

--- a/spec/operations/operation_errors_spec.cr
+++ b/spec/operations/operation_errors_spec.cr
@@ -10,7 +10,6 @@ class SaveUserButNotReally < User::SaveOperation
       add_error(:failure, "Like, really quick")
     end
   end
-
 end
 
 class FailedOperation < Avram::Operation

--- a/spec/operations/operation_errors_spec.cr
+++ b/spec/operations/operation_errors_spec.cr
@@ -5,7 +5,6 @@ class SaveUserButNotReally < User::SaveOperation
 
   before_save do
     if failure
-      self.valid = false
       add_error(:failure, "This failed quick")
       add_error(:failure, "Like, really quick")
     end
@@ -17,7 +16,6 @@ class FailedOperation < Avram::Operation
 
   before_run do
     if failure
-      self.valid = false
       add_error(:oops, "this didn't work")
       add_error(:failure, "move right along")
     end
@@ -30,15 +28,34 @@ end
 
 describe Avram::OperationErrors do
   it "sets a custom error for Operation" do
-    FailedOperation.run(failure: true) do |op, _|
+    op = FailedOperation.new(failure: true)
+    op.add_error(:fail, "Not valid")
+    op.valid?.should eq false
+    op.errors[:fail].should eq ["Not valid"]
+  end
+
+  it "returns a nil value when there's a custom error on Operation" do
+    FailedOperation.run(failure: true) do |op, value|
+      value.should eq nil
+      op.valid?.should eq false
       op.errors[:oops].should eq ["this didn't work"]
       op.errors[:failure].should eq ["move right along"]
     end
   end
 
   it "sets a custom error for SaveOperation" do
-    SaveUserButNotReally.create(failure: true) do |op, _|
+    op = SaveUserButNotReally.new(failure: true)
+    op.add_error(:fail, "User did not save")
+    op.valid?.should eq false
+    op.errors[:fail].should eq ["User did not save"]
+  end
+
+  it "returns a failed save status for SaveOperation" do
+    SaveUserButNotReally.create(failure: true) do |op, value|
+      value.should eq nil
+      op.valid?.should eq false
       op.errors[:failure].should eq ["This failed quick", "Like, really quick"]
+      op.save_status.should eq SaveUserButNotReally::SaveStatus::SaveFailed
     end
   end
 end

--- a/src/avram/operation.cr
+++ b/src/avram/operation.cr
@@ -90,11 +90,10 @@ abstract class Avram::Operation
     @params = Avram::Params.new
   end
 
-  # Returns `true` if all attributes are valid.
-  # Set `valid` to false to force invalid state.
+  # Returns `true` if all attributes are valid,
+  # and there's no custom errors
   def valid?
-    return false unless valid
-    attributes.all? &.valid?
+    custom_errors.empty? && attributes.all?(&.valid?)
   end
 
   def self.param_key

--- a/src/avram/operation.cr
+++ b/src/avram/operation.cr
@@ -15,7 +15,6 @@ abstract class Avram::Operation
 
   @params : Avram::Paramable
   getter params
-  property valid : Bool = true
 
   # Yields the instance of the operation, and the return value from
   # the `run` instance method.

--- a/src/avram/operation.cr
+++ b/src/avram/operation.cr
@@ -15,6 +15,7 @@ abstract class Avram::Operation
 
   @params : Avram::Paramable
   getter params
+  property valid : Bool = true
 
   # Yields the instance of the operation, and the return value from
   # the `run` instance method.
@@ -90,7 +91,10 @@ abstract class Avram::Operation
     @params = Avram::Params.new
   end
 
+  # Returns `true` if all attributes are valid.
+  # Set `valid` to false to force invalid state.
   def valid?
+    return false unless valid
     attributes.all? &.valid?
   end
 

--- a/src/avram/operation_errors.cr
+++ b/src/avram/operation_errors.cr
@@ -1,7 +1,7 @@
 module Avram::OperationErrors
   macro included
     @custom_errors : Hash(Symbol, Array(String)) = {} of Symbol => Array(String)
-    private property valid : Bool = true
+    getter :custom_errors
   end
 
   def errors : Hash(Symbol, Array(String))
@@ -18,7 +18,6 @@ module Avram::OperationErrors
   end
 
   def add_error(key : Symbol, message : String) : Nil
-    self.valid = false
     @custom_errors[key] ||= [] of String
     @custom_errors[key].push(message)
   end

--- a/src/avram/operation_errors.cr
+++ b/src/avram/operation_errors.cr
@@ -1,6 +1,7 @@
 module Avram::OperationErrors
   macro included
     @custom_errors : Hash(Symbol, Array(String)) = {} of Symbol => Array(String)
+    private property valid : Bool = true
   end
 
   def errors : Hash(Symbol, Array(String))
@@ -17,6 +18,7 @@ module Avram::OperationErrors
   end
 
   def add_error(key : Symbol, message : String) : Nil
+    self.valid = false
     @custom_errors[key] ||= [] of String
     @custom_errors[key].push(message)
   end

--- a/src/avram/operation_errors.cr
+++ b/src/avram/operation_errors.cr
@@ -1,6 +1,10 @@
 module Avram::OperationErrors
+  macro included
+    @custom_errors : Hash(Symbol, Array(String)) = {} of Symbol => Array(String)
+  end
+
   def errors : Hash(Symbol, Array(String))
-    attributes.reduce({} of Symbol => Array(String)) do |errors_hash, attribute|
+    attr_errors = attributes.reduce({} of Symbol => Array(String)) do |errors_hash, attribute|
       if attribute.errors.empty?
         errors_hash
       else
@@ -8,5 +12,12 @@ module Avram::OperationErrors
         errors_hash
       end
     end
+
+    attr_errors.merge(@custom_errors)
+  end
+
+  def add_error(key : Symbol, message : String) : Nil
+    @custom_errors[key] ||= [] of String
+    @custom_errors[key].push(message)
   end
 end

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -37,7 +37,6 @@ abstract class Avram::SaveOperation(T)
   @params : Avram::Paramable
   getter :record, :params
   property save_status : SaveStatus = SaveStatus::Unperformed
-  property valid : Bool = true
 
   abstract def attributes
 

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -37,6 +37,7 @@ abstract class Avram::SaveOperation(T)
   @params : Avram::Paramable
   getter :record, :params
   property save_status : SaveStatus = SaveStatus::Unperformed
+  property valid : Bool = true
 
   abstract def attributes
 
@@ -210,7 +211,9 @@ abstract class Avram::SaveOperation(T)
 
   # Runs required validation,
   # then returns `true` if all attributes are valid.
+  # Set `valid` to false to force invalid state.
   def valid? : Bool
+    return false unless valid
     # These validations must be ran after all `before_save` callbacks have completed
     # in the case that someone has set a required field in a `before_save`. If we run
     # this in a `before_save` ourselves, the ordering would cause this to be ran first.

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -209,15 +209,14 @@ abstract class Avram::SaveOperation(T)
   end
 
   # Runs required validation,
-  # then returns `true` if all attributes are valid.
-  # Set `valid` to false to force invalid state.
+  # then returns `true` if all attributes are valid,
+  # and there's no custom errors
   def valid? : Bool
-    return false unless valid
     # These validations must be ran after all `before_save` callbacks have completed
     # in the case that someone has set a required field in a `before_save`. If we run
     # this in a `before_save` ourselves, the ordering would cause this to be ran first.
     validate_required *required_attributes
-    attributes.all? &.valid?
+    custom_errors.empty? && attributes.all?(&.valid?)
   end
 
   # Returns true if the operation has run and saved the record successfully


### PR DESCRIPTION
Fixes #529 

This allows you to set custom errors not related to attributes. When you set an error message, the whole operation is no longer valid.

The main use case is when your operations (or save operations) need some external object, but that object itself may also not be valid.

```crystal
class SaveMessage < Message::SaveOperation
  needs user : User

  before_save do
    if user.is_not_allowed_to_save_message?
       add_error(:user_not_welcome, "You don messed up A A ron.")
    end
  end
end

SaveMessage.create(user: current_user) do |op, _|
  op.errors[:user_not_welcome] == ["You don messed up A A ron"]
end
```