### PR TITLE
Allow table name to be Symbol or String, remove run from macros

### DIFF
--- a/spec/migrator/table_for_spec.cr
+++ b/spec/migrator/table_for_spec.cr
@@ -2,16 +2,16 @@ require "../spec_helper"
 
 describe Avram::TableFor do
   describe ".table_for" do
-    it "turns model name into pluralized symbol" do
-      Avram::TableFor.table_for(User).should eq :users
+    it "turns model name into pluralized table name" do
+      Avram::TableFor.table_for(User).should eq "users"
     end
 
     it "removes double colons" do
-      Avram::TableFor.table_for(Test::Model).should eq :test_models
+      Avram::TableFor.table_for(Test::Model).should eq "test_models"
     end
 
     it "handles constant-case acronym model names" do
-      Avram::TableFor.table_for(Test::HTML).should eq :test_htmls
+      Avram::TableFor.table_for(Test::HTML).should eq "test_htmls"
     end
   end
 end

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -179,10 +179,10 @@ describe Avram::Model do
   end
 
   it "can infer the table name when omitted" do
-    InferredTableNameModel.table_name.should eq(:inferred_table_name_models)
+    InferredTableNameModel.table_name.should eq("inferred_table_name_models")
   end
 
   it "can infer table name for namedspaced models" do
-    NamedSpaced::Model.table_name.should eq(:named_spaced_models)
+    NamedSpaced::Model.table_name.should eq("named_spaced_models")
   end
 end

--- a/src/avram.cr
+++ b/src/avram.cr
@@ -28,6 +28,8 @@ module Avram
   FailedQueryLog = Log.for("failed_query")
   SaveFailedLog  = Log.for("save_failed")
 
+  alias TableName = String | Symbol
+
   def self.initialize_logging
     Avram::Events::QueryEvent.subscribe do |event, duration|
       next if event.query.starts_with?("TRUNCATE")

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -65,7 +65,7 @@ class Avram::BaseQueryTemplate
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: table_name,
-                  to: {{ assoc[:type] }}::TABLE_NAME,
+                  to: {{ assoc[:type] }}.table_name,
                   primary_key: {{ assoc[:foreign_key].id.symbolize }},
                   foreign_key: {{ assoc[:type] }}::PRIMARY_KEY_NAME
                 )
@@ -74,7 +74,7 @@ class Avram::BaseQueryTemplate
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: table_name,
-                  to: {{ assoc[:type] }}::TABLE_NAME,
+                  to: {{ assoc[:type] }}.table_name,
                   foreign_key: {{ assoc[:foreign_key].id.symbolize }},
                   primary_key: primary_key_name
                 )
