### PR TITLE
Add `#revert` for save operations

### DIFF
--- a/spec/operations/revert_save_operation_spec.cr
+++ b/spec/operations/revert_save_operation_spec.cr
@@ -1,0 +1,129 @@
+require "../spec_helper"
+
+private class SaveUser < User::SaveOperation
+  before_save prepare
+
+  def prepare
+    validate_required name, joined_at, age
+  end
+end
+
+private class SaveUserWithNeeds < User::SaveOperation
+  needs height : Int32
+  needs nice : Bool = true
+
+  before_save prepare
+
+  def prepare
+    validate_required name, joined_at, age
+  end
+end
+
+describe Avram::RevertSaveOperation do
+  describe "#revert" do
+    context "when operation has no needs" do
+      it "deletes new record" do
+        operation = SaveUser.new(name: "Dan", age: 34, joined_at: Time.utc)
+
+        operation.revert.valid?.should be_false
+
+        operation.save.should be_true
+        UserQuery.new.first?.should_not(be_nil)
+
+        operation.revert.valid?.should be_true
+        UserQuery.new.first?.should(be_nil)
+      end
+
+      it "reverses updated record" do
+        name = "Dan"
+        age = 34
+        joined = Time.utc(2018, 1, 1, 10, 20, 30)
+
+        new_name = "Mary"
+        new_age = 26
+        new_joined = Time.utc(2018, 1, 1, 20, 30, 40)
+
+        user = UserBox.create &.name(name).age(age).joined_at(joined)
+
+        operation = SaveUser.new(
+          user,
+          name: new_name,
+          age: new_age,
+          joined_at: new_joined
+        )
+
+        operation.revert.valid?.should be_false
+
+        operation.save.should be_true
+
+        updated_user = user.reload
+        updated_user.name.should eq(new_name)
+        updated_user.age.should eq(new_age)
+        updated_user.joined_at.should eq(new_joined)
+
+        operation.revert.valid?.should be_true
+
+        reverted_user = user.reload
+        reverted_user.name.should eq(name)
+        reverted_user.age.should eq(age)
+        reverted_user.joined_at.should eq(joined)
+      end
+    end
+
+    context "when operation has needs" do
+      it "deletes new record" do
+        operation = SaveUserWithNeeds.new(
+          name: "Dan",
+          age: 34,
+          joined_at: Time.utc,
+          nice: true,
+          height: 12
+        )
+
+        operation.revert.valid?.should be_false
+
+        operation.save.should be_true
+        UserQuery.new.first?.should_not(be_nil)
+
+        operation.revert.valid?.should be_true
+        UserQuery.new.first?.should(be_nil)
+      end
+
+      it "reverses updated record" do
+        name = "Dan"
+        age = 34
+        joined = Time.utc(2018, 1, 1, 10, 20, 30)
+
+        new_name = "Mary"
+        new_age = 26
+        new_joined = Time.utc(2018, 1, 1, 20, 30, 40)
+
+        user = UserBox.create &.name(name).age(age).joined_at(joined)
+
+        operation = SaveUserWithNeeds.new(
+          user,
+          name: new_name,
+          age: new_age,
+          joined_at: new_joined,
+          height: 14
+        )
+
+        operation.revert.valid?.should be_false
+
+        operation.save.should be_true
+
+        updated_user = user.reload
+        updated_user.name.should eq(new_name)
+        updated_user.age.should eq(new_age)
+        updated_user.joined_at.should eq(new_joined)
+
+        operation.revert.valid?.should be_true
+
+        reverted_user = user.reload
+        reverted_user.name.should eq(name)
+        reverted_user.age.should eq(age)
+        reverted_user.joined_at.should eq(joined)
+      end
+    end
+  end
+end

--- a/spec/operations/save_operation_spec.cr
+++ b/spec/operations/save_operation_spec.cr
@@ -647,54 +647,6 @@ describe "Avram::SaveOperation" do
       end
     end
   end
