### PR TITLE
Adding helper method for defaults.

### DIFF
--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -20,9 +20,28 @@ class JSONQuery < Blob::BaseQuery
   end
 end
 
+class QueryWithDefault < User::BaseQuery
+
+  def initialize
+    defaults &.age.gte(21)
+  end
+end
+
 describe Avram::Queryable do
   it "can chain scope methods" do
     ChainedQuery.new.young.named("Paul")
+  end
+
+  it "can set default queries" do
+    query = QueryWithDefault.new.query
+
+    query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE users.age >= $1"
+  end
+
+  it "allows you to add on to a query with default" do
+    query = QueryWithDefault.new.name("Santa").query
+
+    query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE users.age >= $1 AND users.name = $2"
   end
 
   describe "#distinct" do

--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -21,7 +21,6 @@ class JSONQuery < Blob::BaseQuery
 end
 
 class QueryWithDefault < User::BaseQuery
-
   def initialize
     defaults &.age.gte(21)
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -220,6 +220,22 @@ module Avram::Queryable(T)
     database.scalar new_query.statement, args: new_query.args, queryable: schema_class.name
   end
 
+  # This method is meant to be used in your query object `initialize`.
+  # Allows you to set a default query for your query objects.
+  #
+  # ```crystal
+  # class AdminUserQuery < User::BaseQuery
+  #   def initialize
+  #     defaults &.admin(true)
+  #   end
+  # end
+  # ```
+  private def defaults : Nil
+    default = yield self
+
+    self.query = default.query
+  end
+
   private def with_ordered_query : self
     self
   end


### PR DESCRIPTION
Fixes #547 

When we merged in https://github.com/luckyframework/avram/pull/411 this broke the ability to easily set defaults on your query objects.

Before that PR you could do this:

```crystal
class SomeQuery < User::BaseQuery
  def initialize
    age.gte(21)
  end
end

# WHERE age >= 21
SomeQuery.new
```

After that PR, you would have to manually set the query object to get the same effect

```crystal
class SomeQuery < User::BaseQuery
  def initialize
    self.query = age.gte(21).query
  end
end
```

With this PR, you can still set the query object manually if you want, but this adds in a new `defaults` method to make it a little more clear on what your intension is. Note that this method is set to `private` because you shouldn't call this from outside of the query class. 

```crystal
class SomeQuery < User::BaseQuery
  def initialize
    defaults &.age.gte(21)
  end
end

# WHERE age >= 21
SomeQuery.new
```