### PR TITLE
Make the references explicit when using namespaced models in migrations

### DIFF
--- a/spec/migrator/alter_table_statement_spec.cr
+++ b/spec/migrator/alter_table_statement_spec.cr
@@ -114,7 +114,7 @@ describe Avram::Migrator::AlterTableStatement do
         add_belongs_to category_label : CategoryLabel, on_delete: :nullify, references: :custom_table
         add_belongs_to employee : User, on_delete: :cascade
         add_belongs_to line_item : LineItem, on_delete: :cascade, foreign_key_type: UUID, fill_existing_with: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
-        add_belongs_to subscription_item : Subscription::Item, on_delete: :cascade
+        add_belongs_to subscription_item : Subscription::Item, on_delete: :cascade, references: :subscription_items
       end
 
       built.statements.first.should eq <<-SQL

--- a/spec/migrator/create_table_statement_spec.cr
+++ b/spec/migrator/create_table_statement_spec.cr
@@ -191,7 +191,7 @@ describe Avram::Migrator::CreateTableStatement do
         add_belongs_to category_label : CategoryLabel, on_delete: :nullify, references: :custom_table
         add_belongs_to employee : User, on_delete: :cascade
         add_belongs_to line_item : LineItem, on_delete: :cascade, foreign_key_type: UUID
-        add_belongs_to subscription_item : Subscription::Item, on_delete: :cascade
+        add_belongs_to subscription_item : Subscription::Item, on_delete: :cascade, references: :subscription_items
       end
 
       built.statements.first.should eq <<-SQL

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -80,6 +80,16 @@ class Avram::Migrator::AlterTableStatement
     {% unless type_declaration.is_a?(TypeDeclaration) %}
       {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
     {% end %}
+    {% if type_declaration.type.stringify =~ /\w::\w/ && references.nil? %}
+      {% raise <<-ERROR
+      Namespaced models must include the `references` option with the name of the table.
+
+      Try this...
+
+        ▸ add_belongs_to(#{type_declaration}, on_delete: #{on_delete}, references: :the_table_name)
+      ERROR
+      %}
+    {% end %}
     {% optional = type_declaration.type.is_a?(Union) %}
 
     {% if optional %}

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -122,6 +122,16 @@ class Avram::Migrator::CreateTableStatement
     {% unless type_declaration.is_a?(TypeDeclaration) %}
       {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
     {% end %}
+    {% if type_declaration.type.stringify =~ /\w::\w/ && references.nil? %}
+      {% raise <<-ERROR
+      Namespaced models must include the `references` option with the name of the table.
+
+      Try this...
+
+        ▸ add_belongs_to(#{type_declaration}, on_delete: #{on_delete}, references: :the_table_name)
+      ERROR
+      %}
+    {% end %}
     {% optional = type_declaration.type.is_a?(Union) %}
 
     {% if optional %}


### PR DESCRIPTION
Fixes #709

Will now throw a compile-time error if you're not explicit with the references for namespaced models. 