### PR TITLE
Adding color to the pending migrations in the status

### DIFF
--- a/script/integration_test
+++ b/script/integration_test
@@ -17,11 +17,11 @@ then
     # Integration test various tasks
     printf "\nRolling back to 20180802180356\n"
     lucky db.rollback_to 20180802180356
+    lucky db.migrations.status
     printf "\nRolling back remainder\n"
     lucky db.rollback_all
     lucky db.migrate.one
     lucky db.migrate
-    lucky db.migrations.status
     lucky db.reset
     lucky db.drop
     lucky db.setup

--- a/src/avram/tasks/db/migrations_status.cr
+++ b/src/avram/tasks/db/migrations_status.cr
@@ -42,7 +42,7 @@ class Db::Migrations::Status < BaseTask
 
   private def migration_statuses
     migrations.map do |migration|
-      status = migration.new.migrated? ? "Migrated" : "Pending"
+      status = migration.new.migrated? ? "Migrated" : "Pending".colorize(:yellow)
       [migration.name, status]
     end
   end


### PR DESCRIPTION
When you run `lucky db.migrations.status`, you get a giant table showing if each migration has been migrated or is still pending.

Most of the Lucky tasks like `db.migrate`, `gen.whatever`, and especially `lucky routes` all print out color of some sort to highlight the important bits. I think adding just a touch of yellow to "Pending" really helps you to focus on what matters in this task.

<img width="777" alt="Screen Shot 2021-10-12 at 6 03 38 PM" src="https://user-images.githubusercontent.com/2391/137049304-e6423313-d177-43aa-95a0-301e69ed3f3f.png">

Related: https://github.com/luckyframework/lucky/discussions/1563