### PR TITLE
Add a criteria method to the type adapter

### DIFF
--- a/spec/support/custom_email.cr
+++ b/spec/support/custom_email.cr
@@ -22,6 +22,10 @@ class CustomEmail
     alias ColumnType = String
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, CustomEmail).new(query, column)
+    end
+
     def parse(value : CustomEmail)
       SuccessfulCast(CustomEmail).new(value)
     end

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -11,10 +11,9 @@ class Avram::BaseQueryTemplate
         include Avram::PrimaryKeyQueryable({{ type }})
       {% end %}
 
-      macro generate_criteria_method(query_class, name, type)
+      macro generate_criteria_method(name, type)
         def \{{ name }}
-          column_name = "#{table_name}.\{{ name }}"
-          \{{ type }}::Lucky::Criteria(\{{ query_class }}, \{{ type }}).new(self, column_name)
+          \{{ type }}.adapter.criteria(self, "#{table_name}.\{{ name }}")
         end
       end
 
@@ -48,20 +47,11 @@ class Avram::BaseQueryTemplate
           {{ column[:name] }}.eq(value)
         end
 
-        {% if column[:type].is_a?(Generic) %}
-          # Checking Array type
-          generate_criteria_method(BaseQuery, {{ column[:name] }}, {{ column[:type].type_vars.first }})
+        generate_criteria_method({{ column[:name] }}, {{ column[:type] }})
 
-          macro inherited
-            generate_criteria_method(\{{ @type.name }}, {{ column[:name] }}, {{ column[:type].type_vars.first }})
-          end
-        {% else %}
-          generate_criteria_method(BaseQuery, {{ column[:name] }}, {{ column[:type] }})
-
-          macro inherited
-            generate_criteria_method(\{{ @type.name }}, {{ column[:name] }}, {{ column[:type] }})
-          end
-        {% end %}
+        macro inherited
+          generate_criteria_method({{ column[:name] }}, {{ column[:type] }})
+        end
       {% end %}
 
       {% for assoc in associations %}

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -7,6 +7,10 @@ struct Bool
     alias ColumnType = Bool
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, Bool).new(query, column)
+    end
+
     def parse(value : String)
       if %w(true 1).includes? value
         SuccessfulCast(Bool).new true

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -45,6 +45,10 @@ macro avram_enum(enum_name, &block)
       alias ColumnType = Int32
       include Avram::Type
 
+      def self.criteria(query : T, column) forall T
+        Criteria(T, Int32).new(query, column)
+      end
+
       def from_db!(value : Int32)
         {{ enum_name }}.new(value)
       end

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -7,6 +7,10 @@ struct Float64
     alias ColumnType = Float64
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, Float64).new(query, column)
+    end
+
     def from_db!(value : Float64)
       value
     end

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -7,6 +7,10 @@ struct Int16
     alias ColumnType = Int16
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, Int16).new(query, column)
+    end
+
     def from_db!(value : Int16)
       value
     end

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -7,6 +7,10 @@ struct Int32
     alias ColumnType = Int32
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, Int32).new(query, column)
+    end
+
     def from_db!(value : Int32)
       value
     end

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -7,6 +7,10 @@ struct Int64
     alias ColumnType = Int64
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, Int64).new(query, column)
+    end
+
     def from_db!(value : Int64)
       value
     end

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -7,6 +7,10 @@ struct JSON::Any
     alias ColumnType = JSON::Any
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, JSON::Any).new(query, column)
+    end
+
     def from_db!(value : JSON::Any)
       value
     end

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -7,6 +7,10 @@ class String
     alias ColumnType = String
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, String).new(query, column)
+    end
+
     def parse(value : String)
       SuccessfulCast(String).new(value)
     end

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -18,6 +18,10 @@ struct Time
       Time::Format::ISO_8601_TIME,
     ]
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, Time).new(query, column)
+    end
+
     def from_db!(value : Time)
       value
     end

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -7,6 +7,10 @@ struct UUID
     alias ColumnType = UUID
     include Avram::Type
 
+    def self.criteria(query : T, column) forall T
+      Criteria(T, UUID).new(query, column)
+    end
+
     def parse(value : UUID)
       SuccessfulCast(UUID).new(value)
     end


### PR DESCRIPTION
No connected issue

After https://github.com/luckyframework/avram/pull/587, there was a still one place with a hard-coded reference to the type extension namespaces https://github.com/luckyframework/avram/blob/5f51bebce324a2b3a0aa3b0457b3799d567a3150/src/avram/base_query_template.cr#L14-L19

This adds a `criteria` method that takes in the query and the column name and returns an instance of an `Avram::Criteria` for the given type.

One of the other benefits it gives us is that we don't need special handling for generic types since we are calling methods on the class instead of using it to access a namespace.

This would be a breaking change since the `criteria` method is completely new and custom types would need to implement it.

The rules for adding custom types would be:

- The type must have an `adapter` class-level method that returns a class that includes the `Avram::Type` module
- That class must have a `criteria` class-level method that returns an instance of `Avram::Criteria` for the type

I considered moving the `criteria` method onto the type we extend but I didn't want to pollute the core library types with another function.