### PR TITLE
Run after_save and after_commit even if no changes were made

### DIFF
--- a/spec/operations/save_operation_callbacks_spec.cr
+++ b/spec/operations/save_operation_callbacks_spec.cr
@@ -160,13 +160,22 @@ end
 private class UpdateOperationWithNoUpdates < Post::SaveOperation
   include TestableOperation
 
-  after_completed :mark_operation_completed
-  after_completed do |_saved_post|
-    mark_callback("after_completed_in_a_block")
+  after_save :mark_operation_saved
+  after_save do |_saved_post|
+    mark_callback("after_save_in_a_block")
   end
 
-  private def mark_operation_completed(_saved_post)
-    mark_callback("after_completed_called")
+  after_commit :mark_operation_committed
+  after_commit do |_saved_post|
+    mark_callback("after_commit_in_a_block")
+  end
+
+  private def mark_operation_saved(_saved_post)
+    mark_callback("after_save_called")
+  end
+
+  private def mark_operation_committed(_saved_post)
+    mark_callback("after_commit_called")
   end
 end
 
@@ -245,12 +254,14 @@ describe "Avram::SaveOperation callbacks" do
     end
   end
 
-  it "runs after_completed callbacks even when nothing is being updated" do
+  it "runs callbacks even when nothing is being updated" do
     post = PostBox.create
     UpdateOperationWithNoUpdates.update(post) do |operation, _updated_post|
       operation.callbacks_that_ran.should eq([
-        "after_completed_called",
-        "after_completed_in_a_block",
+        "after_save_called",
+        "after_save_in_a_block",
+        "after_commit_called",
+        "after_commit_in_a_block",
       ])
     end
   end

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -525,8 +525,7 @@ module Avram::Callbacks
     {% raise <<-ERROR
       after_completed has been removed
 
-      after_save and after_commit now runs even if no changes were made
-      to an existing record.
+      The after_save and after_commit callbacks are called even if no changes were made
 
       Try this...
 
@@ -552,8 +551,7 @@ module Avram::Callbacks
     {% raise <<-ERROR
       after_completed has been removed
 
-      after_save and after_commit now runs even if no changes were made
-      to an existing record.
+      The after_save and after_commit callbacks are called even if no changes were made
 
       Try this...
 

--- a/src/avram/callbacks.cr
+++ b/src/avram/callbacks.cr
@@ -522,9 +522,17 @@ module Avram::Callbacks
   # ```
   #
   macro after_completed(method_name)
-    after_completed do |object|
-      {{ method_name.id }}(object)
-    end
+    {% raise <<-ERROR
+      after_completed has been removed
+
+      after_save and after_commit now runs even if no changes were made
+      to an existing record.
+
+      Try this...
+
+        ▸ after_commit #{method_name.id}
+      ERROR
+    %}
   end
 
   # Run the given block after save and after successful transaction commit
@@ -541,16 +549,17 @@ module Avram::Callbacks
   # end
   # ```
   macro after_completed(&block)
-    def after_completed(%object : T)
-      {% if @type.methods.map(&.name).includes?(:after_completed.id) %}
-        previous_def
-      {% else %}
-        super
-      {% end %}
+    {% raise <<-ERROR
+      after_completed has been removed
 
-      {{ block.args.first }} = %object
-      {{ block.body }}
-    end
+      after_save and after_commit now runs even if no changes were made
+      to an existing record.
+
+      Try this...
+
+        ▸ after_commit #{block.id}
+      ERROR
+    %}
   end
 
   # :nodoc:

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -291,19 +291,17 @@ abstract class Avram::SaveOperation(T)
 
   def save : Bool
     before_save
-    if valid? && (!persisted? || changes.any?)
+
+    if valid?
       transaction_committed = database.transaction do
-        insert_or_update
-        saved_record = record.not_nil!
-        after_save(saved_record)
+        insert_or_update if changes.any? || !persisted?
+        after_save(record.not_nil!)
         true
       end
 
       if transaction_committed
-        saved_record = record.not_nil!
-        after_commit(saved_record)
         self.save_status = SaveStatus::Saved
-        after_completed(saved_record)
+        after_commit(record.not_nil!)
         Avram::Events::SaveSuccessEvent.publish(
           operation_class: self.class.name,
           attributes: generic_attributes
@@ -313,10 +311,6 @@ abstract class Avram::SaveOperation(T)
         mark_as_failed
         false
       end
-    elsif valid? && changes.empty?
-      self.save_status = SaveStatus::Saved
-      after_completed(record.not_nil!)
-      true
     else
       mark_as_failed
       false
@@ -357,7 +351,19 @@ abstract class Avram::SaveOperation(T)
 
   def after_commit(_record : T); end
 
-  def after_completed(_record : T); end
+  def after_completed(_record : T)
+    {% raise <<-ERROR
+      after_completed has been removed
+
+      after_save and after_commit now runs even if no changes were made
+      to an existing record.
+
+      Try this...
+
+        ▸ use after_commit instead
+      ERROR
+    %}
+  end
 
   private def insert : T
     self.created_at.value ||= Time.utc if responds_to?(:created_at)

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -351,20 +351,6 @@ abstract class Avram::SaveOperation(T)
 
   def after_commit(_record : T); end
 
-  def after_completed(_record : T)
-    {% raise <<-ERROR
-      after_completed has been removed
-
-      after_save and after_commit now runs even if no changes were made
-      to an existing record.
-
-      Try this...
-
-        ▸ use after_commit instead
-      ERROR
-    %}
-  end
-
   private def insert : T
     self.created_at.value ||= Time.utc if responds_to?(:created_at)
     self.updated_at.value ||= Time.utc if responds_to?(:updated_at)


### PR DESCRIPTION
Closes #604

This PR ensures all nested operations called in `after_save` run, at all times, and in a transaction. It is, therefore, automatically rolled back if something goes wrong. Other potential benefits are discussed in the linked issue.

With this, we no longer need #600 for completing #596.