### PR TITLE
Add missing overloads for belongs to and has one preloading with existing records

### DIFF
--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -48,11 +48,29 @@ module Avram::Associations::BelongsTo
 
   private macro define_belongs_to_base_query(assoc_name, model, foreign_key)
     class BaseQuery
-      def self.preload_{{ assoc_name }}(record, preload_query = {{ model }}::BaseQuery.new)
+      def self.preload_{{ assoc_name }}(record)
+        preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new)
+      end
+
+      def self.preload_{{ assoc_name }}(record)
+        modified_query = yield {{ model }}::BaseQuery.new
+        preload_{{ assoc_name }}(record: record, preload_query: modified_query)
+      end
+
+      def self.preload_{{ assoc_name }}(record, preload_query)
         preload_{{ assoc_name }}(records: [record], preload_query: preload_query).first
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query = {{ model }}::BaseQuery.new)
+      def self.preload_{{ assoc_name }}(records : Enumerable)
+        preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new)
+      end
+
+      def self.preload_{{ assoc_name }}(records : Enumerable)
+        modified_query = yield {{ model }}::BaseQuery.new
+        preload_{{ assoc_name }}(records: records, preload_query: modified_query)
+      end
+
+      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query)
         ids = records.compact_map(&.{{ foreign_key }})
         empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
         {{ assoc_name }} = ids.empty? ? empty_results  : preload_query.id.in(ids).results.group_by(&.id)

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -45,11 +45,29 @@ module Avram::Associations::HasOne
 
   private macro define_has_one_base_query(assoc_name, model, foreign_key)
     class BaseQuery
-      def self.preload_{{ assoc_name }}(record, preload_query = {{ model }}::BaseQuery.new)
+      def self.preload_{{ assoc_name }}(record)
+        preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new)
+      end
+
+      def self.preload_{{ assoc_name }}(record)
+        modified_query = yield {{ model }}::BaseQuery.new
+        preload_{{ assoc_name }}(record: record, preload_query: modified_query)
+      end
+
+      def self.preload_{{ assoc_name }}(record, preload_query)
         preload_{{ assoc_name }}(records: [record], preload_query: preload_query).first
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query = {{ model }}::BaseQuery.new)
+      def self.preload_{{ assoc_name }}(records : Enumerable)
+        preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new)
+      end
+
+      def self.preload_{{ assoc_name }}(records : Enumerable)
+        modified_query = yield {{ model }}::BaseQuery.new
+        preload_{{ assoc_name }}(records: records, preload_query: modified_query)
+      end
+
+      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query)
         ids = records.map(&.id)
         empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
         {{ assoc_name }} = ids.empty? ? empty_results : preload_query.{{ foreign_key }}.in(ids).results.group_by(&.{{ foreign_key }})


### PR DESCRIPTION
Related to https://github.com/luckyframework/avram/issues/531

There were overloads added of preloading functions in https://github.com/luckyframework/avram/pull/561 that were not defined for belongs_to or has_one associations.