### PR TITLE
Add validate_format_of validator

### DIFF
--- a/spec/validations_spec.cr
+++ b/spec/validations_spec.cr
@@ -359,4 +359,46 @@ describe Avram::Validations do
       attribute.valid?.should be_true
     end
   end
+
+  describe "validate_format_of" do
+    it "validates" do
+      invalid_attribute = attribute("hi AT hey DOT com")
+      result = Avram::Validations.validate_format_of(
+        invalid_attribute,
+        /[^@]+@[^\.]+\..+/
+      )
+      result.should eq(false)
+      invalid_attribute.errors.should eq ["is invalid"]
+
+      valid_attribute = attribute("hi@hey.com")
+      result = Avram::Validations.validate_format_of(
+        valid_attribute,
+        /[^@]+@[^\.]+\..+/
+      )
+      result.should eq(true)
+      valid_attribute.valid?.should be_true
+    end
+
+    it "validates negatively" do
+      invalid_attribute = attribute("hi AT hey DOT com")
+      result = Avram::Validations.validate_format_of(
+        invalid_attribute,
+        with: /DOT/,
+        match: false
+      )
+      result.should eq(false)
+      invalid_attribute.errors.should eq ["is invalid"]
+    end
+
+    it "can allow nil" do
+      nil_attribute = nil_attribute(String)
+      result = Avram::Validations.validate_format_of(
+        nil_attribute,
+        with: /[^@]+@[^\.]+\..+/,
+        allow_nil: true
+      )
+      result.should eq(true)
+      nil_attribute.valid?.should be_true
+    end
+  end
 end

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -261,4 +261,31 @@ module Avram::Validations
 
     no_errors
   end
+
+  # Validates that the passed in attributes matches the given regex
+  #
+  # ```
+  # validate_format_of email, with: /[^@]+@[^\.]+\..+/
+  # ```
+  #
+  # Alternatively, the `match` argument can be set to `false` to not match the
+  # given regex.
+  def validate_format_of(
+    attribute : Avram::Attribute(String),
+    with regex : Regex,
+    match : Bool = true,
+    message : Avram::Attribute::ErrorMessage = "is invalid",
+    allow_nil : Bool = false
+  ) : Bool
+    unless allow_nil && attribute.value.nil?
+      matching = attribute.value.to_s.match(regex)
+
+      if (match && !matching) || (!match && matching)
+        attribute.add_error(message)
+        return false
+      end
+    end
+
+    true
+  end
 end


### PR DESCRIPTION
This PR adds the a format (regex) validator, not unlike Rails' `validates_format_of`.

```cr
# email = hi@wout.codes
validate_format_of email, /[^@]+@[^\.]+\..+/
# => is valid
```

or:

```cr
# email = hi@wout.codes
validate_format_of email, with: /[^@]+@[^\.]+\..+/
# => is valid
```

Unlike the Rails implementation, there is no `without` argument (as in *not* matching), but an additional argument called `match` which is `true` by default. By setting `match` to `false`, the validation will fail if the attribute's value matches the given regex:

```cr
# email = hi@wout.codes
validate_format_of email, with: /gmail\.com/, match: false
# => is valid

# email = someone@gmail.com
validate_format_of email, with: /gmail\.com/, match: false
# => is not valid
```

Finally, this validator also accepts the `allow_nil` argument.

Once we've agreed on this PR, I'll also update the documentation on the website.