### PR TITLE
Handle updates for nested `.has_one` save operations

### DIFF
--- a/spec/operations/nested_save_operation_spec.cr
+++ b/spec/operations/nested_save_operation_spec.cr
@@ -7,6 +7,7 @@ private class SaveBusiness < Business::SaveOperation
 
   class SaveTaxId < TaxId::SaveOperation
     permit_columns number
+    needs easy : Bool
   end
 
   permit_columns name
@@ -42,7 +43,10 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => ""},
         tax_id: {"number" => ""}
 
-      SaveBusiness.create(params) do |operation, business|
+      SaveBusiness.create(
+        params,
+        save_tax_id_easy: true
+      ) do |operation, business|
         business.should be_nil
         operation.valid?.should be_false
         operations_saved?(operation, false)
@@ -52,7 +56,10 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => "123 Main St."},
         tax_id: {"number" => ""}
 
-      SaveBusiness.create(params) do |operation, business|
+      SaveBusiness.create(
+        params,
+        save_tax_id_easy: false
+      ) do |operation, business|
         business.should be_nil
         operation.valid?.should be_false
         operations_saved?(operation, false)
@@ -62,7 +69,10 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => ""},
         tax_id: {"number" => "123"}
 
-      SaveBusiness.create(params) do |operation, business|
+      SaveBusiness.create(
+        params,
+        save_tax_id_easy: true
+      ) do |operation, business|
         business.should be_nil
         operation.valid?.should be_false
         operations_saved?(operation, false)
@@ -87,7 +97,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => new_address},
         tax_id: {"number" => new_tax_num.to_s}
 
-      operation = SaveBusiness.new(business, params)
+      operation = SaveBusiness.new(business, params, save_tax_id_easy: false)
       operation.save_email_address.address.add_error("failed on purpose")
       operation.save_tax_id.number.add_error("failed on purpose")
       operation.save
@@ -98,7 +108,7 @@ describe "Avram::SaveOperation with nested operation" do
       email.reload.address.should eq(address)
       tax.reload.number.should eq(tax_num)
 
-      operation = SaveBusiness.new(business, params)
+      operation = SaveBusiness.new(business, params, save_tax_id_easy: true)
       operation.save_email_address.address.add_error("failed on purpose")
       operation.save
 
@@ -108,7 +118,7 @@ describe "Avram::SaveOperation with nested operation" do
       email.reload.address.should eq(address)
       tax.reload.number.should eq(tax_num)
 
-      operation = SaveBusiness.new(business, params)
+      operation = SaveBusiness.new(business, params, save_tax_id_easy: false)
       operation.save_tax_id.number.add_error("failed on purpose")
       operation.save
 
@@ -122,7 +132,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => new_address},
         tax_id: {"number" => new_tax_num.to_s}
 
-      operation = SaveBusiness.new(business, params)
+      operation = SaveBusiness.new(business, params, save_tax_id_easy: true)
       operation.save_tax_id.number.add_error("failed on purpose")
       operation.save
 
@@ -140,7 +150,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => "foo@bar.com"},
         tax_id: {"number" => "123"}
 
-      operation = SaveBusiness.new(params)
+      operation = SaveBusiness.new(params, save_tax_id_easy: false)
       operation.save_tax_id
       operation.save_email_address
       operation.save
@@ -173,7 +183,11 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => new_address},
         tax_id: {"number" => new_tax_num.to_s}
 
-      SaveBusiness.update(business, params) do |operation, updated_business|
+      SaveBusiness.update(
+        business,
+        params,
+        save_tax_id_easy: true
+      ) do |operation, updated_business|
         operation.valid?.should be_true
         operations_saved?(operation, saved?: true)
         operation.save_tax_id.valid?.should be_true
@@ -192,7 +206,11 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => new_address},
         tax_id: {"number" => new_tax_num.to_s}
 
-      SaveBusiness.update(business, params) do |operation, updated_business|
+      SaveBusiness.update(
+        business,
+        params,
+        save_tax_id_easy: false
+      ) do |operation, updated_business|
         operation.valid?.should be_true
         operations_saved?(operation, saved?: true)
         operation.save_tax_id.valid?.should be_true

--- a/spec/operations/nested_save_operation_spec.cr
+++ b/spec/operations/nested_save_operation_spec.cr
@@ -1,10 +1,6 @@
 require "../spec_helper"
 
 private class SaveBusiness < Business::SaveOperation
