### PR TITLE
Remove primary key name and type from Model setup macro

### DIFF
--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -1,5 +1,5 @@
 class Avram::BaseQueryTemplate
-  macro setup(type, columns, associations, primary_key_name, *args, **named_args)
+  macro setup(type, columns, associations, *args, **named_args)
     class ::{{ type }}::BaseQuery
       private class Nothing
       end
@@ -7,14 +7,6 @@ class Avram::BaseQueryTemplate
       def_clone
       include Avram::Queryable({{ type }})
       include Avram::PrimaryKeyQueryable({{ type }})
-
-      # If not using default 'id' primary key
-      {% if primary_key_name.id != "id".id %}
-        # Then point 'id' to the primary key
-        def id(*args, **named_args)
-          {{ primary_key_name.id }}(*args, **named_args)
-        end
-      {% end %}
 
       macro generate_criteria_method(query_class, name, type)
         def \{{ name }}

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -166,8 +166,6 @@ abstract class Avram::Model
   macro setup(step)
     {{ step.id }}(
       type: {{ @type }},
-      primary_key_type: {{ PRIMARY_KEY_TYPE }},
-      primary_key_name: {{ PRIMARY_KEY_NAME }},
       columns: {{ COLUMNS }},
       associations: {{ ASSOCIATIONS }}
     )

--- a/src/avram/primary_key_queryable.cr
+++ b/src/avram/primary_key_queryable.cr
@@ -10,6 +10,15 @@ module Avram::PrimaryKeyQueryable(T)
       id(id).limit(1).first? || raise Avram::RecordNotFoundError.new(model: table_name, id: id.to_s)
     end
 
+    {% primary_key_name = T.constant("PRIMARY_KEY_NAME") %}
+    # If not using default 'id' primary key
+    {% if primary_key_name.id != "id".id %}
+      # Then point 'id' to the primary key
+      def id(*args, **named_args)
+        {{ primary_key_name.id }}(*args, **named_args)
+      end
+    {% end %}
+
     private def with_ordered_query : self
       if query.ordered?
         self

--- a/src/avram/save_operation_template.cr
+++ b/src/avram/save_operation_template.cr
@@ -1,5 +1,5 @@
 class Avram::SaveOperationTemplate
-  macro setup(type, columns, primary_key_type, primary_key_name, *args, **named_args)
+  macro setup(type, columns, *args, **named_args)
 
     # This makes it easy for plugins and extensions to use the base SaveOperation
     def base_query_class : ::{{ type }}::BaseQuery.class
@@ -11,10 +11,12 @@ class Avram::SaveOperationTemplate
     end
 
     class ::{{ type }}::SaveOperation < Avram::SaveOperation({{ type }})
+      {% primary_key_type = type.resolve.constant("PRIMARY_KEY_TYPE") %}
       {% if primary_key_type.id == UUID.id %}
         before_save set_uuid
 
         def set_uuid
+          {% primary_key_name = type.resolve.constant("PRIMARY_KEY_NAME") %}
           {{ primary_key_name.id }}.value ||= UUID.random()
         end
       {% end %}


### PR DESCRIPTION
Related to: https://github.com/luckyframework/avram/issues/6
Related to: https://github.com/luckyframework/avram/issues/453

Another step on the way on breaking the requirements on having primary keys. If you did not provide a primary key in the model, it immediately failed when trying to run the `setup` macro. Now, anywhere that uses the primary key pulls it through the `Crystal::Macros::TypeNode#constant` which returns `NilLiteral` if the constant is not found.