@@ -88,7 +88,7 @@ class Avram::BaseQueryTemplate
               join(
                 Avram::Join::{{ join_type.id }}.new(
                   from: table_name,
-                  to: {{ assoc[:type] }}::TABLE_NAME,
+                  to: {{ assoc[:type] }}.table_name,
                   foreign_key: {{ assoc[:foreign_key] }},
                   primary_key: primary_key_name
                 )

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -21,11 +21,11 @@ module Avram
 
   # Raised when Avram cannot find a record by given id
   class RecordNotFoundError < AvramError
-    def initialize(model : Symbol, id : String)
+    def initialize(model : TableName, id : String)
       super "Could not find #{model} with id of #{id}"
     end
 
-    def initialize(model : Symbol, query : Symbol)
+    def initialize(model : TableName, query : Symbol)
       super "Could not find #{query} record in #{model}"
     end
   end

--- a/src/avram/insert.cr
+++ b/src/avram/insert.cr
@@ -1,7 +1,7 @@
 class Avram::Insert
   alias Params = Hash(Symbol, String) | Hash(Symbol, String?) | Hash(Symbol, Nil)
 
-  def initialize(@table : Symbol, @params : Params, @column_names : Array(Symbol) = [] of Symbol)
+  def initialize(@table : TableName, @params : Params, @column_names : Array(Symbol) = [] of Symbol)
   end
 
   def statement

--- a/src/avram/join.cr
+++ b/src/avram/join.cr
@@ -5,8 +5,8 @@ module Avram::Join
     getter :from, :to, :from_column, :to_column
 
     def initialize(
-      @from : Symbol,
-      @to : Symbol,
+      @from : TableName,
+      @to : TableName,
       @primary_key : Symbol? = nil,
       @foreign_key : Symbol? = nil,
       @comparison : String? = "=",

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -11,7 +11,7 @@ class Avram::Migrator::AlterTableStatement
   getter fill_existing_with_statements = [] of String
   getter change_type_statements = [] of String
 
-  def initialize(@table_name : Symbol)
+  def initialize(@table_name : TableName)
   end
 
   macro change_type(type_declaration, **type_options)

--- a/src/avram/migrator/build_reference_fragment.cr
+++ b/src/avram/migrator/build_reference_fragment.cr
@@ -1,7 +1,7 @@
 class Avram::Migrator::BuildReferenceFragment
   private getter references, on_delete
 
-  @references : String?
+  @references : TableName?
   @on_delete : Symbol?
 
   def initialize(@references, @on_delete)

--- a/src/avram/migrator/change_null_statement.cr
+++ b/src/avram/migrator/change_null_statement.cr
@@ -7,7 +7,7 @@
 # # => "ALTER TABLE users ALTER COLUMN email DROP NOT NULL;"
 # ```
 class Avram::Migrator::ChangeNullStatement
-  def initialize(@table : Symbol, @column : Symbol, @required : Bool)
+  def initialize(@table : TableName, @column : Symbol, @required : Bool)
   end
 
   def build

--- a/src/avram/migrator/columns/base.cr
+++ b/src/avram/migrator/columns/base.cr
@@ -30,7 +30,7 @@ abstract class Avram::Migrator::Columns::Base
     self
   end
 
-  def build_change_type_statement(table_name : Symbol) : String
+  def build_change_type_statement(table_name : TableName) : String
     "ALTER TABLE #{table_name} ALTER COLUMN #{name} SET DATA TYPE #{column_type};"
   end
 

--- a/src/avram/migrator/create_foreign_key_statement.cr
+++ b/src/avram/migrator/create_foreign_key_statement.cr
@@ -7,7 +7,7 @@
 # # => "ALTER TABLE comments ADD CONSTRAINT comments_author_id_fk FOREIGN KEY (author_id) REFERENCES users (uid) ON DELETE CASCADE;"
 # ```
 class Avram::Migrator::CreateForeignKeyStatement
-  def initialize(@from : Symbol, @to : Symbol, @on_delete : Symbol, @column : Symbol? = nil, @primary_key = :id)
+  def initialize(@from : TableName, @to : TableName, @on_delete : Symbol, @column : Symbol? = nil, @primary_key = :id)
   end
 
   def build

--- a/src/avram/migrator/create_index_statement.cr
+++ b/src/avram/migrator/create_index_statement.cr
@@ -30,7 +30,7 @@ class Avram::Migrator::CreateIndexStatement
 
   ALLOWED_INDEX_TYPES = %w[btree]
 
-  def initialize(@table : Symbol, @columns : Columns, @using : Symbol = :btree, @unique = false, @name : String? | Symbol? = nil)
+  def initialize(@table : TableName, @columns : Columns, @using : Symbol = :btree, @unique = false, @name : String? | Symbol? = nil)
     raise "index type '#{using}' not supported" unless ALLOWED_INDEX_TYPES.includes?(using.to_s)
   end
 

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -8,7 +8,7 @@ class Avram::Migrator::CreateTableStatement
   private getter rows = [] of String
   private getter constraints = [] of String
 
-  def initialize(@table_name : Symbol)
+  def initialize(@table_name : TableName)
   end
 
   # Accepts a block to build a table and indices using `add` and `add_index` methods.

--- a/src/avram/migrator/create_trigger_statement.cr
+++ b/src/avram/migrator/create_trigger_statement.cr
@@ -1,6 +1,6 @@
 class Avram::Migrator::CreateTriggerStatement
   def initialize(
-    @table_name : Symbol,
+    @table_name : TableName,
     @trigger_name : String,
     @function : String,
     callback @trigger_when : Symbol = :before,

--- a/src/avram/migrator/drop_foreign_key_statement.cr
+++ b/src/avram/migrator/drop_foreign_key_statement.cr
@@ -7,7 +7,7 @@
 # # => "ALTER TABLE comments DROP CONSTRAINT comments_author_id_fk;"
 # ```
 class Avram::Migrator::DropForeignKeyStatement
-  def initialize(@from : Symbol, @references : Symbol, @column : Symbol? = nil)
+  def initialize(@from : TableName, @references : TableName, @column : Symbol? = nil)
   end
 
   def build

--- a/src/avram/migrator/drop_index_statement.cr
+++ b/src/avram/migrator/drop_index_statement.cr
@@ -29,7 +29,7 @@ class Avram::Migrator::DropIndexStatement
 
   ALLOWED_ON_DELETE_STRATEGIES = %i[cascade restrict]
 
-  def initialize(@table : Symbol, @columns : Columns? = nil, @if_exists = false, @on_delete = :do_nothing, @name : String? | Symbol? = nil)
+  def initialize(@table : TableName, @columns : Columns? = nil, @if_exists = false, @on_delete = :do_nothing, @name : String? | Symbol? = nil)
   end
 
   def build

--- a/src/avram/migrator/drop_table_statement.cr
+++ b/src/avram/migrator/drop_table_statement.cr
@@ -1,5 +1,5 @@
 class Avram::Migrator::DropTableStatement
-  def initialize(@table_name : Symbol)
+  def initialize(@table_name : TableName)
   end
 
   def build

--- a/src/avram/migrator/drop_trigger_statement.cr
+++ b/src/avram/migrator/drop_trigger_statement.cr
@@ -1,5 +1,5 @@
 class Avram::Migrator::DropTriggerStatement
-  def initialize(@table_name : Symbol, @trigger_name : String)
+  def initialize(@table_name : TableName, @trigger_name : String)
   end
 
   def build

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -28,27 +28,27 @@ module Avram::Migrator::StatementHelpers
     end
   end
 
-  def create_foreign_key(from : Symbol, to : Symbol, on_delete : Symbol, column : Symbol?, primary_key = :id)
+  def create_foreign_key(from : TableName, to : TableName, on_delete : Symbol, column : Symbol?, primary_key = :id)
     prepared_statements << CreateForeignKeyStatement.new(from, to, on_delete, column, primary_key).build
   end
 
-  def drop_foreign_key(from : Symbol, references : Symbol, column : Symbol?)
+  def drop_foreign_key(from : TableName, references : TableName, column : Symbol?)
     prepared_statements << DropForeignKeyStatement.new(from, references, column).build
   end
 
-  def create_index(table_name : Symbol, columns : Columns, unique = false, using = :btree, name : String? | Symbol? = nil)
+  def create_index(table_name : TableName, columns : Columns, unique = false, using = :btree, name : String? | Symbol? = nil)
     prepared_statements << CreateIndexStatement.new(table_name, columns, using, unique, name).build
   end
 
-  def drop_index(table_name : Symbol, columns : Columns? = nil, if_exists = false, on_delete = :do_nothing, name : String? | Symbol? = nil)
+  def drop_index(table_name : TableName, columns : Columns? = nil, if_exists = false, on_delete = :do_nothing, name : String? | Symbol? = nil)
     prepared_statements << Avram::Migrator::DropIndexStatement.new(table_name, columns, if_exists, on_delete, name).build
   end
 
-  def make_required(table : Symbol, column : Symbol)
+  def make_required(table : TableName, column : Symbol)
     prepared_statements << Avram::Migrator::ChangeNullStatement.new(table, column, required: true).build
   end
 
-  def make_optional(table : Symbol, column : Symbol)
+  def make_optional(table : TableName, column : Symbol)
     prepared_statements << Avram::Migrator::ChangeNullStatement.new(table, column, required: false).build
   end
 
@@ -84,13 +84,13 @@ module Avram::Migrator::StatementHelpers
   # create_trigger(:users, "trigger_set_timestamps", "set_timestamps")
   # # => CREATE TRIGGER trigger_set_timestamps BEFORE UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE set_timestamps();
   # ```
-  def create_trigger(table_name : Symbol, name : String, function_name : String, callback : Symbol = :before, on : Array(Symbol) = [:update])
+  def create_trigger(table_name : TableName, name : String, function_name : String, callback : Symbol = :before, on : Array(Symbol) = [:update])
     drop_trigger(table_name, name)
     prepared_statements << Avram::Migrator::CreateTriggerStatement.new(table_name, name, function_name, callback, on).build
   end
 
   # Drop the tigger `name` for the table `table_name`
-  def drop_trigger(table_name : Symbol, name : String)
+  def drop_trigger(table_name : TableName, name : String)
     prepared_statements << Avram::Migrator::DropTriggerStatement.new(table_name, name).build
   end
 end

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -46,18 +46,17 @@ abstract class Avram::Model
   end
 
   macro table(table_name = nil)
-    {% unless table_name %}
-      {% table_name = run("../run_macros/infer_table_name.cr", @type.id) %}
-    {% end %}
-
     default_columns
 
     {{ yield }}
 
     validate_primary_key
 
-    class_getter table_name = {{ table_name.id.symbolize }}
-    TABLE_NAME = {{ table_name.id.symbolize }}
+    {% if table_name %}
+    class_getter table_name : String = {{ table_name.id.stringify }}
+    {% else %}
+    class_getter table_name : String = Avram::TableFor.table_for({{ @type.id }})
+    {% end %}
     setup(Avram::Model.setup_initialize)
     setup(Avram::Model.setup_db_mapping)
     setup(Avram::Model.setup_getters)
@@ -71,14 +70,13 @@ abstract class Avram::Model
   end
 
   macro view(view_name = nil)
-    {% unless view_name %}
-      {% view_name = run("../run_macros/infer_table_name.cr", @type.id) %}
-    {% end %}
-
     {{ yield }}
 
-    class_getter table_name = {{ view_name.id.symbolize }}
-    TABLE_NAME = {{ view_name.id.symbolize }}
+    {% if view_name %}
+      class_getter table_name : String = {{ view_name.id.stringify }}
+    {% else %}
+      class_getter table_name : String = Avram::TableFor.table_for({{ @type.id }})
+    {% end %}
     setup(Avram::Model.setup_initialize)
     setup(Avram::Model.setup_db_mapping)
     setup(Avram::Model.setup_getters)

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -2,7 +2,7 @@ class Avram::QueryBuilder
   def_clone
 
   alias ColumnName = Symbol | String
-  getter table
+  getter table : TableName
   getter distinct_on : ColumnName | Nil = nil
   @limit : Int32?
   @offset : Int32?
@@ -15,7 +15,7 @@ class Avram::QueryBuilder
   @distinct : Bool = false
   @delete : Bool = false
 
-  def initialize(@table : Symbol)
+  def initialize(@table)
   end
 
   def to_sql

--- a/src/avram/table_for.cr
+++ b/src/avram/table_for.cr
@@ -3,6 +3,6 @@ module Avram::TableFor
   # of the `model` passed in.
   # e.g. `User` => `:users`
   macro table_for(model)
-    :{{ run("../run_macros/infer_table_name.cr", model.id) }}
+    Wordsmith::Inflector.pluralize({{ model.stringify }}.gsub("::", "").underscore)
   end
 end

--- a/src/run_macros/infer_table_name.cr
+++ b/src/run_macros/infer_table_name.cr
@@ -1,3 +1,0 @@
-require "wordsmith"
-
-print Wordsmith::Inflector.pluralize(ARGV[0].gsub("::", "").underscore)


### PR DESCRIPTION
I had heard that using `run` in macros slowed down compilation times. Turns out, it's true!

I ran benchmarks on master and this branch (`hyperfine --warmup 3 'crystal build --release spec/model_spec.cr'`)
master: 5.016 seconds (average)
with these changes: 4.156 seconds (average)

**That's a 17% improvement in release compile time!**

## Changes

Our only use for `run` was to infer the table name in migrations and in the models. We turned the model name into a symbol that was the table name. We only ever needed this info at runtime so it made sense to bring the code that was in the file being `run`. The only problem is that we can't return a symbol anymore because the table name isn't determined until runtime and it's not possible to construct symbols at runtime. I added a `TableName` alias that is just `String | Symbol` and updated _everywhere_ that takes in a table name to use it. I also found that all the places we were using `Model::TABLE_NAME` could be replaced by the class method `Model.table_name` so I removed the constant as well.