### PR TITLE
Don't mutate the query builder when calling the statement methods

### DIFF
--- a/spec/query_builder_spec.cr
+++ b/spec/query_builder_spec.cr
@@ -87,6 +87,14 @@ describe Avram::QueryBuilder do
     query.args.should eq ["Paul", "20"]
   end
 
+  it "has the same statement on subsequent calls" do
+    query = new_query
+      .where(Avram::Where::Equal.new(:name, "Paul"))
+      .where(Avram::Where::GreaterThan.new(:age, "20"))
+    query.statement.should eq "SELECT * FROM users WHERE name = $1 AND age > $2"
+    query.statement.should eq "SELECT * FROM users WHERE name = $1 AND age > $2"
+  end
+
   it "accepts raw where clauses" do
     query = new_query
       .where(Avram::Where::Raw.new("name = ?", "Mikias"))
@@ -131,6 +139,16 @@ describe Avram::QueryBuilder do
 
       query.statement_for_update(params).should eq "UPDATE users SET first_name = $1, last_name = $2 WHERE id = $3 LIMIT 1 RETURNING *"
       query.args_for_update(params).should eq ["Paul", nil, "1"]
+    end
+
+    it "has the same placeholder values on subsequent calls" do
+      params = {:first_name => "Paul", :last_name => nil}
+      query = new_query
+        .where(Avram::Where::Equal.new(:id, "1"))
+        .limit(1)
+
+      query.statement_for_update(params).should eq "UPDATE users SET first_name = $1, last_name = $2 WHERE id = $3 LIMIT 1 RETURNING *"
+      query.statement_for_update(params).should eq "UPDATE users SET first_name = $1, last_name = $2 WHERE id = $3 LIMIT 1 RETURNING *"
     end
   end
 

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -55,10 +55,18 @@ class Avram::QueryBuilder
   end
 
   def statement
+    clone.statement!
+  end
+
+  def statement!
     join_sql [@delete ? delete_sql : select_sql] + sql_condition_clauses
   end
 
   def statement_for_update(params, return_columns returning? : Bool = true)
+    clone.statement_for_update!(params, returning?)
+  end
+
+  def statement_for_update!(params, return_columns returning? : Bool = true)
     sql = ["UPDATE #{table}", set_sql_clause(params)]
     sql += sql_condition_clauses
     sql += ["RETURNING #{@selections}"] if returning?
@@ -316,13 +324,7 @@ class Avram::QueryBuilder
     @wheres.pop
   end
 
-  @_wheres_sql : String?
-
   private def wheres_sql
-    @_wheres_sql ||= joined_wheres_queries
-  end
-
-  private def joined_wheres_queries
     if !wheres.empty?
       statements = wheres.flat_map do |sql_clause|
         clause = sql_clause.prepare(->next_prepared_statement_placeholder)


### PR DESCRIPTION
Fixes #712

Clone the queries, so the subsequent calls to #statement and #statement_for_update returns the same result.

https://github.com/luckyframework/avram/blob/e638ffb8eb5e8088449dfa63cb61a0739212f38d/src/avram/queryable.cr#L227-L230