-
-  describe "#revert" do
-    context "when new record was created" do
-      it "deletes new record" do
-        operation = SaveUser.new(name: "Dan", age: 34, joined_at: Time.utc)
-
-        operation.save.should be_true
-        UserQuery.new.first?.should_not(be_nil)
-        operation.revert.valid?.should be_true
-        UserQuery.new.first?.should(be_nil)
-      end
-    end
-
-    context "when existing record was updated" do
-      it "reverts update" do
-        name = "Dan"
-        age = 34
-        joined = Time.utc(2018, 1, 1, 10, 20, 30)
-
-        new_name = "Mary"
-        new_age = 26
-        new_joined = Time.utc(2018, 1, 1, 20, 30, 40)
-
-        user = UserBox.create &.name(name).age(age).joined_at(joined)
-
-        operation = SaveUser.new(
-          user,
-          name: new_name,
-          age: new_age,
-          joined_at: new_joined
-        )
-
-        operation.save.should be_true
-
-        updated_user = user.reload
-        updated_user.name.should eq(new_name)
-        updated_user.age.should eq(new_age)
-        updated_user.joined_at.should eq(new_joined)
-
-        operation.revert.valid?.should be_true
-
-        reverted_user = user.reload
-        reverted_user.name.should eq(name)
-        reverted_user.age.should eq(age)
-        reverted_user.joined_at.should eq(joined)
-      end
-    end
-  end
 end
 
 private def now_as_string

--- a/spec/operations/save_operation_spec.cr
+++ b/spec/operations/save_operation_spec.cr
@@ -624,6 +624,54 @@ describe "Avram::SaveOperation" do
       end
     end
   end
+
+  describe "#revert" do
+    context "when new record was created" do
+      it "deletes new record" do
+        operation = SaveUser.new(name: "Dan", age: 34, joined_at: Time.utc)
+
+        operation.save.should be_true
+        UserQuery.new.first?.should_not(be_nil)
+        operation.revert.should be_a(SaveUser)
+        UserQuery.new.first?.should(be_nil)
+      end
+    end
+
+    context "when existing record was updated" do
+      it "reverts update" do
+        name = "Dan"
+        age = 34
+        joined = Time.utc(2018, 1, 1, 10, 20, 30)
+
+        new_name = "Mary"
+        new_age = 26
+        new_joined = Time.utc(2018, 1, 1, 20, 30, 40)
+
+        user = UserBox.create &.name(name).age(age).joined_at(joined)
+
+        operation = SaveUser.new(
+          user,
+          name: new_name,
+          age: new_age,
+          joined_at: new_joined
+        )
+
+        operation.save.should be_true
+
+        updated_user = user.reload
+        updated_user.name.should eq(new_name)
+        updated_user.age.should eq(new_age)
+        updated_user.joined_at.should eq(new_joined)
+
+        operation.revert.should be_a(SaveUser)
+
+        reverted_user = user.reload
+        reverted_user.name.should eq(name)
+        reverted_user.age.should eq(age)
+        reverted_user.joined_at.should eq(joined)
+      end
+    end
+  end
 end
 
 private def now_as_string

--- a/spec/operations/save_operation_spec.cr
+++ b/spec/operations/save_operation_spec.cr
@@ -625,6 +625,29 @@ describe "Avram::SaveOperation" do
     end
   end
 
+  describe "#new_record?" do
+    context "when saving new records" do
+      it "returns 'true'" do
+        operation = SaveUser.new(name: "Dan", age: 34, joined_at: Time.utc)
+
+        operation.new_record?.should be_true
+        operation.save.should be_true
+        operation.new_record?.should be_true
+      end
+    end
+
+    context "when updating existing records" do
+      it "returns 'false'" do
+        user = UserBox.create &.name("Dan").age(34).joined_at(Time.utc)
+        operation = SaveUser.new(user, name: "Tom")
+
+        operation.new_record?.should be_false
+        operation.save.should be_true
+        operation.new_record?.should be_false
+      end
+    end
+  end
+
   describe "#revert" do
     context "when new record was created" do
       it "deletes new record" do

