### PR TITLE
Add uniqueness validation providing query

### DIFF
--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -4,6 +4,7 @@ class UniquenessSaveOperation < User::SaveOperation
   before_save do
     validate_uniqueness_of name
     validate_uniqueness_of nickname, query: UserQuery.new.nickname.lower
+    validate_uniqueness_of age, query: UserQuery.new.name.nilable_eq(name.value)
   end
 end
 
@@ -110,21 +111,28 @@ describe Avram::Validations do
       operation = UniquenessSaveOperation.new
       operation.name.value = existing_user.name
       operation.nickname.value = existing_user.nickname.not_nil!.downcase
+      operation.age.value = existing_user.age
 
       operation.save
 
+      operation.valid?.should be_false
       operation.name.errors.should contain "is already taken"
       operation.nickname.errors.should contain "is already taken"
+      operation.age.errors.should contain "is already taken"
     end
 
     it "ignores the existing record on update" do
-      existing_user = UserFactory.new.name("Sally").create
+      existing_user = UserFactory.new.name("Sally").nickname("Sal").create
       operation = UniquenessSaveOperation.new(existing_user)
       operation.name.value = existing_user.name
+      operation.nickname.value = existing_user.nickname.not_nil!.downcase
+      operation.age.value = existing_user.age
 
-      operation.valid?
+      operation.save
 
-      operation.name.errors.should_not contain "is already taken"
+      operation.name.errors.should be_empty
+      operation.nickname.errors.should be_empty
+      operation.age.errors.should be_empty
     end
   end
 

--- a/src/avram/database_validations.cr
+++ b/src/avram/database_validations.cr
@@ -23,10 +23,10 @@ module Avram::DatabaseValidations(T)
   # database you will not know if there is a collision until all other validations
   # pass and Avram tries to save the record.
   private def validate_uniqueness_of(
-    attribute : Avram::Attribute(V),
-    query : Avram::Criteria(T::BaseQuery, V),
+    attribute : Avram::Attribute,
+    query : Avram::Criteria(T::BaseQuery, _),
     message : String = "is already taken"
-  ) forall V
+  )
     attribute.value.try do |value|
       if limit_query(query.eq(value)).first?
         attribute.add_error message

--- a/src/avram/database_validations.cr
+++ b/src/avram/database_validations.cr
@@ -5,8 +5,11 @@ module Avram::DatabaseValidations(T)
   #
   # > This will only work with attributes that correspond to a database column.
   #
+  # Passing a criteria is useful when wanting to change how it compares the value in the database.
+  # For example, making sure that it compares emails that are all downcased to account for different capital letters.
+  #
   # ```
-  # validate_uniqueness_of email
+  # validate_uniqueness_of email, query: UserQuery.new.email.lower
   # ```
   #
   # If there is another email address with the same value, the attribute will be
@@ -25,7 +28,7 @@ module Avram::DatabaseValidations(T)
     message : String = "is already taken"
   )
     attribute.value.try do |value|
-      if query.eq(value).first?
+      if limit_query(query.eq(value)).first?
         attribute.add_error message
       end
     end
@@ -56,17 +59,42 @@ module Avram::DatabaseValidations(T)
   # ```
   private def validate_uniqueness_of(
     attribute : Avram::Attribute,
-    message : Avram::Attribute::ErrorMessage = "is already taken"
+    query : Avram::Queryable,
+    message : String = "is already taken"
   )
     attribute.value.try do |value|
-      if build_validation_query(attribute.name, value).first?
+      if limit_query(query).where(attribute.name, value).first?
         attribute.add_error message
       end
     end
   end
 
-  private def build_validation_query(column_name, value) : T::BaseQuery
-    query = T::BaseQuery.new.where(column_name, value)
+  # Validates that the given attribute is unique in the database
+  #
+  # > This will only work with attributes that correspond to a database column.
+  #
+  # ```
+  # validate_uniqueness_of name
+  # ```
+  #
+  # If there is another database row with the same name, the attribute will be
+  # marked as invalid.
+  #
+  # Note that you should also add a unique index when creating the table so that
+  # there are no race conditions and you are guaranteed that the value is unique.
+  #
+  # This validation is still useful as it will check for uniqueness along with
+  # all other validations. If you just have the uniqueness constraint in the
+  # database you will not know if there is a collision until all other validations
+  # pass and Avram tries to save the record.
+  private def validate_uniqueness_of(
+    attribute : Avram::Attribute,
+    message : Avram::Attribute::ErrorMessage = "is already taken"
+  )
+    validate_uniqueness_of(attribute: attribute, query: T::BaseQuery.new, message: message)
+  end
+
+  private def limit_query(query)
     record.try(&.id).try do |id|
       query = query.id.not.eq(id)
     end

--- a/src/avram/database_validations.cr
+++ b/src/avram/database_validations.cr
@@ -23,10 +23,10 @@ module Avram::DatabaseValidations(T)
   # database you will not know if there is a collision until all other validations
   # pass and Avram tries to save the record.
   private def validate_uniqueness_of(
-    attribute : Avram::Attribute,
-    query : Avram::Criteria,
+    attribute : Avram::Attribute(V),
+    query : Avram::Criteria(T::BaseQuery, V),
     message : String = "is already taken"
-  )
+  ) forall V
     attribute.value.try do |value|
       if limit_query(query.eq(value)).first?
         attribute.add_error message
@@ -59,7 +59,7 @@ module Avram::DatabaseValidations(T)
   # ```
   private def validate_uniqueness_of(
     attribute : Avram::Attribute,
-    query : Avram::Queryable,
+    query : T::BaseQuery,
     message : String = "is already taken"
   )
     attribute.value.try do |value|


### PR DESCRIPTION
Fixes #368 
Fixes https://github.com/luckyframework/lucky/issues/1482

Allows for passing a query to the uniqueness validation without specifically passing in a criteria.

If all you wanted to do was limit the uniqueness validation by a different column, before you had to do:

```crystal
validate_uniqueness_of email, query: UserQuery.new.tenant(1).email
```

Now you can do:

```crystal
validate_uniqueness_of email, query: UserQuery.new.tenant(1)
```

It's a small change but it cuts down on confusion and allows users to be clear on what they are actually trying to do.

## Additionally

Other changes were made (I can extract them if necessary)

1. The docs were wrong and have been fixed (on the wrong overloads)
2. The criteria overload was missing the limit to ignore the current record if it was an update
3. Generics were added to the criteria and new overloads to add additional type safety