### PR TITLE
Support datetime-local time parsing

### DIFF
--- a/spec/type_extensions/time_spec.cr
+++ b/spec/type_extensions/time_spec.cr
@@ -5,15 +5,26 @@ describe "Time column type" do
     it "casts various formats successfully" do
       time = Time.local
       times = {
-        iso8601:              time.to_s("%FT%X%z"),
-        rfc2822:              time.to_rfc2822,
-        rfc3339:              time.to_rfc3339,
-        space_separated_yaml: "2001-12-14 21:59:43.10 -5",
-        http_date:            "Sun, 14 Feb 2016 21:00:00 GMT",
+        iso8601:             time.to_s("%FT%X%z"),
+        rfc2822:             time.to_rfc2822,
+        rfc3339:             time.to_rfc3339,
+        datetime_html_input: time.to_s("%Y-%m-%dT%H:%M:%S"),
+        http_date:           time.to_s("%a, %d %b %Y %H:%M:%S GMT"),
       }
       times.each do |_format, item|
         result = Time.adapter.parse(item)
         result.should be_a(Avram::Type::SuccessfulCast(Time))
+
+        unless result.is_a? Avram::Type::SuccessfulCast(Time)
+          next
+        end
+
+        result.value.year.should eq(time.year)
+        result.value.month.should eq(time.month)
+        result.value.day.should eq(time.day)
+        result.value.hour.should eq(time.hour)
+        result.value.minute.should eq(time.minute)
+        result.value.second.should eq(time.second)
       end
     end
 

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -11,6 +11,9 @@ struct Time
       Time::Format::ISO_8601_DATE_TIME,
       Time::Format::RFC_2822,
       Time::Format::RFC_3339,
+      # HTML datetime-local inputs are basically RFC 3339 without the timezone:
+      # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local
+      Time::Format.new("%Y-%m-%dT%H:%M:%S", Time::Location.local),
       # Dates and times go last, otherwise it will parse strings with both
       # dates *and* times incorrectly.
       Time::Format::HTTP_DATE,


### PR DESCRIPTION
This PR intends to close #602.

You can read more about DateTime Local inputs at this link:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local

From what I can gather, browsers basically use [RFC 3339](https://tools.ietf.org/html/rfc3339) without the timezone. Because of this, our `Time::Format::RFC_3339` parser wasn't actually extracting the time element from a `datetime-local` input type in Lucky.

### PR Components

- [TimeExtensions#parse] Add a custom `Time::Format` that will parse these `datetime-local` inputs correctly, though it _will_ always use `Time::Location.local` for the timezone.
- [Specs] Moved the hardcoded strings to use time formatting where possible so that we can test more date/time ranges and check specific time values more easily. 
- [Specs] Add some checks on specific parsed time components so that we can be more confident in the future that we're not missing components of the time.
- [Specs] Removed a test scenario for `space_separated_yaml`. Best I can tell, that was added [here](https://github.com/luckyframework/avram/pull/146) without any additional details, but it has never actually worked since we didn't have a formatter that matched down to the time element. Without a clear user story, I didn't feel confident adding a custom parser that would allow the new test validations to pass for that format.