### PR TITLE
Added new default_validations to Operations

### DIFF
--- a/spec/polymorphic_spec.cr
+++ b/spec/polymorphic_spec.cr
@@ -30,7 +30,21 @@ private class OptionalPolymorphicEvent < BaseModel
   end
 end
 
+class TestPolymorphicSave < PolymorphicEvent::SaveOperation
+  before_save do
+    task = PolymorphicTask::SaveOperation.create!(title: "Use Lucky")
+    task_id.value = task.id
+  end
+end
+
 describe "polymorphic belongs to" do
+  it "allows you to set the association before save" do
+    TestPolymorphicSave.create do |op, tp|
+      op.valid?.should eq(true)
+      tp.should_not be_nil
+    end
+  end
+
   it "sets up a method for accessing associated record" do
     task = PolymorphicTask::SaveOperation.create!(title: "Use Lucky")
     event = PolymorphicEvent::SaveOperation.create!(task_id: task.id)

--- a/src/avram/delete_operation.cr
+++ b/src/avram/delete_operation.cr
@@ -73,9 +73,13 @@ abstract class Avram::DeleteOperation(T)
     end
   end
 
+  # :nodoc:
+  def default_validations; end
+
   # Returns `true` if all attributes are valid,
   # and there's no custom errors
   def valid?
+    default_validations
     custom_errors.empty? && attributes.all?(&.valid?)
   end
 

--- a/src/avram/operation.cr
+++ b/src/avram/operation.cr
@@ -92,9 +92,13 @@ abstract class Avram::Operation
     @params = Avram::Params.new
   end
 
+  # :nodoc:
+  def default_validations; end
+
   # Returns `true` if all attributes are valid,
   # and there's no custom errors
   def valid?
+    default_validations
     custom_errors.empty? && attributes.all?(&.valid?)
   end
 

--- a/src/avram/polymorphic.cr
+++ b/src/avram/polymorphic.cr
@@ -140,7 +140,10 @@ module Avram::Polymorphic
 
     macro finished
       class SaveOperation
-        before_save do
+        # These validations must be run after all of the `before_save`
+        # in case anyone sets their polymorphic association in a callback.
+        # These are ran in the SaveOperation#valid? method
+        default_validations do
           {% list_of_foreign_keys = associations.map(&.id).map { |assoc| "#{assoc.id}_id".id } %}
 
           # TODO: Needs to actually get the foreign key from the ASSOCIATIONS constant

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -206,9 +206,16 @@ abstract class Avram::SaveOperation(T)
     end
   end
 
+  # Runs all required validations for required types
+  # as well as any additional valitaions the type needs to run
+  # e.g. polymorphic validations
   def run_default_validations
     validate_required *required_attributes
+    default_validations
   end
+
+  # :nodoc:
+  def default_validations; end
 
   # This allows you to skip the default validations
   # which may be used as an escape hatch when you want

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -7,6 +7,31 @@ require "./validations/callable_error_message"
 module Avram::Validations
   extend self
 
+  macro included
+    abstract def default_validations
+  end
+
+  # Defines an instance method that gets called
+  # during validation of an operation. Define your default
+  # validations inside of the block.
+  # ```
+  # default_validations do
+  #   validate_required some_attribute
+  # end
+  # ```
+  macro default_validations
+    # :nodoc:
+    def default_validations
+      {% if @type.methods.map(&.name).includes?(:default_validations.id) %}
+        previous_def
+      {% else %}
+        super
+      {% end %}
+
+      {{ yield }}
+    end
+  end
+
   # Validates that at most one attribute is filled
   #
   # If more than one attribute is filled it will mark all but the first filled


### PR DESCRIPTION
 Fixes #645

The original issue was that our polymorphic `before_save` callback would run validations before any that you would set in your own SaveOperation. This prevented you from being able to assign your association in your SaveOperation.

This PR adds a new functionality to operations (SaveOperation, Operation, and DeleteOperation) to set your own `default_validations`. It works similar to `before_save` in that it takes a block, and you can run some code in there. When the operations call `valid?` it will run any required validations (as it always has), as well as any default validations you might need. This means you can also abstract them to a module to include them in several different operations if you need.

```crystal
module DefaultThingValidations
  macro included
    default_validations do
      validate_required thing
    end
  end
end

class SaveThing1 < Thing1::SaveOperation
  include DefaultThingValidations
  before_save do
    # this is called before the default validations
    # so you can do any setup you need
    thing.value = "thing 1"
  end
end

class SaveThing2 < Thing2::SaveOperation
  include DefaultThingValidations
  before_save do
    thing.value = "thing 2"
  end
end
``` 