### PR TITLE
Only truncate expected database tables

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,6 +7,7 @@ require "./support/boxes/base_box"
 require "./support/boxes/**"
 require "./support/**"
 require "../config/*"
+require "../db/migrations/**"
 
 Pulsar.enable_test_mode!
 

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -184,22 +184,27 @@ abstract class Avram::Database
 
   class DatabaseCleaner
     private getter database : Avram::Database
-    private getter database_info : Avram::Database::DatabaseInfo
+    private getter table_names : Array(String)
 
     def initialize(@database)
-      @database_info = database.class.database_info
+      @table_names = database.class
+        .database_info
+        .table_infos
+        .select(&.table?)
+        .reject(&.migrations_table?)
+        .map(&.table_name)
     end
 
     def truncate
-      table_names = database_info.table_names
       return if table_names.empty?
+
       statement = ("TRUNCATE TABLE #{table_names.map { |name| name }.join(", ")} RESTART IDENTITY CASCADE;")
       database.exec statement
     end
 
     def delete
-      table_names = database_info.table_names
       return if table_names.empty?
+
       table_names.each do |t|
         statement = ("DELETE FROM #{t}")
         database.exec statement

--- a/src/avram/database/table_info.cr
+++ b/src/avram/database/table_info.cr
@@ -31,5 +31,9 @@ module Avram
     def column(name : String) : ColumnInfo?
       columns.find(&.column_name.==(name))
     end
+
+    def migrations_table?
+      table_name == "migrations"
+    end
   end
 end


### PR DESCRIPTION
We were truncating all table names in DatabaseInfo. This included:
- The migrations table
- Non-tables like views

This bug showed itself while running specs in generated Lucky apps because the database is truncated after every test.

We did not see this in Avram because the specs did not load the database migrations which it now does.

The bug started in https://github.com/luckyframework/avram/commit/361a9e84d4b1d3cf35346f6eb361c9388bcaccf0