### PR TITLE
Add support for database views

### DIFF
--- a/db/migrations/20201202225520_create_admin_users_view.cr
+++ b/db/migrations/20201202225520_create_admin_users_view.cr
@@ -1,0 +1,14 @@
+class CreateAdminUsersView::V20201202225520 < Avram::Migrator::Migration::V1
+  def migrate
+    execute <<-SQL
+      CREATE VIEW admin_users AS
+        SELECT users.*
+        FROM users
+        JOIN admins on admins.name = users.name;
+    SQL
+  end
+
+  def rollback
+    execute "DROP VIEW admin_users;"
+  end
+end

--- a/db/migrations/20201202231134_create_nickname_infos_view.cr
+++ b/db/migrations/20201202231134_create_nickname_infos_view.cr
@@ -1,0 +1,14 @@
+class CreateNicknameInfosView::V20201202231134 < Avram::Migrator::Migration::V1
+  def migrate
+    execute <<-SQL
+      CREATE VIEW nickname_infos AS
+        SELECT users.nickname, COUNT(nickname)
+        FROM users
+        GROUP BY nickname;
+    SQL
+  end
+
+  def rollback
+    execute "DROP VIEW nickname_infos;"
+  end
+end

--- a/spec/support/models/admin_user.cr
+++ b/spec/support/models/admin_user.cr
@@ -1,0 +1,16 @@
+# an AdminUser is a User who's name is also found in the Admin table
+class AdminUser < BaseModel
+  view do
+    primary_key id : Int64
+    timestamps
+    column name : String
+    column age : Int32
+    column year_born : Int16?
+    column nickname : String?
+    column joined_at : Time
+    column total_score : Int64?
+    column average_score : Float64?
+    column available_for_hire : Bool?
+    has_one sign_in_credential : SignInCredential?
+  end
+end

--- a/spec/support/models/nickname_info.cr
+++ b/spec/support/models/nickname_info.cr
@@ -1,0 +1,6 @@
+class NicknameInfo < BaseModel
+  view do
+    column nickname : String
+    column count : Int64
+  end
+end

--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -20,4 +20,9 @@ describe "views" do
     nickname_info.nickname.should eq "Johnny"
     nickname_info.count.should eq 3
   end
+
+  pending "works with SchemaEnforcer" do
+    AdminUser.ensure_correct_column_mappings!
+    NicknameInfo.ensure_correct_column_mappings!
+  end
 end

--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -1,0 +1,23 @@
+require "./spec_helper"
+
+include LazyLoadHelpers
+
+describe "views" do
+  it "works with a primary key" do
+    user = UserBox.create
+    AdminBox.new.name(user.name).create
+    admin_user = AdminUser::BaseQuery.find(user.id)
+
+    admin_user.name.should eq user.name
+  end
+
+  it "works without a primary key" do
+    UserBox.new.nickname("Johnny").create
+    UserBox.new.nickname("Johnny").create
+    UserBox.new.nickname("Johnny").create
+    nickname_info = NicknameInfo::BaseQuery.first
+
+    nickname_info.nickname.should eq "Johnny"
+    nickname_info.count.should eq 3
+  end
+end

--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -21,7 +21,7 @@ describe "views" do
     nickname_info.count.should eq 3
   end
 
-  pending "works with SchemaEnforcer" do
+  it "works with SchemaEnforcer" do
     AdminUser.ensure_correct_column_mappings!
     NicknameInfo.ensure_correct_column_mappings!
   end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -59,6 +59,24 @@ abstract class Avram::Model
     setup(Avram::SchemaEnforcer.setup)
   end
 
+  macro view(view_name = nil)
+    {% unless view_name %}
+      {% view_name = run("../run_macros/infer_table_name.cr", @type.id) %}
+    {% end %}
+
+    {{ yield }}
+
+    class_getter table_name = {{ view_name.id.symbolize }}
+    TABLE_NAME = {{ view_name.id.symbolize }}
+    setup(Avram::Model.setup_initialize)
+    setup(Avram::Model.setup_db_mapping)
+    setup(Avram::Model.setup_getters)
+    setup(Avram::Model.setup_column_info_methods)
+    setup(Avram::Model.setup_association_queries)
+    setup(Avram::BaseQueryTemplate.setup)
+    setup(Avram::SchemaEnforcer.setup)
+  end
+
   macro primary_key(type_declaration)
     PRIMARY_KEY_TYPE = {{ type_declaration.type }}
     PRIMARY_KEY_NAME = {{ type_declaration.var.symbolize }}

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -73,6 +73,7 @@ abstract class Avram::Model
     setup(Avram::Model.setup_getters)
     setup(Avram::Model.setup_column_info_methods)
     setup(Avram::Model.setup_association_queries)
+    setup(Avram::Model.setup_view_schema_enforcer_validations)
     setup(Avram::BaseQueryTemplate.setup)
     setup(Avram::SchemaEnforcer.setup)
   end
@@ -200,6 +201,11 @@ abstract class Avram::Model
   macro setup_table_schema_enforcer_validations(type, *args, **named_args)
     schema_enforcer_validations << EnsureExistingTable.new(model_class: {{ type.id }})
     schema_enforcer_validations << EnsureMatchingColumns.new(model_class: {{ type.id }})
+  end
+
+  macro setup_view_schema_enforcer_validations(type, *args, **named_args)
+    schema_enforcer_validations << EnsureExistingTable.new(model_class: {{ type.id }})
+    schema_enforcer_validations << EnsureMatchingColumns.new(model_class: {{ type.id }}, check_required: false)
   end
 
   macro setup_getters(columns, *args, **named_args)


### PR DESCRIPTION
Fixes https://github.com/luckyframework/avram/issues/453

To declare a view, instead of using the `table` macro, there is now a `view` macro. There are a few differences between the two:

- There are no default columns. If your view has a primary key or timestamps, they must be defined explicitly
- No `Model::SaveOperation` is defined
- If the view does not have a primary key, some methods don't work or will be missing
  - `Avram::Model#reload` raises a compilation error if invoked without a primary key
  - `Model::BaseQuery` no longer includes `Avram::PrimaryKeyQueryable` which has methods like `#find` that require a primary key

No functionality around materialized views is included with this change.