### PR TITLE
Add Postgres versions and experimental builds to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: postgres:${{ matrix.postgres_version }}
+    container: crystallang/crystal:${{ matrix.crystal_version }}
     services:
       postgres:
         image: postgres:${{ matrix.postgres_version }}-alpine
@@ -64,10 +64,12 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v2
-      - name: Install Crystal
-        uses: oprypin/install-crystal@v1
-        with:
-          crystal: ${{ matrix.crystal_version }}
+      - name: Install PostgreSQL client
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          apt-get update
+          apt-get -yqq install libpq-dev postgresql-client-#{{ matrix.postgres_version }}
       - name: Cache Crystal
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Avram CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     branches: "*"
 
@@ -27,10 +27,16 @@ jobs:
         run: crystal tool format --check
       - name: Lint
         run: ./bin/ameba
+
   specs:
     strategy:
       fail-fast: false
       matrix:
+        postgres_version:
+          - 10
+          - 11
+          - 12
+          - 13
         crystal_version:
           - 0.36.1
           - 1.0.0
@@ -38,10 +44,10 @@ jobs:
           - false
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}
+    container: postgres:${{ matrix.postgres_version }}-alpine
     services:
       postgres:
-        image: postgres:10-alpine
+        image: postgres:${{ matrix.postgres_version }}-alpine
         env:
           POSTGRES_USER: lucky
           POSTGRES_PASSWORD: developer
@@ -50,11 +56,11 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - name: Install PostgreSQL client
-        run: |
-          apt-get update
-          apt-get -yqq install libpq-dev postgresql-client
       - uses: actions/checkout@v2
+      - name: Install Crystal
+      - uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal_version }}
       - name: Cache Crystal
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
           apt-get update
-          apt-get -yqq install libpq-dev postgresql-client-#{{ matrix.postgres_version }}
+          apt-get -yqq install libpq-dev postgresql-client-${{ matrix.postgres_version }}
       - name: Cache Crystal
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v2
-      - uses: oprypin/install-crystal@v1
+      - name: Install Crystal
+        uses: oprypin/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal_version }}
       - name: Cache Crystal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - false
         include:
           - crystal_version: nightly
-          - experimental: true
+            experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container: crystallang/crystal:${{ matrix.crystal_version }}
@@ -47,8 +47,8 @@ jobs:
           - false
         include:
           - crystal_version: nightly
-          - postgres_version: latest
-          - experimental: true
+            postgres_version: latest
+            experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container: postgres:${{ matrix.postgres_version }}-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install PostgreSQL client
         run: |
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
           apt-get update
           apt-get -yqq install libpq-dev postgresql-client-#{{ matrix.postgres_version }}
       - name: Cache Crystal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: postgres:${{ matrix.postgres_version }}-alpine
+    container: postgres:${{ matrix.postgres_version }}
     services:
       postgres:
         image: postgres:${{ matrix.postgres_version }}-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           - false
         include:
           - crystal_version: nightly
-            postgres_version: latest
+            postgres_version: 13
             experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
           - 1.0.0
         experimental:
           - false
+        include:
+          - crystal_version: nightly
+          - experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container: crystallang/crystal:${{ matrix.crystal_version }}
@@ -42,6 +45,10 @@ jobs:
           - 1.0.0
         experimental:
           - false
+        include:
+          - crystal_version: nightly
+          - postgres_version: latest
+          - experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container: postgres:${{ matrix.postgres_version }}-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v2
-      - name: Install Crystal
       - uses: oprypin/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install PostgreSQL client
         run: |
+          apt-get update
+          apt-get -yqq install lsb-release wget
           sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
           apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install PostgreSQL client
         run: |
           apt-get update
-          apt-get -yqq install lsb-release wget
+          apt-get -yqq install lsb-release wget gnupg
           sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
           apt-get update


### PR DESCRIPTION
We currently only officially test Avram against Postgres 10, which seems less than ideal since the current version is actually 13.

This tests against 10, 11, 12, and 13.
It also adds an experimental test against the Crystal nightly build.