### PR TITLE
UUID schema enforcer

### DIFF
--- a/db/migrations/20180628193054_create_product.cr
+++ b/db/migrations/20180628193054_create_product.cr
@@ -4,6 +4,9 @@ class CreateProduct::V20180628193054 < Avram::Migrator::Migration::V1
       primary_key id : UUID
       add_timestamps
     end
+
+    enable_extension "uuid-ossp"
+    execute("ALTER TABLE products ALTER COLUMN id SET DEFAULT uuid_generate_v4();")
   end
 
   def rollback

--- a/spec/schema_enforcer/ensure_uuid_primary_key_has_default_spec.cr
+++ b/spec/schema_enforcer/ensure_uuid_primary_key_has_default_spec.cr
@@ -1,0 +1,34 @@
+require "../spec_helper"
+
+private class TableWithoutUUIDPrimaryKey < BaseModel
+  table :users do
+  end
+end
+
+private class TableWithoutDefaultUUID < BaseModel
+  table :line_items do
+  end
+end
+
+private class TableWithDefaultUUID < BaseModel
+  table :products do
+  end
+end
+
+include SchemaEnforcerHelpers
+
+describe Avram::SchemaEnforcer::EnsureUUIDPrimaryKeyHasDefault do
+  it "does nothing if primary key not uuid" do
+    Avram::SchemaEnforcer::EnsureUUIDPrimaryKeyHasDefault.new(TableWithoutUUIDPrimaryKey).validate!
+  end
+
+  it "raises when table's uuid primary key does not have default" do
+    expect_schema_mismatch "Primary key on the 'line_items' table has the type set as uuid but does not have a default value." do
+      Avram::SchemaEnforcer::EnsureUUIDPrimaryKeyHasDefault.new(TableWithoutDefaultUUID).validate!
+    end
+  end
+
+  it "does nothing when table's uuid primary key has default" do
+    Avram::SchemaEnforcer::EnsureUUIDPrimaryKeyHasDefault.new(TableWithDefaultUUID).validate!
+  end
+end

--- a/src/avram/database/column_info.cr
+++ b/src/avram/database/column_info.cr
@@ -8,6 +8,8 @@ module Avram
     property table_type : String
     property column_name : String
     property is_nullable : String
+    property column_default : String?
+    property data_type : String
 
     def nilable?
       is_nullable == "YES"

--- a/src/avram/database/database_info.cr
+++ b/src/avram/database/database_info.cr
@@ -6,7 +6,9 @@ module Avram
             columns.table_schema,
             columns.table_catalog,
             columns.column_name,
-            columns.is_nullable
+            columns.is_nullable,
+            columns.column_default,
+            columns.data_type
       FROM information_schema.columns as columns
       JOIN information_schema.tables as tables
         ON tables.table_name = columns.table_name

--- a/src/avram/schema_enforcer/ensure_uuid_primary_key_has_default.cr
+++ b/src/avram/schema_enforcer/ensure_uuid_primary_key_has_default.cr
@@ -1,0 +1,37 @@
+class Avram::SchemaEnforcer::EnsureUUIDPrimaryKeyHasDefault < Avram::SchemaEnforcer::Validation
+  def validate!
+    return unless uuid_primary_key? && missing_column_default?
+
+    message = <<-TEXT
+    Primary key on the '#{table_name.colorize.bold}' table has the type set as uuid but does not have a default value.
+
+    To add a default value...
+
+      ▸ Generate a migration:
+
+          lucky gen.migration AddDefaultTo#{Wordsmith::Inflector.pluralize(model_class.name)}PrimaryKey
+
+      ▸ Enable a Postgres extension to generate uuids if one is not already available in the migration:
+
+          enable_extension "uuid-ossp" # https://www.postgresql.org/docs/current/uuid-ossp.html
+
+      ▸ Update the primary key column to have a default value in the migration:
+
+          execute("ALTER TABLE #{table_name.colorize.bold} ALTER COLUMN #{primary_key_info.column_name.colorize.bold} SET DEFAULT uuid_generate_v4();")
+    TEXT
+    raise Avram::SchemaMismatchError.new(message)
+  end
+
+  def uuid_primary_key?
+    primary_key_info.data_type == "uuid"
+  end
+
+  def missing_column_default?
+    primary_key_info.column_default.nil?
+  end
+
+  def primary_key_info
+    table_info = database_info.table(table_name).not_nil!
+    table_info.column(model_class.primary_key_name.to_s).not_nil!
+  end
+end


### PR DESCRIPTION
Related to https://github.com/luckyframework/avram/issues/393

If we ever wanted to support generating UUID primary keys from the database, this validation will aid in catching tables that need to be updated to set a default value. I did **not** add it to the list of validations that run by default.