### PR TITLE
Schema enforcer update

### DIFF
--- a/spec/schema_enforcer/ensure_matching_columns_spec.cr
+++ b/spec/schema_enforcer/ensure_matching_columns_spec.cr
@@ -38,4 +38,10 @@ describe Avram::SchemaEnforcer::EnsureMatchingColumns do
       ModelWithRequiredAttributeOnOptionalColumn.ensure_correct_column_mappings!
     end
   end
+
+  it "does not check nilable/required if turned off" do
+    validation = Avram::SchemaEnforcer::EnsureMatchingColumns.new(ModelWithRequiredAttributeOnOptionalColumn, check_required: false)
+
+    validation.validate!
+  end
 end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -17,6 +17,10 @@ abstract class Avram::Model
     nil
   end
 
+  def self.database_table_info : Avram::Database::TableInfo?
+    database.database_info.table(table_name.to_s)
+  end
+
   def model_name
     self.class.name
   end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -44,6 +44,8 @@ abstract class Avram::Model
 
     {{ yield }}
 
+    schema_enforcer_validations << EnsureExistingTable.new(model_class: {{ @type.id }})
+    schema_enforcer_validations << EnsureMatchingColumns.new(model_class: {{ @type.id }})
     validate_primary_key
 
     class_getter table_name = {{ table_name.id.symbolize }}

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -44,8 +44,6 @@ abstract class Avram::Model
 
     {{ yield }}
 
-    schema_enforcer_validations << EnsureExistingTable.new(model_class: {{ @type.id }})
-    schema_enforcer_validations << EnsureMatchingColumns.new(model_class: {{ @type.id }})
     validate_primary_key
 
     class_getter table_name = {{ table_name.id.symbolize }}
@@ -55,6 +53,7 @@ abstract class Avram::Model
     setup(Avram::Model.setup_getters)
     setup(Avram::Model.setup_column_info_methods)
     setup(Avram::Model.setup_association_queries)
+    setup(Avram::Model.setup_table_schema_enforcer_validations)
     setup(Avram::BaseQueryTemplate.setup)
     setup(Avram::SaveOperationTemplate.setup)
     setup(Avram::SchemaEnforcer.setup)
@@ -178,6 +177,11 @@ abstract class Avram::Model
         {% end %}
       end
     {% end %}
+  end
+
+  macro setup_table_schema_enforcer_validations(type, *args, **named_args)
+    schema_enforcer_validations << EnsureExistingTable.new(model_class: {{ type.id }})
+    schema_enforcer_validations << EnsureMatchingColumns.new(model_class: {{ type.id }})
   end
 
   macro setup_getters(columns, *args, **named_args)

--- a/src/avram/schema_enforcer.cr
+++ b/src/avram/schema_enforcer.cr
@@ -6,11 +6,12 @@ module Avram::SchemaEnforcer
   MODELS_TO_SKIP = [] of String # Stringified class name
 
   macro setup(type, *args, **named_args)
+    class_getter schema_enforcer_validations = [] of Avram::SchemaEnforcer::Validation
+
     def self.ensure_correct_column_mappings!
       return if Avram::SchemaEnforcer::MODELS_TO_SKIP.includes?(self.name)
 
-      EnsureExistingTable.new(model_class: {{ type.id }}).validate!
-      EnsureMatchingColumns.new(model_class: {{ type.id }}).validate!
+      schema_enforcer_validations.each(&.validate!)
     end
 
     {% if !type.resolve.abstract? %}

--- a/src/avram/schema_enforcer/ensure_existing_table.cr
+++ b/src/avram/schema_enforcer/ensure_existing_table.cr
@@ -52,6 +52,6 @@ class Avram::SchemaEnforcer::EnsureExistingTable < Avram::SchemaEnforcer::Valida
   end
 
   private def table_missing?
-    !database_info.table?(table_name)
+    !model_class.database_table_info
   end
 end

--- a/src/avram/schema_enforcer/ensure_matching_columns.cr
+++ b/src/avram/schema_enforcer/ensure_matching_columns.cr
@@ -1,7 +1,15 @@
 class Avram::SchemaEnforcer::EnsureMatchingColumns < Avram::SchemaEnforcer::Validation
+  @check_required : Bool
   @missing_columns = [] of String
   @optional_attribute_errors = [] of String
   @required_attribute_errors = [] of String
+
+  def initialize(model_class)
+    initialize(model_class, check_required: true)
+  end
+
+  def initialize(@model_class, @check_required)
+  end
 
   def validate!
     model_class.columns.each do |attribute|
@@ -20,6 +28,8 @@ class Avram::SchemaEnforcer::EnsureMatchingColumns < Avram::SchemaEnforcer::Vali
       @missing_columns << missing_attribute_error(table_info.table_name, table_info.column_names, attribute)
       return
     end
+
+    return unless @check_required
 
     if !attribute[:nilable] && column.nilable?
       @required_attribute_errors << required_attribute_error(table_info.table_name, attribute)

--- a/src/avram/schema_enforcer/ensure_matching_columns.cr
+++ b/src/avram/schema_enforcer/ensure_matching_columns.cr
@@ -1,13 +1,7 @@
 class Avram::SchemaEnforcer::EnsureMatchingColumns < Avram::SchemaEnforcer::Validation
-  private getter table_info : Database::TableInfo
   @missing_columns = [] of String
   @optional_attribute_errors = [] of String
   @required_attribute_errors = [] of String
-
-  def initialize(model_class)
-    super
-    @table_info = database_info.table(table_name).not_nil!
-  end
 
   def validate!
     model_class.columns.each do |attribute|

--- a/src/avram/schema_enforcer/ensure_uuid_primary_key_has_default.cr
+++ b/src/avram/schema_enforcer/ensure_uuid_primary_key_has_default.cr
@@ -35,7 +35,6 @@ class Avram::SchemaEnforcer::EnsureUUIDPrimaryKeyHasDefault < Avram::SchemaEnfor
   end
 
   def primary_key_info
-    table_info = database_info.table(table_name).not_nil!
     table_info.column(model_class.primary_key_name.to_s).not_nil!
   end
 end

--- a/src/avram/schema_enforcer/validation.cr
+++ b/src/avram/schema_enforcer/validation.cr
@@ -1,14 +1,20 @@
 abstract class Avram::SchemaEnforcer::Validation
   private getter model_class : Avram::Model.class
-  private getter database_info : Avram::Database::DatabaseInfo
 
   def initialize(@model_class)
-    @database_info = @model_class.database.database_info
   end
 
   abstract def validate!
 
   private def table_name
     model_class.table_name.to_s
+  end
+
+  private def database_info
+    model_class.database.database_info
+  end
+
+  private def table_info
+    model_class.database_table_info.not_nil!
   end
 end


### PR DESCRIPTION
Related to https://github.com/luckyframework/avram/issues/453
Related to https://github.com/luckyframework/avram/pull/555

In order for views to work with SchemaEnforcer, `EnsureMatchingColumns` has to have a configuration to not check required vs. nilable on columns since all columns are nilable in views. This update also changes how we set up validations for SchemaEnforcer so that tables _could_ have different validations than views and there's a way to add/remove/customize validations