### PR TITLE
Use simple enums for Avram columns

### DIFF
--- a/spec/support/factories/issue_factory.cr
+++ b/spec/support/factories/issue_factory.cr
@@ -1,7 +1,6 @@
 class IssueFactory < BaseFactory
   def initialize
-    status Issue::Status.new(:opened)
-    role Issue::Role.new(:issue)
+    status Issue::Status::Opened
   end
 
   def build_model

--- a/spec/support/models/issue.cr
+++ b/spec/support/models/issue.cr
@@ -1,13 +1,13 @@
 class Issue < BaseModel
   COLUMN_SQL = "issues.id, issues.status, issues.role"
 
-  avram_enum Status do
+  enum Status
     Opened
     Closed
     Duplicated
   end
 
-  avram_enum Role do
+  enum Role
     Issue    = 1
     Bug      = 2
     Critical = 3
@@ -15,7 +15,7 @@ class Issue < BaseModel
 
   table do
     column status : Issue::Status
-    column role : Issue::Role
+    column role : Issue::Role = Issue::Role::Issue
   end
 end
 

--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -2,12 +2,12 @@ require "../spec_helper"
 
 include LazyLoadHelpers
 
-describe "Enum" do
+describe Enum do
   it "check enum" do
     issue = IssueFactory.create
 
-    issue.status.enum.should eq(Issue::AvramStatus::Opened)
-    issue.role.enum.should eq(Issue::AvramRole::Issue)
+    issue.status.should eq(Issue::Status::Opened)
+    issue.role.should eq(Issue::Role::Issue)
   end
 
   it "update enum" do
@@ -15,8 +15,8 @@ describe "Enum" do
 
     updated_issue = Issue::SaveOperation.update!(issue, status: Issue::Status.new(:closed))
 
-    updated_issue.status.enum.should eq(Issue::AvramStatus::Closed)
-    updated_issue.role.enum.should eq(Issue::AvramRole::Issue)
+    updated_issue.status.should eq(Issue::Status::Closed)
+    updated_issue.role.should eq(Issue::Role::Issue)
   end
 
   it "access enum methods" do
@@ -31,55 +31,5 @@ describe "Enum" do
 
     issue.status.to_s.should eq("Opened")
     issue.status.to_i.should eq(0)
-  end
-
-  it "provides a working ==" do
-    Issue::Status.new(:closed).should eq(Issue::Status.new(:closed))
-    Issue::Status.new(:opened).should_not eq(Issue::Status.new(:closed))
-  end
-
-  it "provides enum-like constant values" do
-    Issue::Status::Closed.should eq(Issue::Status.new(:closed).enum)
-    Issue::Status.new(:closed).enum.should eq(Issue::Status::Closed)
-  end
-
-  it "parses the enum value name" do
-    Issue::Status.new("Closed").should eq(Issue::Status.new(:closed))
-    Issue::Status.new("Opened").should eq(Issue::Status.new(:opened))
-  end
-
-  it "parses the enum value integer when a string" do
-    Issue::Status.new("0").should eq(Issue::Status.new(:opened))
-    Issue::Status.new("1").should eq(Issue::Status.new(:closed))
-  end
-
-  it "implements case equality" do
-    case Issue::Status.new(:closed).value
-    when Issue::Status.new(:closed)
-      true
-    else
-      false
-    end.should be_true
-
-    case Issue::Status::Closed.value
-    when Issue::Status.new(:closed)
-      true
-    else
-      false
-    end.should be_true
-
-    case Issue::Status.new(:opened).value
-    when Issue::Status::Opened
-      true
-    else
-      false
-    end.should be_true
-
-    case Issue::Status::Opened.value
-    when Issue::Status::Opened
-      true
-    else
-      false
-    end.should be_true
   end
 end

--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -2,15 +2,15 @@ require "../spec_helper"
 
 include LazyLoadHelpers
 
-describe Enum do
-  it "check enum" do
+describe "models using enums" do
+  it "can be created" do
     issue = IssueFactory.create
 
     issue.status.should eq(Issue::Status::Opened)
     issue.role.should eq(Issue::Role::Issue)
   end
 
-  it "update enum" do
+  it "can be updated" do
     issue = IssueFactory.create
 
     updated_issue = Issue::SaveOperation.update!(issue, status: Issue::Status.new(:closed))
