### PR TITLE
Restrict validate_size_of to string attributes

### DIFF
--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -13,7 +13,7 @@ class UniquenessWithCustomMessageSaveOperation < User::SaveOperation
   end
 end
 
-private def attribute(value)
+private def attribute(value : T) : Avram::Attribute(T) forall T
   Avram::Attribute.new(value: value, param: nil, param_key: "fake", name: :fake)
 end
 

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -110,7 +110,7 @@ module Avram::Validations
   # validate_size_of api_key, is: 32
   # ```
   def validate_size_of(
-    attribute : Avram::Attribute,
+    attribute : Avram::Attribute(String?),
     *,
     is exact_size,
     message : Avram::Attribute::ErrorMessage = "is invalid",
@@ -121,14 +121,14 @@ module Avram::Validations
     end
   end
 
-  # Validate the size of the attribute is within a `min` and/or `max`
+  # Validate the size of a `String` is within a `min` and/or `max`
   #
   # ```
-  # validate_size_of age, min: 18, max: 100
-  # validate_size_of account_balance, min: 500
+  # validate_size_of feedback, min: 18, max: 100
+  # validate_size_of password, min: 12
   # ```
   def validate_size_of(
-    attribute : Avram::Attribute,
+    attribute : Avram::Attribute(String?),
     min = nil,
     max = nil,
     allow_nil : Bool = false


### PR DESCRIPTION
Fixes #570 

I have seen `validate_size_of` mistakenly used to validate a numeric value since the name doesn't give any indication that the implementation expects strings. As the connected issue points out, even the documentation seems confused.

This change updates the type signature to allow only attributes that contains strings. While the type signature says it only takes in `Avram::Attribute(String?)`, I found it also handles `Avram::Attribute(String)`. I didn't expect it to be that smart 😄 