### PR TITLE
Fix wrong command in help messages

### DIFF
--- a/src/avram/tasks/db/migrations_status.cr
+++ b/src/avram/tasks/db/migrations_status.cr
@@ -18,8 +18,8 @@ class Db::Migrations::Status < BaseTask
 
     Examples:
 
-      lucky db.migration.status
-      LUCKY_ENV=test lucky db.migration.status # Show migration status for test db
+      lucky db.migrations.status
+      LUCKY_ENV=test lucky db.migrations.status # Show migration status for test db
 
     TEXT
   end

--- a/src/avram/tasks/db/rollback_to.cr
+++ b/src/avram/tasks/db/rollback_to.cr
@@ -7,7 +7,7 @@ class Db::RollbackTo < BaseTask
     <<-TEXT
     #{summary}
 
-    You can get the migration version from the filename or by running 'lucky db.migration.status'
+    You can get the migration version from the filename or by running 'lucky db.migrations.status'
 
     Example:
 


### PR DESCRIPTION
Correct command is `db.migrations.status` ("migration**s**" <-- plural)

Originates from commit f3d6328d25732aaa6359b8e9f7a670df2aef5b41.