@@ -19,17 +19,19 @@ describe Enum do
     updated_issue.role.should eq(Issue::Role::Issue)
   end
 
-  it "access enum methods" do
+  it "can be queried" do
     issue = IssueFactory.create
+    query = IssueQuery.new
 
-    issue.status.opened?.should eq(true)
-    issue.status.value.should eq(0)
+    query.status(Issue::Status::Opened).first.should eq(issue)
+    query.status("Opened").first.should eq(issue)
+    query.status(0).first.should eq(issue)
   end
 
-  it "access enum to_s and to_i" do
-    issue = IssueFactory.create
+  it "handles other queries" do
+    IssueFactory.create &.role(Issue::Role::Issue)
+    IssueFactory.create &.role(Issue::Role::Critical)
 
-    issue.status.to_s.should eq("Opened")
-    issue.status.to_i.should eq(0)
+    IssueQuery.new.role.select_max.should eq(Issue::Role::Critical)
   end
 end

--- a/spec/type_extensions/enum_spec.cr
+++ b/spec/type_extensions/enum_spec.cr
@@ -33,5 +33,6 @@ describe "models using enums" do
     IssueFactory.create &.role(Issue::Role::Critical)
 
     IssueQuery.new.role.select_max.should eq(Issue::Role::Critical)
+    IssueQuery.new.role.select_min.should eq(Issue::Role::Issue)
   end
 end

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -1,85 +1,38 @@
-macro redeclare_avram_enum(name)
-  {% for member in name.resolve.constants %}
-    {{ member }} = {{ name }}::{{ member }}
-  {% end %}
-end
-
-macro avram_enum(enum_name, &block)
-  {% avram_enum = ("Avram" + enum_name.names.join("::")).id %}
-  enum {{ avram_enum }}
-    {{ block.body }}
-
-    def ===(other : Int32)
-      value == other
-    end
+abstract struct Enum
+  def self.adapter
+    Lucky(self)
   end
 
-  struct {{ enum_name }}
-    def self.adapter
-      Lucky
+  module Lucky(T)
+    include Avram::Type
+    alias ColumnType = Int32
+
+    def parse(value : String)
+      if result = T.parse?(value)
+        SuccessfulCast.new(result)
+      else
+        FailedCast.new
+      end
     end
 
-    redeclare_avram_enum({{ avram_enum }})
-
-    getter :enum
-
-    # You may need to prefix with {{ @type }}
-    #
-    #   {{ @type }}::{{enum_name}}
-    def initialize(@enum : Avram{{ enum_name }})
+    def parse(value : Int32)
+      if result = T.from_value?(value)
+        SuccessfulCast.new(result)
+      else
+        FailedCast.new
+      end
     end
 
-    def initialize(enum_value : Int32)
-      @enum = Avram{{ enum_name }}.from_value(enum_value)
+    def parse(value : T)
+      SuccessfulCast.new(value)
     end
 
-    def initialize(enum_value : String)
-      int_value = enum_value.to_i?
-      @enum = if int_value
-                Avram{{ enum_name }}.from_value(int_value)
-              else
-                Avram{{ enum_name }}.parse(enum_value)
-              end
+    def to_db(value : T)
+      value.value.to_s
     end
 
-    delegate :===, to_s, to_i, to: @enum
-
-    forward_missing_to @enum
-
-    module Lucky
-      alias ColumnType = Int32
-      include Avram::Type
-
-      def self.criteria(query : T, column) forall T
-        Criteria(T, Int32).new(query, column)
-      end
-
-      def from_db!(value : Int32)
-        {{ enum_name }}.new(value)
-      end
-
-      def parse(value : Avram{{ enum_name }})
-        SuccessfulCast({{ enum_name }}).new(value)
-      end
-
-      def parse(value : String)
-        SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
-      end
-
-      def parse(value : Int32)
-        SuccessfulCast({{ enum_name }}).new({{ enum_name }}.new(value))
-      end
-
-      def to_db(value : Int32)
-        value.to_s
-      end
-
-      def to_db(value : {{ enum_name }})
-        value.value.to_s
-      end
-
-      class Criteria(T, V) < Int32::Lucky::Criteria(T, V)
-      end
+    def criteria(query : V, column) forall V
+      Avram::Criteria(V, T).new(query, column)
     end
   end
 end

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -32,7 +32,21 @@ abstract struct Enum
     end
 
     def criteria(query : V, column) forall V
