### PR TITLE
Prevent ameba from being installed during postinstall

### DIFF
--- a/script/precompile_tasks
+++ b/script/precompile_tasks
@@ -6,7 +6,15 @@ set -e
 # Precompile tasks if not in production and not in CI
 # Also allow skipping precompilation with an ENV var
 if [ "$LUCKY_ENV" != "production" ] && [ -z "$CI" ] && [ -z "$SKIP_LUCKY_TASK_PRECOMPILATION" ]; then
-    shards build && \
-    mkdir -p ../../bin && \
-    cp -r "$(pwd)/bin" "$(pwd)/../.."
+    # This is to prevent Avram's development dependencies being installed
+    # from an external source like running `shards install` from a Lucky app.
+    # Install shards and build shard targets.
+    if [ -z "$BUILD_WITHOUT_DEVELOPMENT" ]; then
+        shards build
+    else
+        shards build --without-development
+    fi
+
+    mkdir -p ../../bin
+    cp -r "$PWD/bin" "$PWD/../.."
 fi

--- a/shard.yml
+++ b/shard.yml
@@ -41,4 +41,4 @@ development_dependencies:
     version: ~> 0.14.2
 
 scripts:
-  postinstall: script/precompile_tasks
+  postinstall: BUILD_WITHOUT_DEVELOPMENT=true script/precompile_tasks


### PR DESCRIPTION
Ref: https://github.com/luckyframework/lucky/issues/1524

Since Lucky includes Avram as a dependency, when you install Lucky, it runs Avram's postinstall script which in turn will run `shards build` from the avram project. This command will install the development_dependencies.

To fix that, we add an ENV var to skip installing development shards. If that ENV var exists, then we install without development dependencies. You can still run `./script/precompile_tasks` locally if you need.