### PR TITLE
Remove bool return type restriction on Avram::Database#transaction

### DIFF
--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -156,7 +156,7 @@ abstract class Avram::Database
   end
 
   # :nodoc:
-  def transaction : Bool
+  def transaction
     if current_transaction
       yield
     else

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -156,9 +156,10 @@ abstract class Avram::Database
   end
 
   # :nodoc:
-  def transaction
+  def transaction : Bool
     if current_transaction
       yield
+      true
     else
       wrap_in_transaction do
         yield


### PR DESCRIPTION
Fixes #416

This allows for code to use transactions like:

```crystal
AppDatabase.transaction do
  StepOneOperation.run!
  StepTwoOperation.run!
end
```

This would only have worked previously if `StepTwoOperation.run!` returned a boolean. Otherwise `true` would have to be added as the last line because we required the block to return a Bool.

I believe the original type restriction was put in place to match crystal-db's but it was not intention https://github.com/crystal-lang/crystal-db/issues/145