-      Avram::Criteria(V, T).new(query, column)
+      Criteria(V, T).new(query, column)
+    end
+
+    class Criteria(T, V) < Avram::Criteria(T, V)
+      def select_min : V?
+        rows.exec_scalar(&.select_min(column))
+          .as(Int32?)
+          .try { |min| V.adapter.parse!(min) }
+      end
+
+      def select_max : V?
+        rows.exec_scalar(&.select_max(column))
+          .as(Int32?)
+          .try { |max| V.adapter.parse!(max) }
+      end
     end
   end
 end

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -1,3 +1,5 @@
+require "./int32_extensions"
+
 abstract struct Enum
   def self.adapter
     Lucky(self)
@@ -35,7 +37,7 @@ abstract struct Enum
       Criteria(V, T).new(query, column)
     end
 
-    class Criteria(T, V) < Avram::Criteria(T, V)
+    class Criteria(T, V) < Int32::Lucky::Criteria(T, V)
       def select_min : V?
         rows.exec_scalar(&.select_min(column))
           .as(Int32?)

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -125,11 +125,11 @@ class Avram::Criteria(T, V)
   end
 
   def select_min : V?
-    V.adapter.parse!(rows.exec_scalar(&.select_min(column)))
+    rows.exec_scalar(&.select_min(column)).as(V?)
   end
 
   def select_max : V?
-    V.adapter.parse!(rows.exec_scalar(&.select_max(column)))
+    rows.exec_scalar(&.select_max(column)).as(V?)
   end
 
   def select_average : Float64?

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -124,16 +124,16 @@ class Avram::Criteria(T, V)
     add_clause(Avram::Where::LessThanOrEqualTo.new(column, V.adapter.to_db!(value)))
   end
 
-  def select_min : V | Nil
-    rows.exec_scalar(&.select_min(column)).as(V | Nil)
+  def select_min : V?
+    V.adapter.parse!(rows.exec_scalar(&.select_min(column)))
   end
 
-  def select_max : V | Nil
-    rows.exec_scalar(&.select_max(column)).as(V | Nil)
+  def select_max : V?
+    V.adapter.parse!(rows.exec_scalar(&.select_max(column)))
   end
 
   def select_average : Float64?
-    rows.exec_scalar(&.select_average(column)).as(PG::Numeric | Nil).try &.to_f64
+    rows.exec_scalar(&.select_average(column)).as(PG::Numeric?).try &.to_f64
   end
 
   def select_average! : Float64

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -21,10 +21,6 @@ module Avram::Type
     end
   end
 
-  def parse(value)
-    FailedCast.new
-  end
-
   def parse!(value)
     parse(value).as(SuccessfulCast).value
   end

--- a/src/avram/type.cr
+++ b/src/avram/type.cr
@@ -21,6 +21,10 @@ module Avram::Type
     end
   end
 
+  def parse(value)
+    FailedCast.new
+  end
+
   def parse!(value)
     parse(value).as(SuccessfulCast).value
   end


### PR DESCRIPTION
Fixes https://github.com/luckyframework/avram/issues/590
Fixes https://github.com/luckyframework/avram/issues/610

Related to https://github.com/luckyframework/avram/issues/697

I was able to drop the need for having the `avram_enum` macro and allow using regular enums. I'm somewhat worried that by dropping the macro that creates a struct, we will be losing functionality but I can't find anything.

It was added in https://github.com/luckyframework/avram/pull/339 but I don't see any specifics as to why they did what they did.

I did find one problem with `Avram::Criteria` and enums that affects `avram_enums` as well where calling `select_max` would return an `Int32` instead of the enum value.

I think the end goal is to allow storage of enums in the database as something other than `Int32` but I think this PR is necessary because it eliminates a lot of assumptions of complexity before we make more changes.

## Warning

This would be a breaking change. Everyone that uses `avram_enum` in their project would have to change to regular enums though it shouldn't effect anything else because I'd hope no one is using the underlying enum that the macro made. If they did, they will have to update that as well.