-  permit_columns name
-  has_one save_email_address : SaveEmailAddress
-  has_one save_tax_id : SaveTaxId
-
   class SaveEmailAddress < EmailAddress::SaveOperation
     permit_columns address
   end
@@ -12,6 +8,10 @@ private class SaveBusiness < Business::SaveOperation
   class SaveTaxId < TaxId::SaveOperation
     permit_columns number
   end
+
+  permit_columns name
+  has_one save_email_address : SaveEmailAddress
+  has_one save_tax_id : SaveTaxId
 end
 
 private class NestedParams < Avram::FakeParams
@@ -37,13 +37,14 @@ end
 
 describe "Avram::SaveOperation with nested operation" do
   context "when not all forms are valid" do
-    it "does not save either" do
+    it "does not create either" do
       params = NestedParams.new business: {"name" => "Fubar"},
         email_address: {"address" => ""},
         tax_id: {"number" => ""}
 
       SaveBusiness.create(params) do |operation, business|
         business.should be_nil
+        operation.valid?.should be_false
         operations_saved?(operation, false)
       end
 
@@ -53,6 +54,7 @@ describe "Avram::SaveOperation with nested operation" do
 
       SaveBusiness.create(params) do |operation, business|
         business.should be_nil
+        operation.valid?.should be_false
         operations_saved?(operation, false)
       end
 
@@ -62,25 +64,142 @@ describe "Avram::SaveOperation with nested operation" do
 
       SaveBusiness.create(params) do |operation, business|
         business.should be_nil
+        operation.valid?.should be_false
         operations_saved?(operation, false)
       end
     end
+
+    it "does not update either" do
+      name = "Foo"
+      address = "current@foo.com"
+      tax_num = 111
+
+      new_name = "Fubar"
+      new_address = "new@foo.com"
+      new_tax_num = 123
+
+      business = BusinessFactory.create &.name(name)
+      email = EmailAddressFactory.create &.business_id(business.id)
+        .address(address)
+      tax = TaxIdFactory.create &.business_id(business.id).number(tax_num)
+
+      params = NestedParams.new business: {"name" => new_name},
+        email_address: {"address" => new_address},
+        tax_id: {"number" => new_tax_num.to_s}
+
+      operation = SaveBusiness.new(business, params)
+      operation.save_email_address.address.add_error("failed on purpose")
+      operation.save_tax_id.number.add_error("failed on purpose")
+      operation.save
+
+      operation.valid?.should be_false
+      operations_saved?(operation, false)
+      business.reload.name.should eq(name)
+      email.reload.address.should eq(address)
+      tax.reload.number.should eq(tax_num)
+
+      operation = SaveBusiness.new(business, params)
+      operation.save_email_address.address.add_error("failed on purpose")
+      operation.save
+
+      operation.valid?.should be_false
+      operations_saved?(operation, false)
+      business.reload.name.should eq(name)
+      email.reload.address.should eq(address)
+      tax.reload.number.should eq(tax_num)
+
+      operation = SaveBusiness.new(business, params)
+      operation.save_tax_id.number.add_error("failed on purpose")
+      operation.save
+
+      operation.valid?.should be_false
+      operations_saved?(operation, false)
+      business.reload.name.should eq(name)
+      email.reload.address.should eq(address)
+      tax.reload.number.should eq(tax_num)
+
+      params = NestedParams.new business: {"name" => name},
+        email_address: {"address" => new_address},
+        tax_id: {"number" => new_tax_num.to_s}
+
+      operation = SaveBusiness.new(business, params)
+      operation.save_tax_id.number.add_error("failed on purpose")
+      operation.save
+
+      operation.valid?.should be_false
+      operations_saved?(operation, false)
+      business.reload.name.should eq(name)
+      email.reload.address.should eq(address)
+      tax.reload.number.should eq(tax_num)
+    end
   end
 
-  context "all forms are valid" do
-    it "sets the relationship and saves both" do
+  context "when all forms are valid" do
+    it "sets the relationship and creates both" do
       params = NestedParams.new business: {"name" => "Fubar"},
         email_address: {"address" => "foo@bar.com"},
         tax_id: {"number" => "123"}
 
