### PR TITLE
Add validation for numbers

### DIFF
--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -262,4 +262,50 @@ describe Avram::Validations do
       just_nil.valid?.should be_false
     end
   end
+
+  describe "validate_numeric" do
+    it "validates" do
+      too_small_attribute = attribute(1)
+      Avram::Validations.validate_numeric(too_small_attribute, greater_than: 2)
+      too_small_attribute.errors.should eq(["is too small"])
+
+      too_large_attribute = attribute(38)
+      Avram::Validations.validate_numeric(too_large_attribute, less_than: 32)
+      too_large_attribute.errors.should eq(["is too large"])
+
+      just_right_attribute = attribute(10)
+      Avram::Validations.validate_numeric(just_right_attribute, greater_than: 9, less_than: 11)
+      just_right_attribute.valid?.should be_true
+    end
+
+    it "raises an error for an impossible condition" do
+      expect_raises(Avram::ImpossibleValidation) do
+        Avram::Validations.validate_numeric attribute(100), greater_than: 4, less_than: 1
+      end
+    end
+
+    it "can allow nil" do
+      just_nil = attribute(nil)
+      Avram::Validations.validate_numeric(just_nil, greater_than: 1, less_than: 2, allow_nil: true)
+      just_nil.valid?.should be_true
+
+      just_nil = attribute(nil)
+      Avram::Validations.validate_numeric(just_nil, greater_than: 1, less_than: 2)
+      just_nil.valid?.should be_false
+    end
+
+    it "handles different types of numbers" do
+      attribute = attribute(10.9)
+      Avram::Validations.validate_numeric(attribute, greater_than: 9, less_than: 11)
+      attribute.valid?.should be_true
+
+      attribute = attribute(10)
+      Avram::Validations.validate_numeric(attribute, greater_than: 9.8, less_than: 10.9)
+      attribute.valid?.should be_true
+
+      attribute = attribute(10_i64)
+      Avram::Validations.validate_numeric(attribute, greater_than: 9, less_than: 11)
+      attribute.valid?.should be_true
+    end
+  end
 end

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -151,4 +151,38 @@ module Avram::Validations
       end
     end
   end
+
+  # Validate a number is `greater_than` and/or `less_than`
+  #
+  # ```
+  # validate_numeric age, greater_than: 18
+  # validate_numeric count, greater_than: 0, less_than: 1200
+  # ```
+  def validate_numeric(
+    attribute : Avram::Attribute(Number?),
+    greater_than = nil,
+    less_than = nil,
+    allow_nil : Bool = false
+  )
+    if greater_than && less_than && greater_than > less_than
+      raise ImpossibleValidation.new(
+        attribute: attribute.name,
+        message: "number greater than #{greater_than} but less than #{less_than}")
+    end
+
+    number = attribute.value
+
+    if number.nil?
+      attribute.add_error "is nil" unless allow_nil
+      return
+    end
+
+    if greater_than && number < greater_than
+      attribute.add_error "is too small"
+    end
+
+    if less_than && number > less_than
+      attribute.add_error "is too large"
+    end
+  end
 end


### PR DESCRIPTION
Completes #537 

```crystal
validate_numeric age, greater_than: 18, less_than: 65
```

Any type of number can be used for the attribute or the conditions since they can all be compared.