### PR TITLE
Fixes for Array(Uploadable)

### DIFF
--- a/src/avram/uploadable.cr
+++ b/src/avram/uploadable.cr
@@ -18,10 +18,14 @@ module Avram::Uploadable
     end
 
     def parse(values : Array(Avram::Uploadable))
-      SuccessfulCast(Array(Avram::Uploadable)).new(values)
+      SuccessfulCast.new(values)
     end
 
     def parse(value : String?)
+      FailedCast.new
+    end
+
+    def parse(values : Array(String))
       FailedCast.new
     end
   end


### PR DESCRIPTION
In order to get https://github.com/luckyframework/lucky/pull/1519 to work, these changes are needed.

I'm not sure how to test this since the actual error I'm solving is a compile-time error happening in Lucky. Here's a small example of what's going on:
https://play.crystal-lang.org/#/r/bana
```crystal
class SuccessfulCast(T)
  def initialize(@value : T)
  end
end

module Uploadable
end

class Upload
  include Uploadable
end


def parse(values : Array(Uploadable))
  SuccessfulCast(Array(Uploadable)).new(values)
end

values = [Upload.new]
parse(values)
```

> Error: instance variable '@value' of SuccessfulCast(Array(Uploadable)) must be Array(Uploadable), not Array(Upload)

In this case, the compiler isn't able to determine that `Avram::Uploadable` and `Lucky::UploadedFile` are the same. To get around this, we can just not pass the Generic to `SuccessfulCast`. https://play.crystal-lang.org/#/r/bang

```crystal
class SuccessfulCast(T)
  def initialize(@value : T)
  end
end

module Uploadable
end

class Upload
  include Uploadable
end


def parse(values : Array(Uploadable))
  SuccessfulCast.new(values)
end

values = [Upload.new]
parse(values)
```

