### PR TITLE
Add belongs_to preload methods for existing records

### DIFF
--- a/spec/preloading/preloading_belongs_to_spec.cr
+++ b/spec/preloading/preloading_belongs_to_spec.cr
@@ -94,4 +94,28 @@ describe "Preloading belongs_to associations" do
 
     Post::BaseQuery.times_called.should eq 0
   end
+
+  it "works with existing record" do
+    with_lazy_load(enabled: false) do
+      post = PostBox.create
+      comment = CommentBox.create &.post_id(post.id)
+
+      comment = Comment::BaseQuery.preload_post(comment)
+
+      comment.post.should eq(post)
+    end
+  end
+
+  it "works with multiple existing records" do
+    with_lazy_load(enabled: false) do
+      post = PostBox.create
+      comment1 = CommentBox.create &.post_id(post.id)
+      comment2 = CommentBox.create &.post_id(post.id)
+
+      comments = Comment::BaseQuery.preload_post([comment1, comment2])
+
+      comments[0].post.should eq(post)
+      comments[1].post.should eq(post)
+    end
+  end
 end

--- a/spec/preloading/preloading_belongs_to_spec.cr
+++ b/spec/preloading/preloading_belongs_to_spec.cr
@@ -95,27 +95,41 @@ describe "Preloading belongs_to associations" do
     Post::BaseQuery.times_called.should eq 0
   end
 
-  it "works with existing record" do
-    with_lazy_load(enabled: false) do
-      post = PostBox.create
-      comment = CommentBox.create &.post_id(post.id)
+  context "with existing record" do
+    it "works" do
+      with_lazy_load(enabled: false) do
+        post = PostBox.create
+        comment = CommentBox.create &.post_id(post.id)
 
-      comment = Comment::BaseQuery.preload_post(comment)
+        comment = Comment::BaseQuery.preload_post(comment)
 
-      comment.post.should eq(post)
+        comment.post.should eq(post)
+      end
     end
-  end
 
-  it "works with multiple existing records" do
-    with_lazy_load(enabled: false) do
-      post = PostBox.create
-      comment1 = CommentBox.create &.post_id(post.id)
-      comment2 = CommentBox.create &.post_id(post.id)
+    it "works with multiple" do
+      with_lazy_load(enabled: false) do
+        post = PostBox.create
+        comment1 = CommentBox.create &.post_id(post.id)
+        comment2 = CommentBox.create &.post_id(post.id)
 
-      comments = Comment::BaseQuery.preload_post([comment1, comment2])
+        comments = Comment::BaseQuery.preload_post([comment1, comment2])
 
-      comments[0].post.should eq(post)
-      comments[1].post.should eq(post)
+        comments[0].post.should eq(post)
+        comments[1].post.should eq(post)
+      end
+    end
+
+    it "works with custom query" do
+      with_lazy_load(enabled: false) do
+        post = PostBox.create
+        comment = CommentBox.create &.post_id(post.id)
+        comment2 = CommentBox.create &.post_id(post.id)
+
+        comment = Comment::BaseQuery.preload_post(comment, Post::BaseQuery.new.preload_comments)
+
+        comment.post.comments.should eq([comment, comment2])
+      end
     end
   end
 end

--- a/spec/preloading/preloading_belongs_to_spec.cr
+++ b/spec/preloading/preloading_belongs_to_spec.cr
@@ -131,5 +131,18 @@ describe "Preloading belongs_to associations" do
         comment.post.comments.should eq([comment, comment2])
       end
     end
+
+    it "does not modify original record" do
+      with_lazy_load(enabled: false) do
+        post = PostBox.create
+        original_comment = CommentBox.create &.post_id(post.id)
+
+        Comment::BaseQuery.preload_post(original_comment)
+
+        expect_raises Avram::LazyLoadError do
+          original_comment.post
+        end
+      end
+    end
   end
 end

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -56,12 +56,12 @@ module Avram::Associations::BelongsTo
         ids = records.compact_map(&.{{ foreign_key }})
         empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
         {{ assoc_name }} = ids.empty? ? empty_results  : preload_query.id.in(ids).results.group_by(&.id)
-        records.each do |record|
-          id = record.{{ foreign_key }}
-          assoc = id.nil? ? nil : {{ assoc_name }}[id]?.try(&.first?)
-          record.__set_preloaded_{{ assoc_name }}(assoc)
-        end
-        records
+        records.map(&.dup)
+          .map do |record|
+            id = record.{{ foreign_key }}
+            assoc = id.nil? ? nil : {{ assoc_name }}[id]?.try(&.first?)
+            record.tap(&.__set_preloaded_{{ assoc_name }}(assoc))
+          end
       end
 
       def preload_{{ assoc_name }}

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -48,6 +48,24 @@ module Avram::Associations::BelongsTo
 
   private macro define_belongs_to_base_query(assoc_name, model, foreign_key)
     class BaseQuery
+      def self.preload_{{ assoc_name }}(record, preload_query = {{ model }}::BaseQuery.new)
+        preload_{{ assoc_name }}(records: [record], preload_query: preload_query).first
+      end
+
+      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query = {{ model }}::BaseQuery.new)
+        ids = records.compact_map(&.{{ foreign_key }})
+        empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
+        {{ assoc_name }} = ids.empty? ? empty_results  : preload_query.dup.id.in(ids).results.group_by(&.id)
+        records.each do |record|
+          if (id = record.{{ foreign_key }})
+            record.__set_preloaded_{{ assoc_name }} {{ assoc_name }}[id]?.try(&.first?)
+          else
+            record.__set_preloaded_{{ assoc_name }} nil
+          end
+        end
+        records
+      end
+
       def preload_{{ assoc_name }}
         preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end
@@ -59,21 +77,7 @@ module Avram::Associations::BelongsTo
 
       def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery)
         add_preload do |records|
-          ids = [] of {{ model }}::PrimaryKeyType
-          records.each do |record|
-            record.{{ foreign_key }}.try do |id|
-              ids << id
-            end
-          end
-          empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
-          {{ assoc_name }} = ids.empty? ? empty_results  : preload_query.dup.id.in(ids).results.group_by(&.id)
-          records.each do |record|
-            if (id = record.{{ foreign_key }})
-              record.__set_preloaded_{{ assoc_name }} {{ assoc_name }}[id]?.try(&.first?)
-            else
-              record.__set_preloaded_{{ assoc_name }} nil
-            end
-          end
+          self.class.preload_{{ assoc_name }}(records, preload_query)
         end
         self
       end


### PR DESCRIPTION
Part 1 of https://github.com/luckyframework/avram/issues/531

Provides a way to preload associations onto existing records. This is especially useful when you have helper methods for your actions to load certain objects from the database but don't have associations preloaded for an association needed in a particular action. You could either update that helper method to preload the association you need, but that could be overkill for your other actions. You could also make a separate query for the association records but they won't be connected to the other record so you have to pass around both where they are needed.

## Usage

```crystal
user.organization # LazyLoadError
user = UserQuery.preload_organization(user)
user.organization # Success!
```