### PR TITLE
Can preload has many associations with an existing record

### DIFF
--- a/spec/preloading/preloading_has_many_through_spec.cr
+++ b/spec/preloading/preloading_has_many_through_spec.cr
@@ -78,4 +78,63 @@ describe "Preloading has_many through associations" do
       end
     end
   end
+
+  context "with existing record" do
+    it "works" do
+      with_lazy_load(enabled: false) do
+        tag = TagBox.create
+        post = PostBox.create
+        TaggingBox.create &.tag_id(tag.id).post_id(post.id)
+
+        post = Post::BaseQuery.preload_tags(post)
+
+        post.tags.should eq([tag])
+      end
+    end
+
+    it "works with multiple" do
+      with_lazy_load(enabled: false) do
+        tag1 = TagBox.create
+        tag2 = TagBox.create
+        post1 = PostBox.create
+        post2 = PostBox.create
+        TaggingBox.create &.tag_id(tag1.id).post_id(post1.id)
+        TaggingBox.create &.tag_id(tag2.id).post_id(post2.id)
+
+        posts = Post::BaseQuery.preload_tags([post1, post2])
+
+        posts[0].tags.should eq([tag1])
+        posts[1].tags.should eq([tag2])
+      end
+    end
+
+    it "works with custom query" do
+      with_lazy_load(enabled: false) do
+        manager = ManagerBox.create
+        employee1 = EmployeeBox.new.manager_id(manager.id).create
+        employee2 = EmployeeBox.new.manager_id(manager.id).create
+        customer1 = CustomerBox.new.employee_id(employee1.id).create
+        CustomerBox.new.employee_id(employee2.id).create
+        customer3 = CustomerBox.new.employee_id(employee1.id).create
+
+        manager = Manager::BaseQuery.preload_customers(manager, Customer::BaseQuery.new.employee_id(employee1.id))
+
+        manager.customers.should eq([customer1, customer3])
+      end
+    end
+
+    it "does not modify original record" do
+      with_lazy_load(enabled: false) do
+        tag = TagBox.create
+        original_post = PostBox.create
+        TaggingBox.create &.tag_id(tag.id).post_id(original_post.id)
+
+        Post::BaseQuery.preload_tags(original_post)
+
+        expect_raises Avram::LazyLoadError do
+          original_post.tags
+        end
+      end
+    end
+  end
 end

--- a/spec/preloading/preloading_has_many_through_spec.cr
+++ b/spec/preloading/preloading_has_many_through_spec.cr
@@ -119,7 +119,8 @@ describe "Preloading has_many through associations" do
 
         manager = Manager::BaseQuery.preload_customers(manager, Customer::BaseQuery.new.employee_id(employee1.id))
 
-        manager.customers.should eq([customer1, customer3])
+        # the order of the customers seems to be somewhat random
+        manager.customers.sort_by(&.id).should eq([customer1, customer3])
       end
     end
 

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -47,11 +47,29 @@ module Avram::Associations::HasMany
 
   private macro define_has_many_base_query(assoc_name, model, foreign_key, through)
     class BaseQuery
-      def self.preload_{{ assoc_name }}(record, preload_query = {{ model }}::BaseQuery.new)
+      def self.preload_{{ assoc_name }}(record)
+        preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new)
+      end
+
+      def self.preload_{{ assoc_name }}(record)
+        modified_query = yield {{ model }}::BaseQuery.new
+        preload_{{ assoc_name }}(record: record, preload_query: modified_query)
+      end
+
+      def self.preload_{{ assoc_name }}(record, preload_query)
         preload_{{ assoc_name }}(records: [record], preload_query: preload_query).first
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query = {{ model }}::BaseQuery.new)
+      def self.preload_{{ assoc_name }}(records : Enumerable)
+        preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new)
+      end
+
+      def self.preload_{{ assoc_name }}(records : Enumerable)
+        modified_query = yield {{ model }}::BaseQuery.new
+        preload_{{ assoc_name }}(records: records, preload_query: modified_query)
+      end
+
+      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query)
         ids = records.map(&.id)
         empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
         {{ assoc_name }} = ids.empty? ? empty_results  : preload_query.{{ foreign_key }}.in(ids).results.group_by(&.{{ foreign_key }})


### PR DESCRIPTION
Fixes https://github.com/luckyframework/avram/issues/531

This is one of the last updates to support preloading associations with existing records. It adds support for has many and has many through associations.

There were some overloaded methods added that are not defined for belongs to or has one associations to support has many through's. I will make another PR adding those so that all associations have every method overload.