### PR TITLE
If there are pending migrations, tell the app to shut down

### DIFF
--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -172,8 +172,23 @@ class Avram::Migrator::Runner
 
   def ensure_migrated!
     if !pending_migrations.empty?
-      raise "There are pending migrations. Please run lucky db.migrate"
+      puts ""
+      puts error_background
+      puts pending_migrations_error.colorize.on_red.white
+      puts error_background
+      puts ""
+      Process.signal(:term, Process.ppid)
+      Process.signal(:hup, Process.ppid)
+      exit 1
     end
+  end
+
+  private def pending_migrations_error
+    " There are pending migrations. Please run lucky db.migrate "
+  end
+
+  private def error_background
+    (" " * pending_migrations_error.size).colorize.on_red
   end
 
   private def migrated_migrations


### PR DESCRIPTION
Fixes #671
Fixes https://github.com/luckyframework/lucky/issues/1142

This PR adds a front and center error when there's pending migrations.

## Before PR:
![](https://user-images.githubusercontent.com/2391/116312821-d0b32600-a761-11eb-81e4-208dac1e7311.png)

## After PR:
<img width="1042" alt="Screen Shot 2021-10-03 at 9 24 56 AM" src="https://user-images.githubusercontent.com/2391/135762858-d037f5aa-a4ee-4b6e-8b1d-1652da55dcd7.png">


there is one minor issue still here which is if you boot your app locally without a process manager (e.g. `crystal src/start_server.cr`), it will try to send interrupt signals to the parent process.
<img width="709" alt="Screen Shot 2021-10-03 at 9 25 35 AM" src="https://user-images.githubusercontent.com/2391/135762915-c6c2fbe3-3d11-4b07-8ef4-f63535f3d1fa.png">

Most likely this isn't a big issue. You can even just run `lucky watch` and it's fine. It's only when booting the app manually through crystal.

