### PR TITLE
Changing how the select_count method counts returned rows.

### DIFF
--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -765,14 +765,13 @@ describe Avram::Queryable do
       query.select_count.should eq 1
     end
 
-    it "raises when used with offset or limit" do
-      expect_raises(Avram::UnsupportedQueryError) do
-        UserQuery.new.limit(1).select_count
-      end
+    it "works with distinct_on" do
+      UserFactory.new.age(30).create
+      UserFactory.new.age(30).create
 
-      expect_raises(Avram::UnsupportedQueryError) do
-        UserQuery.new.offset(1).select_count
-      end
+      query = UserQuery.new.distinct_on(&.age)
+
+      query.select_count.should eq 1
     end
 
     it "returns 0 if postgres returns no results" do

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -196,7 +196,10 @@ module Avram::Queryable(T)
   end
 
   def select_count : Int64
-    exec_scalar(&.select_count).as(Int64)
+    table = "(#{query.statement}) AS temp"
+    new_query = Avram::QueryBuilder.new(table).select_count
+    result = database.scalar new_query.statement, args: query.args, queryable: schema_class.name
+    result.as(Int64)
   rescue e : DB::NoResultsError
     0_i64
   end


### PR DESCRIPTION
Fixes #686

This new way now allows for counting against more complex queries which include using `distinct_on`. The main reason for this is using pagination when you have these complex queries.

Before this PR, you couldn't do this:

```crystal
get "/messages" do
  pages, messages = paginate(MessageQuery.new.distinct_on(&.status))
  html IndexPage, messages: messages, pages: pages
end
```

This would throw an error that `status` needs to be in a "GROUP BY" or used in an aggregate function. But of course, if you added `status` to a group, it would also want `id`, and you'd still have to change the count from `COUNT(*)` to `COUNT(status)` or something else... 

Also as @wyhaines pointed out in [686](https://github.com/luckyframework/avram/issues/686#issuecomment-862664764), there's several cases where this method is actually faster than the previous. All of the queries I tried seemed to perform about the same speed if not faster. 