### PR TITLE
Fix DateTime Form Input Parsing

### DIFF
--- a/spec/type_extensions/time_spec.cr
+++ b/spec/type_extensions/time_spec.cr
@@ -1,30 +1,58 @@
 require "../spec_helper"
 
+enum TimeComponent
+  Year
+  Month
+  Day
+  Hour
+  Minute
+  Second
+end
+
+struct FormattedTime
+  property label : String
+  property value : String
+  property components : Array(TimeComponent)
+
+  def initialize(@label : String, @value : String, excluded_components : Array(TimeComponent) = [] of TimeComponent)
+    @components = [
+      TimeComponent::Year,
+      TimeComponent::Month,
+      TimeComponent::Day,
+      TimeComponent::Hour,
+      TimeComponent::Minute,
+      TimeComponent::Second,
+    ] - excluded_components
+  end
+end
+
 describe "Time column type" do
   describe ".parse" do
     it "casts various formats successfully" do
       time = Time.utc
-      times = {
-        iso8601:             time.to_s("%FT%X%z"),
-        rfc2822:             time.to_rfc2822,
-        rfc3339:             time.to_rfc3339,
-        datetime_html_input: time.to_s("%Y-%m-%dT%H:%M:%S"),
-        http_date:           time.to_s("%a, %d %b %Y %H:%M:%S GMT"),
-      }
-      times.each do |_format, item|
-        result = Time.adapter.parse(item)
+      times = [
+        FormattedTime.new("ISO 8601", time.to_s("%FT%X%z")),
+        FormattedTime.new("RFC 2822", time.to_rfc2822),
+        FormattedTime.new("RFC 3339", time.to_rfc3339),
+        FormattedTime.new("DateTime HTML Input", time.to_s("%Y-%m-%dT%H:%M:%S")),
+        FormattedTime.new("DateTime HTML Input (no seconds)", time.to_s("%Y-%m-%dT%H:%M"), excluded_components: [TimeComponent::Second]),
+        FormattedTime.new("HTTP Date", time.to_s("%a, %d %b %Y %H:%M:%S GMT")),
+      ]
+
+      times.each do |formatted_time|
+        result = Time.adapter.parse(formatted_time.value)
         result.should be_a(Avram::Type::SuccessfulCast(Time))
 
         unless result.is_a? Avram::Type::SuccessfulCast(Time)
           next
         end
 
-        result.value.year.should eq(time.year)
-        result.value.month.should eq(time.month)
-        result.value.day.should eq(time.day)
-        result.value.hour.should eq(time.hour)
-        result.value.minute.should eq(time.minute)
-        result.value.second.should eq(time.second)
+        result.value.year.should eq(time.year) if formatted_time.components.includes? TimeComponent::Year
+        result.value.month.should eq(time.month) if formatted_time.components.includes? TimeComponent::Month
+        result.value.day.should eq(time.day) if formatted_time.components.includes? TimeComponent::Day
+        result.value.hour.should eq(time.hour) if formatted_time.components.includes? TimeComponent::Hour
+        result.value.minute.should eq(time.minute) if formatted_time.components.includes? TimeComponent::Minute
+        result.value.second.should eq(time.second) if formatted_time.components.includes? TimeComponent::Second
       end
     end
 

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -14,6 +14,7 @@ struct Time
       # HTML datetime-local inputs are basically RFC 3339 without the timezone:
       # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local
       Time::Format.new("%Y-%m-%dT%H:%M:%S", Time::Location::UTC),
+      Time::Format.new("%Y-%m-%dT%H:%M", Time::Location::UTC),
       # Dates and times go last, otherwise it will parse strings with both
       # dates *and* times incorrectly.
       Time::Format::HTTP_DATE,


### PR DESCRIPTION
Closes https://github.com/luckyframework/lucky/issues/1530

I originally fixed this here: https://github.com/luckyframework/avram/pull/603

At least, LuckyCasts DateTime inputs were working at some point with this PR. However, since then, it appears as though that's stopped working:
https://github.com/luckyframework/lucky/issues/1530

I attempted to refactor this test file to make it a bit cleaner and easier to extend with other tests in the future. I'm not sure if I should put the struct/enum in another `support` file or something, but it made sense to me to keep it local to the test since this is the only place it was needed.

I've tested this branch with LuckyCasts, and DateTimes are saving correctly with it in place.