### PR TITLE
Generate UUID primary keys in the database

### DIFF
--- a/db/migrations/20180625202051_create_line_item.cr
+++ b/db/migrations/20180625202051_create_line_item.cr
@@ -1,5 +1,7 @@
 class CreateLineItem::V20180625202051 < Avram::Migrator::Migration::V1
   def migrate
+    enable_extension "pgcrypto"
+
     create :line_items do
       primary_key id : UUID
       add_timestamps

--- a/db/migrations/20180628193054_create_product.cr
+++ b/db/migrations/20180628193054_create_product.cr
@@ -4,9 +4,6 @@ class CreateProduct::V20180628193054 < Avram::Migrator::Migration::V1
       primary_key id : UUID
       add_timestamps
     end
-
-    enable_extension "uuid-ossp"
-    execute("ALTER TABLE products ALTER COLUMN id SET DEFAULT uuid_generate_v4();")
   end
 
   def rollback

--- a/spec/migrator/create_table_statement_spec.cr
+++ b/spec/migrator/create_table_statement_spec.cr
@@ -50,7 +50,7 @@ describe Avram::Migrator::CreateTableStatement do
     built.statements.size.should eq 1
     built.statements.first.should eq <<-SQL
     CREATE TABLE users (
-      id uuid PRIMARY KEY);
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid());
     SQL
 
     built = Avram::Migrator::CreateTableStatement.new(:users).build do

--- a/spec/schema_enforcer/ensure_uuid_primary_key_has_default_spec.cr
+++ b/spec/schema_enforcer/ensure_uuid_primary_key_has_default_spec.cr
@@ -6,7 +6,7 @@ private class TableWithoutUUIDPrimaryKey < BaseModel
 end
 
 private class TableWithoutDefaultUUID < BaseModel
-  table :line_items do
+  table :prices do
   end
 end
 
@@ -23,7 +23,7 @@ describe Avram::SchemaEnforcer::EnsureUUIDPrimaryKeyHasDefault do
   end
 
   it "raises when table's uuid primary key does not have default" do
-    expect_schema_mismatch "Primary key on the 'line_items' table has the type set as uuid but does not have a default value." do
+    expect_schema_mismatch "Primary key on the 'prices' table has the type set as uuid but does not have a default value." do
       Avram::SchemaEnforcer::EnsureUUIDPrimaryKeyHasDefault.new(TableWithoutDefaultUUID).validate!
     end
   end

--- a/src/avram/migrator/columns/primary_keys/uuid_primary_key.cr
+++ b/src/avram/migrator/columns/primary_keys/uuid_primary_key.cr
@@ -8,5 +8,9 @@ module Avram::Migrator::Columns::PrimaryKeys
     def column_type : String
       "uuid"
     end
+
+    def build : String
+      %(  #{name} #{column_type} PRIMARY KEY DEFAULT gen_random_uuid())
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/luckyframework/avram/issues/122

When a user creates a migration that uses a UUID primary key, the migration will automatically set the default value to be `gen_random_uuid()` which comes from the `pgcrypto` extension. If they do not have that extension enabled, the migration will fail saying that `gen_random_uuid()` is an unknown function. They will need to add `enable_extension "pgcrypto"` in their migration before creating the table to get it working.

This does not remove or change how Avram currently sets the id value itself before inserting the record into the database https://github.com/luckyframework/avram/blob/1e6f4edd4d49c518c858ee9ecc277a3b963051eb/src/avram/save_operation_template.cr#L15-L22

We will definitely need to consider how we want to make that change but it doesn't need to be considered right now since there's no harm in doing both.