-      SaveBusiness.create(params) do |operation, business|
+      operation = SaveBusiness.new(params)
+      operation.save_tax_id
+      operation.save_email_address
+      operation.save
+
+      operation.valid?.should be_true
+      operations_saved?(operation, saved?: true)
+      operation.save_tax_id.valid?.should be_true
+      operation.save_email_address.valid?.should be_true
+
+      business = operation.record.not_nil!
+      business.name.should eq "Fubar"
+      business.email_address!.address.should eq "foo@bar.com"
+      business.tax_id!.number.should eq 123
+    end
+
+    it "sets the relationship and updates both" do
+      name = "Foo"
+      address = "current@foo.com"
+      tax_num = 111
+
+      new_name = "Fubar"
+      new_address = "new@foo.com"
+      new_tax_num = 123
+
+      business = BusinessFactory.create &.name(name)
+      EmailAddressFactory.create &.business_id(business.id).address(address)
+      TaxIdFactory.create &.business_id(business.id).number(tax_num)
+
+      params = NestedParams.new business: {"name" => new_name},
+        email_address: {"address" => new_address},
+        tax_id: {"number" => new_tax_num.to_s}
+
+      SaveBusiness.update(business, params) do |operation, updated_business|
+        operation.valid?.should be_true
         operations_saved?(operation, saved?: true)
-        operation.errors.keys.size.should eq 0
-        operation.save_tax_id.errors.keys.size.should eq 0
-        operation.save_email_address.errors.keys.size.should eq 0
-        business.not_nil!.name.should eq "Fubar"
-        business.not_nil!.email_address!.address.should eq "foo@bar.com"
-        business.not_nil!.tax_id!.number.should eq 123
+        operation.save_tax_id.valid?.should be_true
+        operation.save_email_address.valid?.should be_true
+        updated_business.name.should eq new_name
+        updated_business.email_address!.address.should eq new_address
+        updated_business.tax_id!.number.should eq new_tax_num
+      end
+
+      new_address = "foo@bar.net"
+      new_tax_num = 456
+
+      business = business.reload
+
+      params = NestedParams.new business: {"name" => business.name},
+        email_address: {"address" => new_address},
+        tax_id: {"number" => new_tax_num.to_s}
+
+      SaveBusiness.update(business, params) do |operation, updated_business|
+        operation.valid?.should be_true
+        operations_saved?(operation, saved?: true)
+        operation.save_tax_id.valid?.should be_true
+        operation.save_email_address.valid?.should be_true
+        updated_business.name.should eq business.name
+        updated_business.email_address!.address.should eq new_address
+        updated_business.tax_id!.number.should eq new_tax_num
       end
     end
   end

--- a/spec/operations/nested_save_operation_spec.cr
+++ b/spec/operations/nested_save_operation_spec.cr
@@ -7,7 +7,6 @@ private class SaveBusiness < Business::SaveOperation
 
   class SaveTaxId < TaxId::SaveOperation
     permit_columns number
-    needs easy : Bool
   end
 
   permit_columns name
@@ -43,10 +42,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => ""},
         tax_id: {"number" => ""}
 
-      SaveBusiness.create(
-        params,
-        save_tax_id_easy: true
-      ) do |operation, business|
+      SaveBusiness.create(params) do |operation, business|
         business.should be_nil
         operation.valid?.should be_false
         operations_saved?(operation, false)
@@ -56,10 +52,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => "123 Main St."},
         tax_id: {"number" => ""}
 
-      SaveBusiness.create(
-        params,
-        save_tax_id_easy: false
-      ) do |operation, business|
+      SaveBusiness.create(params) do |operation, business|
         business.should be_nil
         operation.valid?.should be_false
         operations_saved?(operation, false)
@@ -69,10 +62,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => ""},
         tax_id: {"number" => "123"}
 
-      SaveBusiness.create(
-        params,
-        save_tax_id_easy: true
-      ) do |operation, business|
+      SaveBusiness.create(params) do |operation, business|
         business.should be_nil
         operation.valid?.should be_false
         operations_saved?(operation, false)
@@ -97,7 +87,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => new_address},
         tax_id: {"number" => new_tax_num.to_s}
 
-      operation = SaveBusiness.new(business, params, save_tax_id_easy: false)
+      operation = SaveBusiness.new(business, params)
       operation.save_email_address.address.add_error("failed on purpose")
       operation.save_tax_id.number.add_error("failed on purpose")
       operation.save
@@ -108,7 +98,7 @@ describe "Avram::SaveOperation with nested operation" do
       email.reload.address.should eq(address)
       tax.reload.number.should eq(tax_num)
 
-      operation = SaveBusiness.new(business, params, save_tax_id_easy: true)
+      operation = SaveBusiness.new(business, params)
       operation.save_email_address.address.add_error("failed on purpose")
       operation.save
 
@@ -118,7 +108,7 @@ describe "Avram::SaveOperation with nested operation" do
       email.reload.address.should eq(address)
       tax.reload.number.should eq(tax_num)
 
