### PR TITLE
Add new method for droping a foreign key constraint in migrations.

### DIFF
--- a/spec/migrator/drop_foreign_key_statement_spec.cr
+++ b/spec/migrator/drop_foreign_key_statement_spec.cr
@@ -1,0 +1,13 @@
+require "../spec_helper"
+
+describe Avram::Migrator::DropForeignKeyStatement do
+  it "generates correct sql" do
+    statement = Avram::Migrator::DropForeignKeyStatement.new(:comments, :users).build
+    statement.should eq "ALTER TABLE comments DROP CONSTRAINT comments_user_id_fk;"
+  end
+
+  it "generates correct sql with a custom colum" do
+    statement = Avram::Migrator::DropForeignKeyStatement.new(:comments, :users, column: :author_id).build
+    statement.should eq "ALTER TABLE comments DROP CONSTRAINT comments_author_id_fk;"
+  end
+end

--- a/src/avram/migrator/drop_foreign_key_statement.cr
+++ b/src/avram/migrator/drop_foreign_key_statement.cr
@@ -1,0 +1,22 @@
+# Generates an ALTER TABLE statement for dropping a foreign key constraint on a table.
+#
+# ### Usage
+#
+# ```
+# DropForeignKeyStatement.new(from: :comments, references: :users, column: :author_id).build
+# # => "ALTER TABLE comments DROP CONSTRAINT comments_author_id_fk;"
+# ```
+class Avram::Migrator::DropForeignKeyStatement
+  def initialize(@from : Symbol, @references : Symbol, @column : Symbol? = nil)
+  end
+
+  def build
+    foreign_key = @column || Wordsmith::Inflector.singularize(@references.to_s) + "_id"
+    String.build do |index|
+      index << "ALTER TABLE"
+      index << " #{@from}"
+      index << " DROP CONSTRAINT #{@from}_#{foreign_key}_fk"
+      index << ";"
+    end
+  end
+end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -32,6 +32,10 @@ module Avram::Migrator::StatementHelpers
     prepared_statements << CreateForeignKeyStatement.new(from, to, on_delete, column, primary_key).build
   end
 
+  def drop_foreign_key(from : Symbol, references : Symbol, column : Symbol?)
+    prepared_statements << DropForeignKeyStatement.new(from, references, column).build
+  end
+
   def create_index(table_name : Symbol, columns : Columns, unique = false, using = :btree, name : String? | Symbol? = nil)
     prepared_statements << CreateIndexStatement.new(table_name, columns, using, unique, name).build
   end


### PR DESCRIPTION
In order to complete #622, we have to drop the constraint first, then recreate it with the new `on_delete` statement.

This PR adds in the ability to drop a foreign key constraint which would allow you to change your `belongs_to` if you needed.

```crystal
# In a previous migration, you had
def migrate
  create table_for(Post) do
    add_belongs_to user : User, on_delete: :nullify
  end
end

# Now you want to change it to cascade
def migrate
  drop_foreign_key :posts, :users
  create_foreign_key :posts, :users, on_delete: :cascade
end
```

This is more of an escape hatch without you having to write all of the SQL by hand. The next step would be a separate PR that implements a `change_belongs_to` type macro.