### PR TITLE
Add support for case insensitive text columns (citext)

### DIFF
--- a/db/migrations/20180612221318_create_businesses.cr
+++ b/db/migrations/20180612221318_create_businesses.cr
@@ -13,10 +13,12 @@ class CreateBusinesses::V20180612221318 < Avram::Migrator::Migration::V1
       add_belongs_to business : Business, on_delete: :cascade
     end
 
+    enable_extension "citext"
+
     create :email_addresses do
       primary_key id : Int64
       add_timestamps
-      add address : String
+      add address : String, case_sensitive: false
       add_belongs_to business : Business?, on_delete: :cascade
     end
   end

--- a/spec/case_insensitive_column_spec.cr
+++ b/spec/case_insensitive_column_spec.cr
@@ -1,0 +1,21 @@
+require "./spec_helper.cr"
+
+class EmailAddressQuery < EmailAddress::BaseQuery
+end
+
+private class SaveEmailAddress < EmailAddress::SaveOperation
+  before_save do
+    validate_uniqueness_of address
+  end
+end
+
+describe "Case insensitive columns" do
+  it "fails uniqueness validation" do
+    existing = EmailAddressBox.create
+
+    SaveEmailAddress.create(address: existing.address) do |operation, _result|
+      operation.valid?.should be_false
+      operation.address.errors.should eq(["is already taken"])
+    end
+  end
+end

--- a/spec/support/boxes/business_box.cr
+++ b/spec/support/boxes/business_box.cr
@@ -3,9 +3,3 @@ class BusinessBox < BaseBox
     name "My Biz"
   end
 end
-
-class EmailAddressBox < BaseBox
-  def initialize
-    address "foo@bar.com"
-  end
-end

--- a/spec/support/boxes/email_address_box.cr
+++ b/spec/support/boxes/email_address_box.cr
@@ -1,0 +1,5 @@
+class EmailAddressBox < BaseBox
+  def initialize
+    address "foo@bar.com"
+  end
+end

--- a/spec/support/models/business.cr
+++ b/spec/support/models/business.cr
@@ -12,10 +12,3 @@ class TaxId < BaseModel
     belongs_to business : Business
   end
 end
-
-class EmailAddress < BaseModel
-  table do
-    column address : String
-    belongs_to business : Business?
-  end
-end

--- a/spec/support/models/email_address.cr
+++ b/spec/support/models/email_address.cr
@@ -1,0 +1,6 @@
+class EmailAddress < BaseModel
+  table do
+    column address : String
+    belongs_to business : Business?
+  end
+end

--- a/src/avram/migrator/columns/string_column.cr
+++ b/src/avram/migrator/columns/string_column.cr
@@ -3,12 +3,16 @@ require "./base"
 module Avram::Migrator::Columns
   class StringColumn(T) < Base
     @default : T | Nil = nil
+    private getter? case_sensitive : Bool
 
-    def initialize(@name, @nilable, @default)
+    def initialize(@name, @nilable, @default, @case_sensitive = true)
     end
 
+    # If `case_sensitive?` is false then the column type is set to `citext`
+    # which requires the `citext` extension to be enabled
+    # otherwise the type is `text`
     def column_type : String
-      "text"
+      case_sensitive? ? "text" : "citext"
     end
   end
 end


### PR DESCRIPTION
Fixes #550 

## Usage

In a migration you'd pass the the `case_sensitive: false` flag to a string column to make its type `citext`. The [citext extension](https://www.postgresql.org/docs/current/citext.html) must be enabled.

```crystal
enable_extension "citext"

create table_for(User) do
  add name : String
  add email : String, case_sensitive: false
end
```

This would create the `users` table with a case sensitive `name` column and a case insensitive `email` column.