### PR TITLE
Enum string parsing

### DIFF
--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -43,6 +43,16 @@ describe "Enum" do
     Issue::Status.new(:closed).enum.should eq(Issue::Status::Closed)
   end
 
+  it "parses the enum value name" do
+    Issue::Status.new("Closed").should eq(Issue::Status.new(:closed))
+    Issue::Status.new("Opened").should eq(Issue::Status.new(:opened))
+  end
+
+  it "parses the enum value integer when a string" do
+    Issue::Status.new("0").should eq(Issue::Status.new(:opened))
+    Issue::Status.new("1").should eq(Issue::Status.new(:closed))
+  end
+
   it "implements case equality" do
     case Issue::Status.new(:closed).value
     when Issue::Status.new(:closed)

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -34,7 +34,7 @@ macro avram_enum(enum_name, &block)
     end
 
     def initialize(enum_value : String)
-      @enum = Avram{{ enum_name }}.from_value(enum_value.to_i)
+      @enum = Avram{{ enum_name }}.parse(enum_value)
     end
 
     delegate :===, to_s, to_i, to: @enum
@@ -58,7 +58,7 @@ macro avram_enum(enum_name, &block)
       end
 
       def parse(value : String)
-        SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value.to_i))
+        SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
       end
 
       def parse(value : Int32)

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -34,7 +34,12 @@ macro avram_enum(enum_name, &block)
     end
 
     def initialize(enum_value : String)
-      @enum = Avram{{ enum_name }}.parse(enum_value)
+      int_value = enum_value.to_i?
+      @enum = if int_value
+                Avram{{ enum_name }}.from_value(int_value)
+              else
+                Avram{{ enum_name }}.parse(enum_value)
+              end
     end
 
     delegate :===, to_s, to_i, to: @enum


### PR DESCRIPTION
Handles cases where an enum value is passed around as a string. The following is possible in Lucky after this change:

```crystal
# models/thing.cr
class Thing < BaseModel
  avram_enum Type do
    Image
  end

  table do
    column type : Thing::Type
  end
end

# operations/save_thing.cr
class SaveThing < Thing::SaveOperation
  permit_columns type
end

# pages/things/new_page.cr
class Things::NewPage < AuthLayout
  needs operation : SaveThing

  def content
    mount Shared::Field, attribute: op.type, label_text: "Type" do |input_html|
      input_html.select_input append_class: "select-input" do
        options_for_select op.type, [{"Image", Thing::Type.new(:image)}]
      end
    end
  end
end
```

There's no type conversions to or from strings or integers in this sample code. A string is passed around (the enum value name), and parsed by avram prior to saving.