### PR TITLE
fixing bug with associations

### DIFF
--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -4,12 +4,14 @@ describe Avram::Model do
   describe "has_many" do
     it "gets the related records" do
       post = PostBox.create
+      post2 = PostBox.create
       comment = CommentBox.new.post_id(post.id).create
 
       post = Post::BaseQuery.new.find(post.id)
 
-      post.comments.to_a.should eq [comment]
+      post.comments.should eq [comment]
       comment.post.should eq post
+      post2.comments.size.should eq 0
     end
 
     it "gets the related records for nilable association that exists" do
@@ -45,10 +47,12 @@ describe Avram::Model do
     it "joins the two associations" do
       tag = TagBox.create
       post = PostBox.create
+      post2 = PostBox.create
       TagBox.create
       TaggingBox.new.tag_id(tag.id).post_id(post.id).create
 
       post.tags.should eq [tag]
+      post2.tags.size.should eq 0
     end
 
     it "counts has_many through belongs_to associations" do

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -185,9 +185,9 @@ abstract class Avram::Model
   macro setup_association_queries(associations, *args, **named_args)
     {% for assoc in associations %}
       def {{ assoc[:assoc_name] }}_query
-        {% if assoc[:type] == :has_many %}
+        {% if assoc[:relationship_type] == :has_many %}
           {{ assoc[:type] }}::BaseQuery.new.{{ assoc[:foreign_key].id }}(id)
-        {% elsif assoc[:type] == :belongs_to %}
+        {% elsif assoc[:relationship_type] == :belongs_to %}
           {{ assoc[:type] }}::BaseQuery.new.id({{ assoc[:foreign_key].id }})
         {% else %}
           {{ assoc[:type] }}::BaseQuery.new


### PR DESCRIPTION
Fixes #571

Turns out this affected all associations. We never caught this because the tests only ever setup a single record. Since we were calling `type`, the associations never matched because `Tag` would never equal `:belongs_to`. 