### PR TITLE
Add any? and none? as query methods

### DIFF
--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -284,20 +284,20 @@ describe Avram::Queryable do
     it "is true if there is a record in the database" do
       UserFactory.new.name("First").create
 
-      UserQuery.new.name("First").any?.should be_true
+      UserQuery.new.name("First").any?.should be_true # ameba:disable Performance/AnyInsteadOfEmpty
     end
 
     it "is false if there is not a record in the database" do
       UserFactory.new.name("First").create
 
-      UserQuery.new.name("Second").any?.should be_false
+      UserQuery.new.name("Second").any?.should be_false # ameba:disable Performance/AnyInsteadOfEmpty
     end
 
     it "does not mutate the query" do
       query = UserQuery.new.name("name")
       original_query_sql = query.to_sql
 
-      query.any?
+      query.any? # ameba:disable Performance/AnyInsteadOfEmpty
 
       query.to_sql.should eq original_query_sql
     end

--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -280,6 +280,43 @@ describe Avram::Queryable do
     end
   end
 
+  describe "#any?" do
+    it "is true if there is a record in the database" do
+      UserFactory.new.name("First").create
+
+      UserQuery.new.name("First").any?.should be_true
+    end
+
+    it "is false if there is not a record in the database" do
+      UserFactory.new.name("First").create
+
+      UserQuery.new.name("Second").any?.should be_false
+    end
+
+    it "does not mutate the query" do
+      query = UserQuery.new.name("name")
+      original_query_sql = query.to_sql
+
+      query.any?
+
+      query.to_sql.should eq original_query_sql
+    end
+  end
+
+  describe "#none?" do
+    it "is true if no records found in database" do
+      UserFactory.new.name("First").create
+
+      UserQuery.new.name("Second").none?.should be_true
+    end
+
+    it "is false if there is a record in the database" do
+      UserFactory.new.name("First").create
+
+      UserQuery.new.name("First").none?.should be_false
+    end
+  end
+
   describe ".find" do
     it "gets the record with the given id" do
       UserFactory.create

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -74,19 +74,19 @@ abstract class Avram::Database
   end
 
   # Methods without a block
-  {% for crystal_db_alias in [:exec, :scalar, :query, :query_all, :query_one, :query_each] %}
+  {% for crystal_db_alias in [:exec, :scalar, :query, :query_all, :query_one, :query_one?, :query_each] %}
     # Same as crystal-db's `DB::QueryMethods#{{ crystal_db_alias.id }}` but with instrumentation
     def {{ crystal_db_alias.id }}(query, *args_, args : Array? = nil, queryable : String? = nil, **named_args)
       publish_query_event(query, args_, args, queryable) do
         run do |db|
-          db.{{ crystal_db_alias.id }}(query, *args_, args: args)
+          db.{{ crystal_db_alias.id }}(query, *args_, **named_args, args: args)
         end
       end
     end
 
     # Same as crystal-db's `DB::QueryMethods#{{ crystal_db_alias.id }}` but with instrumentation
     def self.{{ crystal_db_alias.id }}(query, *args_, args : Array? = nil, queryable : String? = nil, **named_args)
-      new.{{ crystal_db_alias.id }}(query, *args_, args: args, queryable: queryable)
+      new.{{ crystal_db_alias.id }}(query, *args_, **named_args, args: args, queryable: queryable)
     end
   {% end %}
 

--- a/src/avram/database_validations.cr
+++ b/src/avram/database_validations.cr
@@ -28,7 +28,7 @@ module Avram::DatabaseValidations(T)
     message : String = "is already taken"
   )
     attribute.value.try do |value|
-      if limit_query(query.eq(value)).first?
+      if limit_query(query.eq(value)).any?
         attribute.add_error message
       end
     end
@@ -63,7 +63,7 @@ module Avram::DatabaseValidations(T)
     message : String = "is already taken"
   )
     attribute.value.try do |value|
-      if limit_query(query).where(attribute.name, value).first?
+      if limit_query(query).where(attribute.name, value).any?
         attribute.add_error message
       end
     end

--- a/src/avram/database_validations.cr
+++ b/src/avram/database_validations.cr
@@ -28,7 +28,7 @@ module Avram::DatabaseValidations(T)
     message : String = "is already taken"
   )
     attribute.value.try do |value|
-      if limit_query(query.eq(value)).any?
+      if limit_query(query.eq(value)).any? # ameba:disable Performance/AnyInsteadOfEmpty
         attribute.add_error message
       end
     end
@@ -63,7 +63,7 @@ module Avram::DatabaseValidations(T)
     message : String = "is already taken"
   )
     attribute.value.try do |value|
-      if limit_query(query).where(attribute.name, value).any?
+      if limit_query(query).where(attribute.name, value).any? # ameba:disable Performance/AnyInsteadOfEmpty
         attribute.add_error message
       end
     end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -246,6 +246,10 @@ class Avram::QueryBuilder
     self
   end
 
+  def select(@selections : String)
+    self
+  end
+
   def ordered?
     !@orders.empty?
   end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -36,6 +36,14 @@ module Avram::Queryable(T)
       new.last?
     end
 
+    def self.any? : Bool
+      new.any?
+    end
+
+    def self.none? : Bool
+      new.none?
+    end
+
     def self.truncate
       query = self.new
       query.database.exec "TRUNCATE TABLE #{query.table_name}"
@@ -193,6 +201,17 @@ module Avram::Queryable(T)
 
   def last
     last? || raise RecordNotFoundError.new(model: table_name, query: :last)
+  end
+
+  def any? : Bool
+    queryable = clone
+    new_query = queryable.query.limit(1).select("1 AS one")
+    results = database.query_one?(new_query.statement, args: new_query.args, queryable: schema_class.name, as: Int32)
+    !results.nil?
+  end
+
+  def none? : Bool
+    !any?
   end
 
   def select_count : Int64


### PR DESCRIPTION
Fixes #680 

Provides two simple methods to check if there are any records in the database matching the specified conditions. Within avram's codebase, it simplifies the uniqueness checks.

Usage looks like:

```crystal
UserQuery.any?
UserQuery.new.name("Sally").any?
```