### PR TITLE
Load correct has_one association with lazy loading

### DIFF
--- a/spec/lazy_loading_spec.cr
+++ b/spec/lazy_loading_spec.cr
@@ -14,6 +14,9 @@ describe "Lazy loading associations" do
   end
 
   it "can lazy load has_one" do
+    # to verify it is loading the correct association, not just the first
+    SignInCredentialBox.new.user_id(AdminBox.create.id).create
+
     admin = AdminBox.create
     sign_in_credential = SignInCredentialBox.new.user_id(admin.id).create
     admin.sign_in_credential!.should eq(sign_in_credential)

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -33,10 +33,9 @@ module Avram::Associations::HasOne
       if _{{ assoc_name }}_preloaded?
         @_preloaded_{{ assoc_name }}{% unless nilable %}.not_nil!{% end %}
       elsif lazy_load_enabled? || allow_lazy
-        query = {{ model }}::BaseQuery.new
-        query.{{ foreign_key.id }}(id)
-
-        query.first{% if nilable %}?{% end %}
+        {{ model }}::BaseQuery.new
+          .{{ foreign_key.id }}(id)
+          .first{% if nilable %}?{% end %}
       else
         raise Avram::LazyLoadError.new {{ @type.name.stringify }}, {{ assoc_name.stringify }}
       end


### PR DESCRIPTION
The code was still depending on the query being mutated instead of immutable so it was always loading the first association in the database. This only affected code that was using lazy loading (by enabling it or using the bang methods).