### PR TITLE
Adding in a new after_completed callback

### DIFF
--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -309,6 +309,7 @@ abstract class Avram::SaveOperation(T)
         saved_record = record.not_nil!
         after_commit(saved_record)
         self.save_status = SaveStatus::Saved
+        after_completed(saved_record)
         Avram::Events::SaveSuccessEvent.publish(
           operation_class: self.class.name,
           attributes: generic_attributes
@@ -320,6 +321,7 @@ abstract class Avram::SaveOperation(T)
       end
     elsif valid? && changes.empty?
       self.save_status = SaveStatus::Saved
+      after_completed(record.not_nil!)
       true
     else
       mark_as_failed
@@ -360,6 +362,8 @@ abstract class Avram::SaveOperation(T)
   def after_save(_record : T); end
 
   def after_commit(_record : T); end
+
+  def after_completed(_record : T); end
 
   private def insert : T
     self.created_at.value ||= Time.utc if responds_to?(:created_at)


### PR DESCRIPTION
Fixes #432 

Also see comment: https://github.com/luckyframework/avram/pull/481#issuecomment-713881686

This is a new callback added for SaveOperation that will run after commits, but this also runs even if no changes are happening to the record. As where `after_commit` only runs if an actual DB commit happens, `after_completed` will run even when there's no changes to be made.

Naming is hard, so I'm down for a different name. I also thought about calling it `after_finalized` or `after_succesful_run`.

Another option I toyed with was doing `after_validated`; however, I felt that a name like that would imply that it would run after the `valid?` calls... This would allow us to call in both spots, but the original issue for #432 wanted to run things after stuff was saved, and that would not be the case here 🤔  