--- a/spec/operations/save_operation_spec.cr
+++ b/spec/operations/save_operation_spec.cr
@@ -655,7 +655,7 @@ describe "Avram::SaveOperation" do
 
         operation.save.should be_true
         UserQuery.new.first?.should_not(be_nil)
-        operation.revert.should be_a(SaveUser)
+        operation.revert.valid?.should be_true
         UserQuery.new.first?.should(be_nil)
       end
     end
@@ -686,7 +686,7 @@ describe "Avram::SaveOperation" do
         updated_user.age.should eq(new_age)
         updated_user.joined_at.should eq(new_joined)
 
-        operation.revert.should be_a(SaveUser)
+        operation.revert.valid?.should be_true
 
         reverted_user = user.reload
         reverted_user.name.should eq(name)

--- a/src/avram/revert_save_operation.cr
+++ b/src/avram/revert_save_operation.cr
@@ -20,6 +20,9 @@ module Avram::RevertSaveOperation
             \{{ need.var }}: \{{ need.var }},
           \{% end %}
         )\{% end %}
+
+        operation.add_error(:revert, "No record to revert")
+        return operation
       end
 
       unless saved?

--- a/src/avram/revert_save_operation.cr
+++ b/src/avram/revert_save_operation.cr
@@ -1,0 +1,73 @@
+module Avram::RevertSaveOperation
+  macro included
+    macro inherited
+      generate_revert_methods
+    end
+  end
+
+  macro generate_revert_methods
+    def revert : self
+      if persisted?
+        operation = \{% begin %}self.class.new(
+          record.not_nil!,
+          \{% for need in OPERATION_NEEDS %}
+            \{{ need.var }}: \{{ need.var }},
+          \{% end %}
+        )\{% end %}
+      else
+        operation = \{% begin %}self.class.new(
+          \{% for need in OPERATION_NEEDS %}
+            \{{ need.var }}: \{{ need.var }},
+          \{% end %}
+        )\{% end %}
+      end
+
+      unless saved?
+        operation.add_error(:revert, "Cannot revert an unsaved record")
+        return operation
+      end
+
+      if new_record?
+        revert_create(operation)
+      else
+        revert_update(operation)
+      end
+
+      operation
+    end
+
+    def revert! : self
+      operation = revert
+      return operation if operation.valid?
+      raise Avram::InvalidOperationError.new(operation: operation)
+    end
+
+    private def revert_create(operation)
+      if record.not_nil!.delete.rows_affected < 1
+        operation.add_error(:revert, "Could not delete record")
+      end
+    end
+
+    private def revert_update(operation)
+      \{% for attribute in ATTRIBUTES %}
+        operation.\{{ attribute.var }}.value =
+          \{{ attribute.var }}.original_value
+      \{% end %}
+
+      \{% if @type.constant(:COLUMN_ATTRIBUTES) %}
+        \{% for column in COLUMN_ATTRIBUTES.uniq %}
+          operation.\{{ column[:name].id }}.value =
+            \{{ column[:name].id }}.original_value
+        \{% end %}
+      \{% end %}
+
+      unless operation.save
+        operation.add_error(:revert, "Could not update record")
+      end
+    end
+
+    macro inherited
+      generate_revert_methods
+    end
+  end
+end


### PR DESCRIPTION
Reverts a saved record to its initial state -- a newly-created record is deleted, and an updated existing record is reversed to its original state.

Among other things, this is needed to complete https://github.com/luckyframework/avram/pull/596. When an operation contains multiple nested operations (via `.has_one` macro), this should help us revert already-saved nested operations if one nested operation fails.

Currently, when a nested operation fails, the parent operation marks all nested operations as failed. But any nested operation that successfully saved before the said failure could have its changes intact in the database in particular instances.

After this change, #596 is as simple as:

```crystal
  # This method would be renamed
  def mark_nested_save_operations_as_failed
    nested_save_operations.each do |operation|
      operation.revert # <= Magic happens here
      operation.as(Avram::MarkAsFailed).mark_as_failed
    end
  end
```

I've tested this locally, and it works. All specs pass.