### PR TITLE
Remove special handling of Float64 columns

### DIFF
--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -4,7 +4,7 @@ struct Float64
   end
 
   module Lucky
-    alias ColumnType = Float64
+    alias ColumnType = ::PG::Numeric
     include Avram::Type
 
     def self.criteria(query : T, column) forall T

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -166,16 +166,12 @@ abstract class Avram::Model
     DB.mapping({
       {% for column in columns %}
         {{column[:name]}}: {
-          {% if column[:type].id == Float64.id %}
-            type: PG::Numeric,
-          {% elsif column[:type].id == Array(Float64).id %}
+          {% if column[:type].id == Array(Float64).id %}
             type: Array(PG::Numeric),
-          {% else %}
-            {% if column[:type].is_a?(Generic) %}
+          {% elsif column[:type].is_a?(Generic) %}
             type: {{column[:type]}},
-            {% else %}
+          {% else %}
             type: {{column[:type]}}::Lucky::ColumnType,
-            {% end %}
           {% end %}
           nilable: {{column[:nilable]}},
         },


### PR DESCRIPTION
I didn't really dig into the history of why it was written the way it was, but the `ColumnType` alias for `Float64` was specifically made for that and was unused.