### PR TITLE
New method to add parenthesis to queries

### DIFF
--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -432,6 +432,20 @@ describe Avram::Queryable do
       orig_query.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users"
       new_query.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE ( users.nickname = $1 ) LIMIT 3"
     end
+
+    it "doesn't add parenthesis when query to wrap is provided" do
+      query = UserQuery.new.name("Susan").where do |q|
+        some_condition = false
+        if some_condition
+          q.name("john")
+        else
+          q
+        end
+      end.age(25).query
+
+      query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE users.name = $1 AND users.age = $2"
+      query.args.should eq ["Susan", "25"]
+    end
   end
 
   describe "#limit" do

--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -401,6 +401,30 @@ describe Avram::Queryable do
     end
   end
 
+  describe "#where with block" do
+    it "wraps a simple where clause with parenthesis" do
+      query = UserQuery.new.where(&.age(30)).query
+
+      query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE ( users.age = $1 )"
+      query.args.should eq ["30"]
+    end
+
+    it "wraps complex queries" do
+      query = UserQuery.new.where { |user_q|
+        user_q.where { |q|
+          q.age(25).or(&.age(26))
+        }.where { |q|
+          q.name("Billy").or(&.name("Tommy"))
+        }
+      }.or { |q|
+        q.nickname("Strange")
+      }.query
+
+      query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE ( ( users.age = $1 OR users.age = $2 ) AND ( users.name = $3 OR users.name = $4 ) ) OR users.nickname = $5"
+      query.args.should eq ["25", "26", "Billy", "Tommy", "Strange"]
+    end
+  end
+
   describe "#limit" do
     it "adds a limit clause" do
       queryable = UserQuery.new.limit(2)

--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -423,6 +423,15 @@ describe Avram::Queryable do
       query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE ( ( users.age = $1 OR users.age = $2 ) AND ( users.name = $3 OR users.name = $4 ) ) OR users.nickname = $5"
       query.args.should eq ["25", "26", "Billy", "Tommy", "Strange"]
     end
+
+    it "clones properly when assigned to a variable and updated later" do
+      orig_query = UserQuery.new
+
+      new_query = orig_query.where(&.nickname("BusyCat")).limit(3)
+
+      orig_query.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users"
+      new_query.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users WHERE ( users.nickname = $1 ) LIMIT 3"
+    end
   end
 
   describe "#limit" do

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -309,6 +309,11 @@ class Avram::QueryBuilder
     @wheres.last.conjunction = Avram::Where::Conjunction::None unless @wheres.empty?
   end
 
+  # Removes the last `Avram::Where` to be added
+  def remove_last_where
+    @wheres.pop
+  end
+
   @_wheres_sql : String?
 
   private def wheres_sql

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -308,6 +308,12 @@ class Avram::QueryBuilder
     block.call(self)
   end
 
+  # Clears the last conjunction
+  # e.g. users.age = $1 AND -> users.age = $1
+  def clear_conjunction
+    @wheres.last.conjunction = Avram::Where::Conjunction::None unless @wheres.empty?
+  end
+
   @_wheres_sql : String?
 
   private def wheres_sql
@@ -321,6 +327,9 @@ class Avram::QueryBuilder
 
         [clause, sql_clause.conjunction.to_s]
       end
+
+      # Remove blank conjunctions
+      statements.reject!(&.blank?)
 
       # Remove the last floating conjunction
       statements.pop

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -123,11 +123,10 @@ module Avram::Queryable(T)
   end
 
   def where : self
-    query.where(Avram::Where::PrecedenceStart.new)
-    result = yield self
-    result.query.clear_conjunction
-    result.query.where(Avram::Where::PrecedenceEnd.new)
-    result
+    cloned = clone.tap &.query.where(Avram::Where::PrecedenceStart.new)
+    result = yield cloned
+    cloned = result.clone.tap &.query.clear_conjunction
+    cloned.clone.tap &.query.where(Avram::Where::PrecedenceEnd.new)
   end
 
   def merge_query(query_to_merge : Avram::QueryBuilder) : self

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -122,6 +122,14 @@ module Avram::Queryable(T)
     clone.tap &.query.where(sql_clause)
   end
 
+  def where : self
+    query.where(Avram::Where::PrecedenceStart.new)
+    result = yield self
+    result.query.clear_conjunction
+    result.query.where(Avram::Where::PrecedenceEnd.new)
+    result
+  end
+
   def merge_query(query_to_merge : Avram::QueryBuilder) : self
     clone.tap &.query.merge(query_to_merge)
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -125,8 +125,14 @@ module Avram::Queryable(T)
   def where : self
     cloned = clone.tap &.query.where(Avram::Where::PrecedenceStart.new)
     result = yield cloned
-    cloned = result.clone.tap &.query.clear_conjunction
-    cloned.clone.tap &.query.where(Avram::Where::PrecedenceEnd.new)
+
+    # If no query was added to the yielded block, we remove the precedence
+    if result.query.wheres.last.is_a?(Avram::Where::PrecedenceStart)
+      result.clone.tap &.query.remove_last_where
+    else
+      cloned = result.clone.tap &.query.clear_conjunction
+      cloned.clone.tap &.query.where(Avram::Where::PrecedenceEnd.new)
+    end
   end
 
   def merge_query(query_to_merge : Avram::QueryBuilder) : self

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -2,6 +2,7 @@ module Avram::Where
   enum Conjunction
     And
     Or
+    None
 
     def to_s
       case self
@@ -9,6 +10,8 @@ module Avram::Where
         "AND"
       when .or?
         "OR"
+      else
+        ""
       end
     end
   end
@@ -20,6 +23,22 @@ module Avram::Where
 
     def clone
       self
+    end
+  end
+
+  class PrecedenceStart < Condition
+    def initialize
+      @conjunction = Avram::Where::Conjunction::None
+    end
+
+    def prepare(placeholder_supplier : Proc(String)) : String
+      "("
+    end
+  end
+
+  class PrecedenceEnd < Condition
+    def prepare(placeholder_supplier : Proc(String)) : String
+      ")"
     end
   end
 


### PR DESCRIPTION
Fixes #488

When it comes to more complex queries, you may need to specify precedence for your conditions. This is done by wrapping your condition in parenthesis.

This PR adds a new `where` overload for your query objects that takes a block, and will wrap whatever query is defined inside the block.

```crystal
# This Query
UserQuery.new
  .name("Bill")
  .or { |q|
    q.where(&.age(19).nickname("Duke"))
  }
```

```sql
-- Gives us this SQL
SELECT *
FROM users
WHERE name = 'Bill' OR ( age = 19 AND nickname = 'Duke' )
```

This opens Avram up to a lot more complex (but type-safe) queries.