### PR TITLE
Adding ability to listen for notifications from postgres

### DIFF
--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -3,12 +3,15 @@ require "./spec_helper"
 describe Avram::Database do
   describe "listen" do
     it "yields the payload from a notify" do
+      done = Channel(Nil).new
       TestDatabase.listen("dinner_time") do |notification|
         notification.channel.should eq "dinner_time"
         notification.payload.should eq "Tacos"
+        done.send(nil)
       end
 
       TestDatabase.exec("SELECT pg_notify('dinner_time', 'Tacos')")
+      done.receive
     end
   end
 end

--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -1,0 +1,14 @@
+require "./spec_helper"
+
+describe Avram::Database do
+  describe "listen" do
+    it "yields the payload from a notify" do
+      TestDatabase.listen("dinner_time") do |notification|
+        notification.channel.should eq "dinner_time"
+        notification.payload.should eq "Tacos"
+      end
+
+      TestDatabase.exec("SELECT pg_notify('dinner_time', 'Tacos')")
+    end
+  end
+end

--- a/src/avram/connection.cr
+++ b/src/avram/connection.cr
@@ -7,6 +7,12 @@ class Avram::Connection
     try_connection!
   end
 
+  def connect_listen(*channels : String, &block : PQ::Notification ->) : Nil
+    PG.connect_listen(@connection_string, *channels, &block)
+  rescue DB::ConnectionRefused
+    raise ConnectionError.new(connection_uri, database_class: @database_class)
+  end
+
   def try_connection!
     DB.open(@connection_string)
   rescue DB::ConnectionRefused

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -50,9 +50,7 @@ abstract class Avram::Database
   # end
   # ```
   def self.listen(*channels : String, &block : PQ::Notification ->) : Nil
-    new.listen(*channels) do |notification|
-      block.call(notification)
-    end
+    new.listen(*channels, &block)
   end
 
   @@database_info : DatabaseInfo?


### PR DESCRIPTION
This allows us to listen for `pg_notify()` calls for any number of channels. 

```sql
SELECT pg_notify('workers', json_build_object('id', 1, 'name', 'test')::text)
```

```crystal
AppDatabase.listen("workers") do |notify|
  data = JSON.parse(notify.payload)
  puts data["id"] #=> 1
  puts data["name"] #=> "test"
end
```