### PR TITLE
Move param extraction for operations into the attributes

### DIFF
--- a/src/avram/define_attribute.cr
+++ b/src/avram/define_attribute.cr
@@ -79,31 +79,11 @@ module Avram::DefineAttribute
 
     private def _{{ name }}
       @_{{ name }} ||= Avram::Attribute({{ type }}).new(
-        name: :{{ name }},
-        param: {{ name }}_param,
+        name: {{ name.id.symbolize }},
         value: {{ default_value }},
         param_key: self.class.param_key
       ).tap do |attribute|
-        if {{ name }}_param_given?
-          set_{{ name }}_from_param(attribute)
-        end
-      end
-    end
-
-    private def {{ name }}_param
-      params.nested(self.class.param_key)["{{ name }}"]?
-    end
-
-    private def {{ name }}_param_given?
-      params.nested(self.class.param_key).has_key?("{{ name }}")
-    end
-
-    def set_{{ name }}_from_param(attribute : Avram::Attribute)
-      parse_result = {{ type }}.adapter.parse({{ name }}_param)
-      if parse_result.is_a? Avram::Type::SuccessfulCast
-        attribute.value = parse_result.value
-      else
-        attribute.add_error "is invalid"
+        attribute.extract(params)
       end
     end
   end
@@ -113,19 +93,6 @@ module Avram::DefineAttribute
       {% raise "file_attribute must be declared with a Symbol" %}
     {% end %}
 
-    {% name = key.id %}
-
-    attribute {{ name }} : Avram::Uploadable
-
-    private def {{ name }}_param
-      if file = params.nested_file?(self.class.param_key)
-        file["{{ name }}"]?
-      end
-    end
-
-    private def {{ name }}_param_given?
-      file = params.nested_file?(self.class.param_key)
-      file && file.has_key?("{{ name }}")
-    end
+    attribute {{ key.id }} : Avram::Uploadable
   end
 end


### PR DESCRIPTION
Related to https://github.com/luckyframework/avram/issues/408

My goal is to eventually get to a place where any type of conversion from a thing to an attribute value can be handled and easily added to by users, libraries, and future maintainers of Avram. The way the code was, operations were hard-coded to extract and transform values into attributes with Lucky in mind. Hopefully you can see where these changes are headed towards. Method overloads could be added to support different types to convert the extraction to (like arrays!) or even what we are extracting from (maybe someone wants to use Avram in Amber someday and needs to pull attributes using their params API). Here's what I think the benefits of this change are:

- Have clear ways to statically type the object we're pulling attributes out of and the things we are converting them into
- Removes code from macros
- Brings together Lucky-specific code in a way that might be able to be extracted in the future

I have no idea if this way is the best, so definitely let me know if you can think of a better way. I hope this is a step in the right direction, though.