-      operation = SaveBusiness.new(business, params, save_tax_id_easy: false)
+      operation = SaveBusiness.new(business, params)
       operation.save_tax_id.number.add_error("failed on purpose")
       operation.save
 
@@ -132,7 +122,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => new_address},
         tax_id: {"number" => new_tax_num.to_s}
 
-      operation = SaveBusiness.new(business, params, save_tax_id_easy: true)
+      operation = SaveBusiness.new(business, params)
       operation.save_tax_id.number.add_error("failed on purpose")
       operation.save
 
@@ -150,7 +140,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => "foo@bar.com"},
         tax_id: {"number" => "123"}
 
-      operation = SaveBusiness.new(params, save_tax_id_easy: false)
+      operation = SaveBusiness.new(params)
       operation.save_tax_id
       operation.save_email_address
       operation.save
@@ -183,11 +173,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => new_address},
         tax_id: {"number" => new_tax_num.to_s}
 
-      SaveBusiness.update(
-        business,
-        params,
-        save_tax_id_easy: true
-      ) do |operation, updated_business|
+      SaveBusiness.update(business, params) do |operation, updated_business|
         operation.valid?.should be_true
         operations_saved?(operation, saved?: true)
         operation.save_tax_id.valid?.should be_true
@@ -206,11 +192,7 @@ describe "Avram::SaveOperation with nested operation" do
         email_address: {"address" => new_address},
         tax_id: {"number" => new_tax_num.to_s}
 
-      SaveBusiness.update(
-        business,
-        params,
-        save_tax_id_easy: false
-      ) do |operation, updated_business|
+      SaveBusiness.update(business, params) do |operation, updated_business|
         operation.valid?.should be_true
         operations_saved?(operation, saved?: true)
         operation.save_tax_id.valid?.should be_true

--- a/spec/operations/save_operation_spec.cr
+++ b/spec/operations/save_operation_spec.cr
@@ -624,6 +624,29 @@ describe "Avram::SaveOperation" do
       end
     end
   end
+
+  describe "#new_record?" do
+    context "when creating" do
+      it "returns 'true'" do
+        operation = SaveUser.new(name: "Dan", age: 34, joined_at: Time.utc)
+
+        operation.new_record?.should be_true
+        operation.save.should be_true
+        operation.new_record?.should be_true
+      end
+    end
+
+    context "when updating" do
+      it "returns 'false'" do
+        user = UserFactory.create &.name("Dan").age(34).joined_at(Time.utc)
+        operation = SaveUser.new(user, name: "Tom")
+
+        operation.new_record?.should be_false
+        operation.save.should be_true
+        operation.new_record?.should be_false
+      end
+    end
+  end
 end
 
 private def now_as_string

--- a/spec/support/factories/tax_id_factory.cr
+++ b/spec/support/factories/tax_id_factory.cr
@@ -1,0 +1,5 @@
+class TaxIdFactory < BaseFactory
+  def initialize
+    number 123
+  end
+end

--- a/src/avram/nested_save_operation.cr
+++ b/src/avram/nested_save_operation.cr
@@ -1,79 +1,52 @@
 module Avram::NestedSaveOperation
-  macro included
-    macro inherited
-      define_has_one
-    end
-  end
+  macro has_one(type_declaration)
+    {% name = type_declaration.var %}
+    {% type = type_declaration.type.resolve %}
 
-  macro define_has_one
-    macro has_one(type_declaration)
-      \{% name = type_declaration.var %}
-      \{% type = type_declaration.type.resolve %}
+    {% model_type = type.ancestors.find do |t|
+         t.stringify.starts_with?("Avram::SaveOperation(")
+       end.type_vars.first %}
 
-      \{% model_type = type.ancestors.find do |t|
-          t.stringify.starts_with?("Avram::SaveOperation(")
-        end.type_vars.first %}
+    {% assoc = T.constant(:ASSOCIATIONS).find do |assoc|
+         assoc[:relationship_type] == :has_one &&
+           assoc[:type].resolve.name == model_type.name
+       end %}
 
-      \{% assoc = T.constant(:ASSOCIATIONS).find do |assoc|
-          assoc[:relationship_type] == :has_one &&
-            assoc[:type].resolve.name == model_type.name
-        end %}
+    {% unless assoc %}
+      {% raise "#{T} must have a has_one association with #{model_type}" %}
+    {% end %}
 
