### PR TITLE
Move new HTTP form datetime-local parser to force UTC

### DIFF
--- a/spec/type_extensions/time_spec.cr
+++ b/spec/type_extensions/time_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe "Time column type" do
   describe ".parse" do
     it "casts various formats successfully" do
-      time = Time.local
+      time = Time.utc
       times = {
         iso8601:             time.to_s("%FT%X%z"),
         rfc2822:             time.to_rfc2822,

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -13,7 +13,7 @@ struct Time
       Time::Format::RFC_3339,
       # HTML datetime-local inputs are basically RFC 3339 without the timezone:
       # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local
-      Time::Format.new("%Y-%m-%dT%H:%M:%S", Time::Location.local),
+      Time::Format.new("%Y-%m-%dT%H:%M:%S", Time::Location::UTC),
       # Dates and times go last, otherwise it will parse strings with both
       # dates *and* times incorrectly.
       Time::Format::HTTP_DATE,


### PR DESCRIPTION
Previously, we were using `Time.local` and `Time::Location.local`. For reasons we have been unable to discover, the specs would fail for anyone who didn't have their crystal time zone set to UTC.

Forcing this parser and spec to use UTC time is expected to get the test suite green for every scenario.