### PR TITLE
make migration id bigserial

### DIFF
--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -4,6 +4,8 @@ require "./*"
 abstract class Avram::Migrator::Migration::V1
   include Avram::Migrator::StatementHelpers
 
+  alias MigrationId = Int32 | Int64
+
   macro inherited
     Avram::Migrator::Runner.migrations << self
 
@@ -62,7 +64,7 @@ abstract class Avram::Migrator::Migration::V1
 
   def migrated?
     DB.open(Avram::Migrator::Runner.database_url) do |db|
-      db.query_one? "SELECT id FROM migrations WHERE version = $1", version, as: Int64
+      db.query_one? "SELECT id FROM migrations WHERE version = $1", version, as: MigrationId
     end
   end
 

--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -62,7 +62,7 @@ abstract class Avram::Migrator::Migration::V1
 
   def migrated?
     DB.open(Avram::Migrator::Runner.database_url) do |db|
-      db.query_one? "SELECT id FROM migrations WHERE version = $1", version, as: Int32
+      db.query_one? "SELECT id FROM migrations WHERE version = $1", version, as: Int64
     end
   end
 

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -110,7 +110,7 @@ class Avram::Migrator::Runner
   private def self.create_table_for_tracking_migrations
     <<-SQL
     CREATE TABLE IF NOT EXISTS #{MIGRATIONS_TABLE_NAME} (
-      id serial PRIMARY KEY,
+      id bigserial PRIMARY KEY,
       version bigint NOT NULL
     )
     SQL


### PR DESCRIPTION
Cockrochdb uses a bigserial and this breaks with using the migrator.  This is compatible with both postgresql and cockroachdb.