-      \{% if ! assoc %}
-        \{% raise "#{T} must have a has_one association with #{model_type}" %}
-      \{% end %}
+    after_save save_{{ name }}
 
-      \{% for need in type.constant(:OPERATION_NEEDS) %}
-        needs \{{ name }}_\{{ need }}
-      \{% end %}
-
-      after_save save_\{{ name }}
-
-      def save_\{{ name }}(saved_record)
-        unless \{{ name }}.save
-          add_error(:\{{ name }}, "failed")
-          mark_nested_save_operations_as_failed
-          database.rollback
-        end
-      end
-
-      def \{{ name }}
-        @\{{ name }} ||= if new_record?
-          \{% begin %}\{{ type }}.new(
-            params,
-            \{% for need in type.constant(:OPERATION_NEEDS) %}
-              \{{ need.var }}: \{{ name }}_\{{ need.var }},
-            \{% end %}
-          )\{% end %}
-        else
-          \{% begin %}\{{ type }}.new(
-            record.not_nil!.\{{ assoc[:assoc_name].id }}!,
-            params,
-            \{% for need in type.constant(:OPERATION_NEEDS) %}
-              \{{ need.var }}: \{{ name }}_\{{ need.var }},
-            \{% end %}
-          )\{% end %}
-        end
-
-        nested = @\{{ name }}.not_nil!
-
-        record.try do |record|
-          nested.\{{ @type.constant(:FOREIGN_KEY).id }}.value = record.id
-        end
-
-        nested
-      end
-
-      def nested_save_operations
-        \{% if @type.methods.map(&.name).includes?(:nested_save_operations.id) %}
-          previous_def +
-        \{% end %}
-        [\{{ name }}]
+    def save_{{ name }}(saved_record)
+      unless {{ name }}.save
+        add_error(:{{ name }}, "failed")
+        mark_nested_save_operations_as_failed
+        database.rollback
       end
     end
 
-    macro inherited
-      define_has_one
+    def {{ name }}
+      @{{ name }} ||= if new_record?
+        {{ type }}.new(params)
+      else
+        {{ type }}.new(record.not_nil!.{{ assoc[:assoc_name].id }}!, params)
+      end
+
+      nested = @{{ name }}.not_nil!
+
+      record.try do |record|
+        nested.{{ @type.constant(:FOREIGN_KEY).id }}.value = record.id
+      end
+
+      nested
+    end
+
+    def nested_save_operations
+      {% if @type.methods.map(&.name).includes?(:nested_save_operations.id) %}
+        previous_def +
+      {% end %}
+      [{{ name }}]
     end
   end
 

--- a/src/avram/nested_save_operation.cr
+++ b/src/avram/nested_save_operation.cr
@@ -19,6 +19,8 @@ module Avram::NestedSaveOperation
     after_save save_{{ name }}
 
     def save_{{ name }}(saved_record)
+      {{ name }}.{{ @type.constant(:FOREIGN_KEY).id }}.value = saved_record.id
+
       unless {{ name }}.save
         add_error(:{{ name }}, "failed")
         mark_nested_save_operations_as_failed
@@ -32,14 +34,6 @@ module Avram::NestedSaveOperation
       else
         {{ type }}.new(record.not_nil!.{{ assoc[:assoc_name].id }}!, params)
       end
-
-      nested = @{{ name }}.not_nil!
-
-      record.try do |record|
-        nested.{{ @type.constant(:FOREIGN_KEY).id }}.value = record.id
-      end
-
-      nested
     end
 
     def nested_save_operations

--- a/src/avram/nested_save_operation.cr
+++ b/src/avram/nested_save_operation.cr
@@ -1,52 +1,79 @@
 module Avram::NestedSaveOperation
-  macro has_one(type_declaration)
-    {% name = type_declaration.var %}
-    {% type = type_declaration.type.resolve %}
+  macro included
+    macro inherited
+      define_has_one
+    end
+  end
 
-    {% model_type = type.ancestors.find do |t|
-         t.stringify.starts_with?("Avram::SaveOperation(")
-       end.type_vars.first %}
+  macro define_has_one
+    macro has_one(type_declaration)
+      \{% name = type_declaration.var %}
+      \{% type = type_declaration.type.resolve %}
 
-    {% assoc = T.constant(:ASSOCIATIONS).find do |assoc|
-         assoc[:relationship_type] == :has_one &&
-           assoc[:type].resolve.name == model_type.name
-       end %}
+      \{% model_type = type.ancestors.find do |t|
+          t.stringify.starts_with?("Avram::SaveOperation(")
+        end.type_vars.first %}
 
