### PR TITLE
Resolve type before using it in migrations

### DIFF
--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -113,16 +113,16 @@ class Avram::Migrator::AlterTableStatement
   end
 
   macro add(type_declaration, index = false, using = :btree, unique = false, default = nil, fill_existing_with = nil, **type_options)
-    {% type = type_declaration.type %}
+    {% type = type_declaration.type.resolve %}
     {% nilable = false %}
     {% array = false %}
     {% should_fill_existing = (!(fill_existing_with == nil)) && (fill_existing_with != :nothing) %}
 
-    {% if type.is_a?(Union) %}
-      {% type = type.types.first %}
+    {% if type.nilable? %}
+      {% type = type.union_types.reject(&.==(Nil)).first %}
       {% nilable = true %}
     {% end %}
-    {% if type.is_a?(Generic) %}
+    {% if type < Array %}
       {% type = type.type_vars.first %}
       {% array = true %}
     {% end %}

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -87,14 +87,14 @@ class Avram::Migrator::CreateTableStatement
   end
 
   macro add(type_declaration, default = nil, index = false, unique = false, using = :btree, **type_options)
-    {% type = type_declaration.type %}
+    {% type = type_declaration.type.resolve %}
     {% nilable = false %}
     {% array = false %}
-    {% if type.is_a?(Union) %}
-      {% type = type.types.first %}
+    {% if type.nilable? %}
+      {% type = type.union_types.reject(&.==(Nil)).first %}
       {% nilable = true %}
     {% end %}
-    {% if type.is_a?(Generic) %}
+    {% if type < Array %}
       {% type = type.type_vars.first %}
       {% array = true %}
     {% end %}


### PR DESCRIPTION
Fixes #689 

Imagine accidentally doing `add admin : Boolean` where `Boolean` should have actually been `Bool` but you forgot.

Before this change the error you got from that would look like:
<img width="810" alt="CleanShot 2021-07-09 at 16 03 57@2x" src="https://user-images.githubusercontent.com/17329408/125131023-0ebcb680-e0d0-11eb-9cf7-2054132e0141.png">

With this change, it now looks like:
<img width="458" alt="CleanShot 2021-07-09 at 16 03 31@2x" src="https://user-images.githubusercontent.com/17329408/125131039-15e3c480-e0d0-11eb-8b61-cf8a986a3048.png">
