### PR TITLE
Adding the before_save and after_save callbacks for Factories.

### DIFF
--- a/spec/factory_spec.cr
+++ b/spec/factory_spec.cr
@@ -59,4 +59,28 @@ describe Avram::Factory do
       tags.last.name.should eq "new-tag-2"
     end
   end
+
+  describe "before_save" do
+    it "sets the association before saving" do
+      factory = ScanFactory.new
+      line_item_id = LineItemFactory.create.id
+      factory.before_save do
+        factory.line_item_id(line_item_id)
+      end
+      scan = factory.create
+      scan.line_item_id.should eq line_item_id
+    end
+  end
+
+  describe "after_save" do
+    it "runs the block after the record is created" do
+      factory = LineItemFactory.new
+      factory.after_save do |line_item|
+        ScanFactory.create &.line_item_id(line_item.id)
+      end
+      line_item = factory.create
+
+      line_item.scans_count.should eq 1
+    end
+  end
 end


### PR DESCRIPTION
Fixes #331 

This allows you to do some setup before/after a factory record is created. Note that this is at the instance level as opposed to macro level that the SaveOperation uses. (see comments on #331)

Here's a basic example:

```crystal
class ProfileFactory < Avram::Factory
  def initialize
    hidden_account true
    before_save do
      user_id UserFactory.create.id
    end
  end
end
```

You can use these to only save associations if it hasn't already been saved, or do things like setup a record for your "has_many" association for specific records...