### PR TITLE
Use .adapter instead of using Lucky namespace for parsing

### DIFF
--- a/spec/support/custom_email.cr
+++ b/spec/support/custom_email.cr
@@ -1,4 +1,8 @@
 class CustomEmail
+  def self.adapter
+    Lucky
+  end
+
   def initialize(@email : String)
   end
 

--- a/spec/type_extensions/array_spec.cr
+++ b/spec/type_extensions/array_spec.cr
@@ -2,32 +2,32 @@ require "../spec_helper"
 
 describe "Array" do
   it "parses Array(Bool) from Array(String)" do
-    result = Bool::Lucky.parse(["true"])
+    result = Bool.adapter.parse(["true"])
     result.value.should eq([true])
   end
 
   it "parses Array(String)" do
-    result = String::Lucky.parse(["test"])
+    result = String.adapter.parse(["test"])
     result.value.should eq(["test"])
   end
 
   it "parses Array(Int32) from Array(String)" do
-    result = Int32::Lucky.parse(["10"])
+    result = Int32.adapter.parse(["10"])
     result.value.should eq([10])
   end
 
   it "parses Array(Int16) from Array(String)" do
-    result = Int16::Lucky.parse(["1"])
+    result = Int16.adapter.parse(["1"])
     result.value.should eq([1_i16])
   end
 
   it "parses Array(Int64) from Array(String)" do
-    result = Int64::Lucky.parse(["1000"])
+    result = Int64.adapter.parse(["1000"])
     result.value.should eq([1000_i64])
   end
 
   it "parses Array(Float64) from Array(String)" do
-    result = Float64::Lucky.parse(["3.1415"])
+    result = Float64.adapter.parse(["3.1415"])
     result.value.should eq([3.1415])
   end
 end

--- a/spec/type_extensions/int32_spec.cr
+++ b/spec/type_extensions/int32_spec.cr
@@ -2,17 +2,17 @@ require "../spec_helper"
 
 describe "Int32" do
   it "parses Int32 from String" do
-    result = Int32::Lucky.parse("10")
+    result = Int32.adapter.parse("10")
     result.value.should eq(10)
   end
 
   it "parses Int32 from Int64" do
-    result = Int32::Lucky.parse(400_i64)
+    result = Int32.adapter.parse(400_i64)
     result.value.should eq(400)
   end
 
   it "returns FailedCast when overflow from Int64 to Int32" do
-    result = Int32::Lucky.parse(2147483648)
+    result = Int32.adapter.parse(2147483648)
     result.value.should eq(nil)
     result.should be_a(Avram::Type::FailedCast)
   end

--- a/spec/type_extensions/time_spec.cr
+++ b/spec/type_extensions/time_spec.cr
@@ -12,14 +12,14 @@ describe "Time column type" do
         http_date:            "Sun, 14 Feb 2016 21:00:00 GMT",
       }
       times.each do |_format, item|
-        result = Time::Lucky.parse(item)
+        result = Time.adapter.parse(item)
         result.should be_a(Avram::Type::SuccessfulCast(Time))
       end
     end
 
     it "allows adding other formats" do
       Avram.temp_config(time_formats: ["%Y-%B-%-d"]) do
-        result = Time::Lucky.parse("2017-January-30")
+        result = Time.adapter.parse("2017-January-30")
 
         result.should be_a(Avram::Type::SuccessfulCast(Time))
         value = result.as(Avram::Type::SuccessfulCast(Time)).value
@@ -32,13 +32,13 @@ describe "Time column type" do
     it "casts a Time successfully" do
       time = Time.local
 
-      result = Time::Lucky.parse(time)
+      result = Time.adapter.parse(time)
 
       result.value.should eq(time)
     end
 
     it "can't cast an invalid value" do
-      result = Time::Lucky.parse("oh no")
+      result = Time.adapter.parse("oh no")
 
       result.should be_a(Avram::Type::FailedCast)
     end

