### PR TITLE
Add back Avram::Model#to_param

### DIFF
--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -63,6 +63,24 @@ describe Avram::Model do
     user.available_for_hire?.should be_false
   end
 
+  it "can be used for params" do
+    now = Time.utc
+
+    user = User.new id: 123_i64,
+      name: "Name",
+      age: 24,
+      year_born: 1990_i16,
+      joined_at: now,
+      created_at: now,
+      updated_at: now,
+      nickname: "nick",
+      total_score: nil,
+      average_score: nil,
+      available_for_hire: nil
+
+    user.to_param.should eq "123"
+  end
+
   it "sets up getters that parse the values" do
     user = QueryMe.new id: 123_i64,
       created_at: Time.utc,

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -35,6 +35,11 @@ abstract class Avram::Model
     {% raise "Unable to call Avram::Model#reload on #{@type.name} because it does not have a primary key." %}
   end
 
+  # Refer to `PrimaryKeyMethods#to_param`
+  def to_param : String
+    {% raise "Unable to call Avram::Model#to_param on #{@type.name} because it does not have a primary key. Add a primary key or define your own `to_param` method." %}
+  end
+
   macro table(table_name = nil)
     {% unless table_name %}
       {% table_name = run("../run_macros/infer_table_name.cr", @type.id) %}

--- a/src/avram/primary_key_methods.cr
+++ b/src/avram/primary_key_methods.cr
@@ -65,4 +65,10 @@ module Avram::PrimaryKeyMethods
     query = yield base_query_class.new
     query.find(id)
   end
+
+  # For integration with Lucky
+  # This allows an `Avram::Model` to be passed into a Lucky::Action to create a url/path
+  def to_param : String
+    id.to_s
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/luckyframework/avram/issues/558

Adds an implementation when primary key is defined, otherwise raises a compilation error when used.