-    {% unless assoc %}
-      {% raise "#{T} must have a has_one association with #{model_type}" %}
-    {% end %}
+      \{% assoc = T.constant(:ASSOCIATIONS).find do |assoc|
+          assoc[:relationship_type] == :has_one &&
+            assoc[:type].resolve.name == model_type.name
+        end %}
 
-    after_save save_{{ name }}
+      \{% if ! assoc %}
+        \{% raise "#{T} must have a has_one association with #{model_type}" %}
+      \{% end %}
 
-    def save_{{ name }}(saved_record)
-      unless {{ name }}.save
-        add_error(:{{ name }}, "failed")
-        mark_nested_save_operations_as_failed
-        database.rollback
+      \{% for need in type.constant(:OPERATION_NEEDS) %}
+        needs \{{ name }}_\{{ need }}
+      \{% end %}
+
+      after_save save_\{{ name }}
+
+      def save_\{{ name }}(saved_record)
+        unless \{{ name }}.save
+          add_error(:\{{ name }}, "failed")
+          mark_nested_save_operations_as_failed
+          database.rollback
+        end
+      end
+
+      def \{{ name }}
+        @\{{ name }} ||= if new_record?
+          \{% begin %}\{{ type }}.new(
+            params,
+            \{% for need in type.constant(:OPERATION_NEEDS) %}
+              \{{ need.var }}: \{{ name }}_\{{ need.var }},
+            \{% end %}
+          )\{% end %}
+        else
+          \{% begin %}\{{ type }}.new(
+            record.not_nil!.\{{ assoc[:assoc_name].id }}!,
+            params,
+            \{% for need in type.constant(:OPERATION_NEEDS) %}
+              \{{ need.var }}: \{{ name }}_\{{ need.var }},
+            \{% end %}
+          )\{% end %}
+        end
+
+        nested = @\{{ name }}.not_nil!
+
+        record.try do |record|
+          nested.\{{ @type.constant(:FOREIGN_KEY).id }}.value = record.id
+        end
+
+        nested
+      end
+
+      def nested_save_operations
+        \{% if @type.methods.map(&.name).includes?(:nested_save_operations.id) %}
+          previous_def +
+        \{% end %}
+        [\{{ name }}]
       end
     end
 
-    def {{ name }}
-      @{{ name }} ||= if new_record?
-        {{ type }}.new(params)
-      else
-        {{ type }}.new(record.not_nil!.{{ assoc[:assoc_name].id }}!, params)
-      end
-
-      nested = @{{ name }}.not_nil!
-
-      record.try do |record|
-        nested.{{ @type.constant(:FOREIGN_KEY).id }}.value = record.id
-      end
-
-      nested
-    end
-
-    def nested_save_operations
-      {% if @type.methods.map(&.name).includes?(:nested_save_operations.id) %}
-        previous_def +
-      {% end %}
-      [{{ name }}]
+    macro inherited
+      define_has_one
     end
   end
 

--- a/src/avram/nested_save_operation.cr
+++ b/src/avram/nested_save_operation.cr
@@ -16,6 +16,8 @@ module Avram::NestedSaveOperation
       {% raise "#{T} must have a has_one association with #{model_type}" %}
     {% end %}
 
+    @_{{ name }} : {{ type }} | Nil
+
     after_save save_{{ name }}
 
     def save_{{ name }}(saved_record)
@@ -29,7 +31,7 @@ module Avram::NestedSaveOperation
     end
 
     def {{ name }}
-      @{{ name }} ||= if new_record?
+      @_{{ name }} ||= if new_record?
         {{ type }}.new(params)
       else
         {{ type }}.new(record.not_nil!.{{ assoc[:assoc_name].id }}!, params)

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -333,6 +333,15 @@ abstract class Avram::SaveOperation(T)
     !!record_id
   end
 
+  # `#persisted?` always returns `true` in `after_*` hooks, whether
+  # a new record was created, or an existing one was updated.
+  #
+  # This method should always return `true` for a create or `false`
+  # for an update, independent of the stage we are at in the operation.
+  def new_record? : Bool
+    {{ T.constant(:PRIMARY_KEY_NAME).id }}.value.nil?
+  end
+
   private def insert_or_update
     if persisted?
       update record_id


### PR DESCRIPTION
Resolves https://github.com/luckyframework/avram/issues/7

This PR seeks to support updating for `.has_one`s. The previous implementation worked for creates, not for updates. So if you called `SomeOperation.update` for an operation that called `.has_one`, you would get an error.