### PR TITLE
Remove Avram::Model#to_param

### DIFF
--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -63,24 +63,6 @@ describe Avram::Model do
     user.available_for_hire?.should be_false
   end
 
-  it "can be used for params" do
-    now = Time.utc
-
-    user = User.new id: 123_i64,
-      name: "Name",
-      age: 24,
-      year_born: 1990_i16,
-      joined_at: now,
-      created_at: now,
-      updated_at: now,
-      nickname: "nick",
-      total_score: nil,
-      average_score: nil,
-      available_for_hire: nil
-
-    user.to_param.should eq "123"
-  end
-
   it "sets up getters that parse the values" do
     user = QueryMe.new id: 123_i64,
       created_at: Time.utc,

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -21,10 +21,6 @@ abstract class Avram::Model
     self.class.name
   end
 
-  def to_param
-    id.to_s
-  end
-
   # Reload the model with the latest information from the database
   #
   # This method will return a new model instance with the


### PR DESCRIPTION
Related to https://github.com/luckyframework/avram/issues/453

This is an undocumented method on models that is yet another hurdle to jump when adding supports for database views. This also doesn't provide any functionality over calling `#id` on the model directly. If anyone was using it, it would take two seconds to add it back to the models they use it on.