### PR TITLE
Custom setting for Time format

### DIFF
--- a/src/avram.cr
+++ b/src/avram.cr
@@ -21,6 +21,8 @@ module Avram
     setting lazy_load_enabled : Bool = true
     setting database_to_migrate : Avram::Database.class, example: "AppDatabase"
     setting time_formats : Array(String) = [] of String
+    # This is the default format for storing the Time
+    setting default_time_format : String? = nil, example: "%F %X.%6N %:z"
   end
 
   Log            = ::Log.for(Avram)

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -72,7 +72,11 @@ struct Time
     end
 
     def to_db(value : Time)
-      value.to_s
+      if default_format = Avram.settings.default_time_format
+        value.to_s(default_format)
+      else
+        value.to_s
+      end
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)


### PR DESCRIPTION
Fixes #727

This PR allows you to set a custom format that will be used on all `Time` columns. As of right now, we have no way to do this on a per-column level. It's all or nothing.

I'm opening this as a draft because I'm still not sold on going this route. The fear is this gives people the wide open ability to just do `default_time_format = "%Y"` which would set all `created_at`, and `updated_at` to just the year, and would break all html forms using time inputs. Maybe we could just have a `include_milliseconds = true`? I'm not sure, but I'll keep thinking about it.