### PR TITLE
Fix edge cases in migrator when using fill_existing_with with a boolean value

### DIFF
--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -104,7 +104,6 @@ describe Avram::Migrator::AlterTableStatement do
       built.statements[1].should eq "UPDATE users SET admin = 'false';"
       built.statements[2].should eq "ALTER TABLE users ALTER COLUMN admin SET NOT NULL;"
     end
-
   end
 
   describe "associations" do

--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -93,6 +93,18 @@ describe Avram::Migrator::AlterTableStatement do
       built.statements[0].should eq "ALTER TABLE users\n  ADD confirmed_at timestamptz;"
       built.statements[1].should eq "UPDATE users SET confirmed_at = NOW();"
     end
+
+    it "fills existing with the correct boolean value" do
+      built = Avram::Migrator::AlterTableStatement.new(:users).build do
+        add admin : Bool, fill_existing_with: false
+      end
+
+      built.statements.size.should eq 3
+      built.statements[0].should eq "ALTER TABLE users\n  ADD admin boolean;"
+      built.statements[1].should eq "UPDATE users SET admin = 'false';"
+      built.statements[2].should eq "ALTER TABLE users ALTER COLUMN admin SET NOT NULL;"
+    end
+
   end
 
   describe "associations" do

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -99,7 +99,7 @@ class Avram::Migrator::AlterTableStatement
     .set_references(references: %table_name.to_s, on_delete: {{ on_delete }})
     .build_add_statement_for_alter
 
-    {% if fill_existing_with && fill_existing_with != :nothing %}
+    {% if !(fill_existing_with == nil) && fill_existing_with != :nothing %}
       add_fill_existing_with_statements(
         column: {{ foreign_key_name.stringify }},
         type: {{ foreign_key_type }},
@@ -115,7 +115,8 @@ class Avram::Migrator::AlterTableStatement
     {% type = type_declaration.type %}
     {% nilable = false %}
     {% array = false %}
-    {% should_fill_existing = fill_existing_with && (fill_existing_with != :nothing) %}
+    {% should_fill_existing =  (!(fill_existing_with == nil)) && (fill_existing_with != :nothing) %}
+    
     {% if type.is_a?(Union) %}
       {% type = type.types.first %}
       {% nilable = true %}

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -115,7 +115,7 @@ class Avram::Migrator::AlterTableStatement
     {% type = type_declaration.type %}
     {% nilable = false %}
     {% array = false %}
-    {% should_fill_existing =  (!(fill_existing_with == nil)) && (fill_existing_with != :nothing) %}
+    {% should_fill_existing = (!(fill_existing_with == nil)) && (fill_existing_with != :nothing) %}
     
     {% if type.is_a?(Union) %}
       {% type = type.types.first %}

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -116,7 +116,7 @@ class Avram::Migrator::AlterTableStatement
     {% nilable = false %}
     {% array = false %}
     {% should_fill_existing = (!(fill_existing_with == nil)) && (fill_existing_with != :nothing) %}
-    
+
     {% if type.is_a?(Union) %}
       {% type = type.types.first %}
       {% nilable = true %}


### PR DESCRIPTION
This covers a very edge case when performing migrations that imply adding a not null boolean column filling previous records with the false value.
In practice when performing this kind of modification

```
alter table_for(SomeTable) do
 add a_column : Boolean, fill_existing_with: false
```
the migration fails as the fill_existing_with is not considered.
The patch fixes this particular case.


Note 1:
There is currently a way to bypass this by switching the former code to:
```
alter table_for(SomeTable) do
 add a_column : Boolean, fill_existing_with: "false"
```
(add double quotes)

Note 2:
the resulting statement is now:
```
UPDATE users SET admin = 'false';
```
Is it correct? I didn't touch the logic in the BoolColumn, but I would assume that in theory it should be without single quotes. However, it seems that the same applies to FloatColumn as well...

Note 3:
Why is the default value for fill_existing_with in the add_macro nil and not :nothing? 

