### PR TITLE
Support belongs to with namespaced classes

### DIFF
--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -114,6 +114,7 @@ describe Avram::Migrator::AlterTableStatement do
         add_belongs_to category_label : CategoryLabel, on_delete: :nullify, references: :custom_table
         add_belongs_to employee : User, on_delete: :cascade
         add_belongs_to line_item : LineItem, on_delete: :cascade, foreign_key_type: UUID, fill_existing_with: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+        add_belongs_to subscription_item : Subscription::Item, on_delete: :cascade
       end
 
       built.statements.first.should eq <<-SQL
@@ -122,7 +123,8 @@ describe Avram::Migrator::AlterTableStatement do
         ADD post_id bigint REFERENCES posts ON DELETE RESTRICT,
         ADD category_label_id bigint NOT NULL REFERENCES custom_table ON DELETE SET NULL,
         ADD employee_id bigint NOT NULL REFERENCES users ON DELETE CASCADE,
-        ADD line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE;
+        ADD line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE,
+        ADD subscription_item_id bigint NOT NULL REFERENCES subscription_items ON DELETE CASCADE;
       SQL
 
       built.statements[1].should eq "CREATE UNIQUE INDEX comments_user_id_index ON comments USING btree (user_id);"
@@ -130,7 +132,8 @@ describe Avram::Migrator::AlterTableStatement do
       built.statements[3].should eq "CREATE INDEX comments_category_label_id_index ON comments USING btree (category_label_id);"
       built.statements[4].should eq "CREATE INDEX comments_employee_id_index ON comments USING btree (employee_id);"
       built.statements[5].should eq "CREATE INDEX comments_line_item_id_index ON comments USING btree (line_item_id);"
-      built.statements[6].should eq "UPDATE comments SET line_item_id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';"
+      built.statements[6].should eq "CREATE INDEX comments_subscription_item_id_index ON comments USING btree (subscription_item_id);"
+      built.statements[7].should eq "UPDATE comments SET line_item_id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';"
     end
 
     it "raises error when on_delete strategy is invalid or nil" do

--- a/spec/migrator/create_table_statement_spec.cr
+++ b/spec/migrator/create_table_statement_spec.cr
@@ -191,6 +191,7 @@ describe Avram::Migrator::CreateTableStatement do
         add_belongs_to category_label : CategoryLabel, on_delete: :nullify, references: :custom_table
         add_belongs_to employee : User, on_delete: :cascade
         add_belongs_to line_item : LineItem, on_delete: :cascade, foreign_key_type: UUID
+        add_belongs_to subscription_item : Subscription::Item, on_delete: :cascade
       end
 
       built.statements.first.should eq <<-SQL
@@ -199,7 +200,8 @@ describe Avram::Migrator::CreateTableStatement do
         post_id bigint REFERENCES posts ON DELETE RESTRICT,
         category_label_id bigint NOT NULL REFERENCES custom_table ON DELETE SET NULL,
         employee_id bigint NOT NULL REFERENCES users ON DELETE CASCADE,
-        line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE);
+        line_item_id uuid NOT NULL REFERENCES line_items ON DELETE CASCADE,
+        subscription_item_id bigint NOT NULL REFERENCES subscription_items ON DELETE CASCADE);
       SQL
 
       built.statements[1].should eq "CREATE INDEX comments_user_id_index ON comments USING btree (user_id);"
@@ -207,6 +209,7 @@ describe Avram::Migrator::CreateTableStatement do
       built.statements[3].should eq "CREATE INDEX comments_category_label_id_index ON comments USING btree (category_label_id);"
       built.statements[4].should eq "CREATE INDEX comments_employee_id_index ON comments USING btree (employee_id);"
       built.statements[5].should eq "CREATE INDEX comments_line_item_id_index ON comments USING btree (line_item_id);"
+      built.statements[6].should eq "CREATE INDEX comments_subscription_item_id_index ON comments USING btree (subscription_item_id);"
     end
 
     it "can create tables with association on composite primary keys" do

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -83,10 +83,11 @@ class Avram::Migrator::AlterTableStatement
     {% optional = type_declaration.type.is_a?(Union) %}
 
     {% if optional %}
-      {% underscored_class = type_declaration.type.types.first.stringify.underscore %}
+      {% underscored_class = type_declaration.type.types.first %}
     {% else %}
-      {% underscored_class = type_declaration.type.stringify.underscore %}
+      {% underscored_class = type_declaration.type %}
     {% end %}
+    {% underscored_class = underscored_class.stringify.underscore.gsub(/::/, "_") %}
 
     {% foreign_key_name = type_declaration.var + "_id" %}
     %table_name = {{ references }} || Wordsmith::Inflector.pluralize({{ underscored_class }})

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -125,10 +125,11 @@ class Avram::Migrator::CreateTableStatement
     {% optional = type_declaration.type.is_a?(Union) %}
 
     {% if optional %}
-      {% underscored_class = type_declaration.type.types.first.stringify.underscore %}
+      {% underscored_class = type_declaration.type.types.first %}
     {% else %}
-      {% underscored_class = type_declaration.type.stringify.underscore %}
+      {% underscored_class = type_declaration.type %}
     {% end %}
+    {% underscored_class = underscored_class.stringify.underscore.gsub(/::/, "_") %}
 
     {% foreign_key_name = type_declaration.var + "_id" %}
     %table_name = {{ references }} || Wordsmith::Inflector.pluralize({{ underscored_class }})


### PR DESCRIPTION
Fixes #684 

`add_belongs_to namespaced_assoc : Namespaced::Assoc, on_delete: :cascade`

Before: `namespaced::assocs`
After: `namespaced_assocs`