### PR TITLE
Composite primary key migration

### DIFF
--- a/spec/migrator/create_table_statement_spec.cr
+++ b/spec/migrator/create_table_statement_spec.cr
@@ -90,6 +90,25 @@ describe Avram::Migrator::CreateTableStatement do
     SQL
   end
 
+  it "can create tables with composite primary keys with primary key constraint at end" do
+    built = Avram::Migrator::CreateTableStatement.new(:users).build do
+      add id1 : Int64
+      add id2 : UUID
+      composite_primary_key :id1, :id2
+
+      add example : String
+    end
+
+    built.statements.size.should eq 1
+    built.statements.first.should eq <<-SQL
+    CREATE TABLE users (
+      id1 bigint NOT NULL,
+      id2 uuid NOT NULL,
+      example text NOT NULL,
+      PRIMARY KEY (id1, id2));
+    SQL
+  end
+
   it "sets default values" do
     built = Avram::Migrator::CreateTableStatement.new(:users).build do
       add name : String, default: "name"

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -75,6 +75,9 @@ class Avram::Migrator::CreateTableStatement
   end
 
   macro composite_primary_key(*columns)
+    {% if columns.size < 2 %}
+    {% raise "composite_primary_key expected at least two primary keys, instead got #{columns.size}" %}
+    {% end %}
     constraints << "  PRIMARY KEY ({{columns.join(", ").id}})"
   end
 

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -6,6 +6,7 @@ class Avram::Migrator::CreateTableStatement
   include Avram::Migrator::MissingOnDeleteWithBelongsToError
 
   private getter rows = [] of String
+  private getter constraints = [] of String
 
   def initialize(@table_name : Symbol)
   end
@@ -55,6 +56,8 @@ class Avram::Migrator::CreateTableStatement
     String.build do |statement|
       statement << initial_table_statement
       statement << rows.join(",\n")
+      statement << ",\n" if !constraints.empty?
+      statement << constraints.join(", \n")
       statement << ");"
     end
   end
@@ -69,6 +72,10 @@ class Avram::Migrator::CreateTableStatement
     rows << Avram::Migrator::Columns::PrimaryKeys::{{ type_declaration.type }}PrimaryKey
       .new(name: {{ type_declaration.var.stringify }})
       .build
+  end
+
+  macro composite_primary_key(*columns)
+    constraints << "  PRIMARY KEY ({{columns.join(", ").id}})"
   end
 
   macro add_timestamps


### PR DESCRIPTION
This PR is about the migration part of the composite primary key implementation.
It adds `composite_primary_key` to the create table migrator.
It works like this
```crystal
def migrate
  create table_for(UserPost) do
    add_belongs_to user : User, on_delete: :cascade
    add_belongs_to post : Post, on_delete: :cascade
    primary_key :user_id, :post_id
  end
end
```

There is still some work to do with add_belongs_to if it's a composite PK but for that it needs some work on the model part.
Issue #129 