--- a/spec/type_extensions/uuid_spec.cr
+++ b/spec/type_extensions/uuid_spec.cr
@@ -4,16 +4,16 @@ describe "UUID column type" do
   describe ".parse" do
     it "casts a UUID successfully" do
       uuid = UUID.new("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
-      UUID::Lucky.parse(uuid).value.should eq uuid
+      UUID.adapter.parse(uuid).value.should eq uuid
     end
 
     it "casts a string successfully" do
-      UUID::Lucky.parse("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+      UUID.adapter.parse("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
         .should be_a(Avram::Type::SuccessfulCast(UUID))
     end
 
     it "cannot cast a non-uuid string" do
-      UUID::Lucky.parse("not a uuid").should be_a(Avram::Type::FailedCast)
+      UUID.adapter.parse("not a uuid").should be_a(Avram::Type::FailedCast)
     end
   end
 

--- a/spec/type_extensions/uuid_spec.cr
+++ b/spec/type_extensions/uuid_spec.cr
@@ -20,7 +20,7 @@ describe "UUID column type" do
   describe ".to_db" do
     it "turns the uuid into a string" do
       uuid = UUID.new("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
-      UUID::Lucky.to_db(uuid).should eq "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+      UUID.adapter.to_db(uuid).should eq "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
     end
   end
 end

--- a/src/avram/between_criteria.cr
+++ b/src/avram/between_criteria.cr
@@ -3,8 +3,8 @@ module Avram::BetweenCriteria(T, V)
     # WHERE @column >= `low_value` AND @column <= `high_value`
     def between(low_value : V, high_value : V)
       add_clauses([
-        Avram::Where::GreaterThanOrEqualTo.new(@column, V::Lucky.to_db!(low_value)),
-        Avram::Where::LessThanOrEqualTo.new(@column, V::Lucky.to_db!(high_value))
+        Avram::Where::GreaterThanOrEqualTo.new(@column, V.adapter.to_db!(low_value)),
+        Avram::Where::LessThanOrEqualTo.new(@column, V.adapter.to_db!(high_value))
       ])
     end
   end

--- a/src/avram/charms/array_extensions.cr
+++ b/src/avram/charms/array_extensions.cr
@@ -2,6 +2,6 @@ class Array(T)
   # Proxy to the `T`'s adapter so we can call methods like
   # `Array(String).adapter.to_db(["test"])`
   def self.adapter
-    T::Lucky
+    T.adapter
   end
 end

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -81,7 +81,7 @@ class Avram::Criteria(T, V)
   end
 
   private def perform_eq(value) : T
-    add_clause(Avram::Where::Equal.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::Equal.new(column, V.adapter.to_db!(value)))
   end
 
   def nilable_eq(value) : T
@@ -109,19 +109,19 @@ class Avram::Criteria(T, V)
   end
 
   def gt(value) : T
-    add_clause(Avram::Where::GreaterThan.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::GreaterThan.new(column, V.adapter.to_db!(value)))
   end
 
   def gte(value) : T
-    add_clause(Avram::Where::GreaterThanOrEqualTo.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::GreaterThanOrEqualTo.new(column, V.adapter.to_db!(value)))
   end
 
   def lt(value) : T
-    add_clause(Avram::Where::LessThan.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::LessThan.new(column, V.adapter.to_db!(value)))
   end
 
   def lte(value) : T
-    add_clause(Avram::Where::LessThanOrEqualTo.new(column, V::Lucky.to_db!(value)))
+    add_clause(Avram::Where::LessThanOrEqualTo.new(column, V.adapter.to_db!(value)))
   end
 
   def select_min : V | Nil
@@ -145,7 +145,7 @@ class Avram::Criteria(T, V)
   end
 
   def in(values) : T
-    values = values.map { |value| V::Lucky.to_db!(value) }
+    values = values.map { |value| V.adapter.to_db!(value) }
     add_clause(Avram::Where::In.new(column, values))
   end
 

--- a/src/avram/define_attribute.cr
+++ b/src/avram/define_attribute.cr
@@ -99,7 +99,7 @@ module Avram::DefineAttribute
     end
 
     def set_{{ name }}_from_param(attribute : Avram::Attribute)
-      parse_result = {{ type }}::Lucky.parse({{ name }}_param)
+      parse_result = {{ type }}.adapter.parse({{ name }}_param)
       if parse_result.is_a? Avram::Type::SuccessfulCast
         attribute.value = parse_result.value
       else

--- a/src/avram/delete_operation.cr
+++ b/src/avram/delete_operation.cr
@@ -152,11 +152,7 @@ abstract class Avram::DeleteOperation(T)
 
       private def default_value_for_{{ attribute[:name] }}
         {% if attribute[:value] || attribute[:value] == false %}
-          {% if attribute[:type].is_a?(Generic) %}
-            parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse([{{ attribute[:value] }}])
-          {% else %}
-            parse_result = {{ attribute[:type] }}::Lucky.parse({{ attribute[:value] }})
-          {% end %}
+          parse_result = {{ attribute[:type] }}.adapter.parse({{ attribute[:value] }})
           if parse_result.is_a? Avram::Type::SuccessfulCast
             parse_result.value.as({{ attribute[:type] }})
           else
@@ -185,9 +181,9 @@ abstract class Avram::DeleteOperation(T)
         {% if attribute[:type].is_a?(Generic) %}
           # Pass `_value` in as an Array. Currently only single values are supported.
           # TODO: Update this once Lucky params support Arrays natively
-          parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse([_value])
+          parse_result = {{ attribute[:type] }}.adapter.parse([_value])
         {% else %}
-          parse_result = {{ attribute[:type] }}::Lucky.parse(_value)
+          parse_result = {{ attribute[:type] }}.adapter.parse(_value)
         {% end %}
         if parse_result.is_a? Avram::Type::SuccessfulCast
           {{ attribute[:name] }}.value = parse_result.value.as({{ attribute[:type] }})

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -209,9 +209,8 @@ abstract class Avram::Model
 
   macro setup_getters(columns, *args, **named_args)
     {% for column in columns %}
-      {% db_type = column[:type].is_a?(Generic) ? column[:type].type_vars.first : column[:type] %}
       def {{column[:name]}} : {{column[:type]}}{{(column[:nilable] ? "?" : "").id}}
-        {{ db_type }}::Lucky.from_db!(@{{column[:name]}})
+        {{ column[:type] }}.adapter.from_db!(@{{column[:name]}})
       end
       {% if column[:type].id == Bool.id %}
       def {{column[:name]}}? : Bool

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -138,11 +138,7 @@ abstract class Avram::SaveOperation(T)
 
       private def default_value_for_{{ attribute[:name] }}
         {% if attribute[:value] || attribute[:value] == false %}
-          {% if attribute[:type].is_a?(Generic) %}
-            parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse([{{ attribute[:value] }}])
-          {% else %}
-            parse_result = {{ attribute[:type] }}::Lucky.parse({{ attribute[:value] }})
-          {% end %}
+          parse_result = {{ attribute[:type] }}.adapter.parse({{ attribute[:value] }})
           if parse_result.is_a? Avram::Type::SuccessfulCast
             parse_result.value.as({{ attribute[:type] }})
           else
@@ -171,9 +167,9 @@ abstract class Avram::SaveOperation(T)
         {% if attribute[:type].is_a?(Generic) %}
           # Pass `_value` in as an Array. Currently only single values are supported.
           # TODO: Update this once Lucky params support Arrays natively
-          parse_result = {{ attribute[:type].type_vars.first }}::Lucky.parse([_value])
+          parse_result = {{ attribute[:type] }}.adapter.parse([_value])
         {% else %}
-          parse_result = {{ attribute[:type] }}::Lucky.parse(_value)
+          parse_result = {{ attribute[:type] }}.adapter.parse(_value)
         {% end %}
         if parse_result.is_a? Avram::Type::SuccessfulCast
           {{ attribute[:name] }}.value = parse_result.value.as({{ attribute[:type] }})

--- a/src/avram/uploadable.cr
+++ b/src/avram/uploadable.cr
@@ -6,6 +6,10 @@ module Avram::Uploadable
   # This should test if the filename is a blank string.
   abstract def blank? : Bool
 
+  def self.adapter
+    Lucky
+  end
+
   module Lucky
     include Avram::Type
 


### PR DESCRIPTION
Related to #408 

This brings several advantages

- We can potentially remove the Lucky namespace from Avram code
- Custom types only have to implement the method instead of the namespace
- There were bugs with generic classes where `Array(String)` was made into `Array(String)::Lucky` which doesn't work but the method does

This is a breaking change as anyone using custom types will need to add this adapter method if they didn't already.

This does not fix the related issue because the `Array.adapter` method delegates to the generic class which means there's no support for turning, for example, a string param into an array

https://github.com/luckyframework/avram/blob/03d1a7bcc981a75b103c2f54b81a430096ea0c84/src/avram/charms/array_extensions.cr#L2-L6