### PR TITLE
New Query Cache Feature

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -34,6 +34,9 @@ dependencies:
   pulsar:
     github: luckyframework/pulsar
     version: ~> 0.2.2
+  splay_tree_map:
+    github: wyhaines/splay_tree_map.cr
+    version: ~> 0.1.3
 
 development_dependencies:
   ameba:

--- a/shard.yml
+++ b/shard.yml
@@ -17,8 +17,9 @@ dependencies:
     github: luckyframework/lucky_task
     version: ~> 0.1.0
   pg:
-    github: will/crystal-pg
-    version: ~> 0.24.0
+    # TODO: https://github.com/will/crystal-pg/pull/236
+    github: jwoertink/crystal-pg
+    branch: register_uuid_array
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4.7

--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -1,30 +1,36 @@
 require "./spec_helper"
 
+include QueryCacheHelpers
+
 describe Avram::Model do
   describe "has_many" do
     it "gets the related records" do
-      post = PostFactory.create
-      post2 = PostFactory.create
-      comment = CommentFactory.new.post_id(post.id).create
+      without_query_cache do
+        post = PostFactory.create
+        post2 = PostFactory.create
+        comment = CommentFactory.create &.post_id(post.id)
 
-      post = Post::BaseQuery.new.find(post.id)
+        post = Post::BaseQuery.new.find(post.id)
 
-      post.comments.should eq [comment]
-      comment.post.should eq post
-      post2.comments.size.should eq 0
+        post.comments.should eq [comment]
+        comment.post.should eq post
+        post2.comments.size.should eq 0
+      end
     end
 
     it "gets the related records for nilable association that exists" do
-      manager = ManagerFactory.create
-      employee = EmployeeFactory.new.manager_id(manager.id).create
-      customer = CustomerFactory.new.employee_id(employee.id).create
+      without_query_cache do
+        manager = ManagerFactory.create
+        employee = EmployeeFactory.create &.manager_id(manager.id)
+        customer = CustomerFactory.create &.employee_id(employee.id)
 
-      manager = Manager::BaseQuery.new.find(manager.id)
+        manager = Manager::BaseQuery.new.find(manager.id)
 
-      manager.employees.to_a.should eq [employee]
-      employee.manager.should eq manager
-      employee.customers.should eq [customer]
-      manager.customers.should eq [customer]
+        manager.employees.to_a.should eq [employee]
+        employee.manager.should eq manager
+        employee.customers.should eq [customer]
+        manager.customers.should eq [customer]
+      end
     end
 
     it "returns nil for nilable association that doesn't exist" do

--- a/spec/query_cache_spec.cr
+++ b/spec/query_cache_spec.cr
@@ -1,0 +1,36 @@
+require "./spec_helper"
+
+describe Avram::QueryCache do
+  it "does not cache on inserts" do
+    UserFactory.create &.name("Bob")
+    UserFactory.create &.name("Bob")
+
+    UserQuery.new.select_count.should eq(2)
+    TestDatabase.cache_vault.empty?.should eq(true)
+  end
+
+  it "only runs the query once" do
+    UserQuery.new.name("Bob").first?
+    UserQuery.new.name("Bob").first?
+    UserQuery.new.name("Frank").first?
+    UserQuery.new.name("Frank").first?
+    UserQuery.new.name("Frank").first?
+
+    # {"Bob sql" => [bob_results], "Frank sql" => [frank_results]}
+    TestDatabase.cache_vault.size.should eq(2)
+    TestDatabase.cache_counter["miss"].should eq(2)
+    TestDatabase.cache_counter["hit"].should eq(3)
+  end
+
+  it "doesn't persist cache between specs" do
+    TestDatabase.cache_vault.empty?.should eq(true)
+
+    UserQuery.new.name("Bob").first?
+    UserQuery.new.name("Bob").first?
+    UserQuery.new.name("Bob").first?
+
+    TestDatabase.cache_vault.size.should eq(1)
+    TestDatabase.cache_counter["miss"].should eq(1)
+    TestDatabase.cache_counter["hit"].should eq(2)
+  end
+end

--- a/spec/queryable_spec.cr
+++ b/spec/queryable_spec.cr
@@ -1358,7 +1358,7 @@ describe Avram::Queryable do
 
       users = UserQuery.new.group(&.age).group(&.id)
       users.query.statement.should eq "SELECT #{User::COLUMN_SQL} FROM users GROUP BY users.age, users.id"
-      users.map(&.name).should eq ["Dwight", "Michael", "Jim"]
+      users.map(&.name).sort!.should eq ["Dwight", "Jim", "Michael"]
     end
 
     it "raises an error when grouped incorrectly" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -19,8 +19,9 @@ Db::Create.new(quiet: true).run_task
 Db::Migrate.new(quiet: true).run_task
 Db::VerifyConnection.new(quiet: true).run_task
 
-Spec.before_each do
+Spec.after_each do
   TestDatabase.truncate
+  TestDatabase.reset_cache!
 end
 
 class SampleBackupDatabase < Avram::Database

--- a/spec/support/query_cache_helpers.cr
+++ b/spec/support/query_cache_helpers.cr
@@ -1,0 +1,7 @@
+module QueryCacheHelpers
+  private def without_query_cache
+    TestDatabase.temp_config(enable_query_cache: false) do
+      yield
+    end
+  end
+end

--- a/src/avram.cr
+++ b/src/avram.cr
@@ -5,6 +5,7 @@ require "pulsar"
 require "db"
 require "pg"
 require "uuid"
+require "splay_tree_map"
 
 require "./avram/object_extensions"
 require "./avram/criteria"

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -116,6 +116,7 @@ abstract class Avram::Database
   # A. In most cases this shouldn't matter because the SaveOperation would return the non-cached version
   #    using postgres RETURNING statement.
   def query_with_cache(query, *args_, args : Array? = nil, queryable : String? = nil)
+    queryable = queryable ? "#{queryable}Cache" : nil
     publish_query_event(query, args_, args, queryable) do
       run do |db|
         key = build_cache_key(query, args.try(&.join('_')), queryable)
@@ -130,8 +131,8 @@ abstract class Avram::Database
     end
   end
 
-  def self.query_with_cache(query, *, args : Array? = nil, queryable : String? = nil, skip_cache : Bool = false)
-    new.query_with_cache(query, args: args, queryable: queryable, skip_cache: skip_cache) do |rs|
+  def self.query_with_cache(query, *args_, args : Array? = nil, queryable : String? = nil)
+    new.query_with_cache(query, *args_, args: args, queryable: queryable) do |rs|
       yield rs
     end
   end

--- a/src/avram/query_cache.cr
+++ b/src/avram/query_cache.cr
@@ -1,0 +1,72 @@
+module Avram
+  # This module is included in the inherited Database.
+  # Each inheritence will have access to its own cache
+  module QueryCache
+    macro included
+      # The benefit of using SplayTreeMap is that it's threadsafe
+      # unlike Hash. This gives us extra performance in a multithreaded
+      # environment.
+      CACHE_VAULT = SplayTreeMap(String, Avram::ResultSet).new
+      CACHE_COUNTER = SplayTreeMap(String, Int64).new(0i64)
+
+      # Used similar to Hash, the keys are generally
+      # going to be some SQL statement combined with
+      # the args passed to that SQL to build a unique string.
+      #
+      # The values are the ResultSet returned from Postgres.
+      # You can use this value to pass in to your model
+      # ```
+      # rs = AppDatabase.cache_vault["SELECT ..."]
+      # User.from_rs(rs)
+      # ```
+      def self.cache_vault : SplayTreeMap
+        CACHE_VAULT
+      end
+
+      # Used similar to Hash, the keys will be "hit",
+      # or "miss". This keeps track of how many times
+      # your Database has hit the cache, or missed.
+      #
+      # Running the same query 5 times would be 1 miss (no cache)
+      # and then 4 hits (the cache)
+      # ```
+      # AppDatabase.cache_counter["miss"] # => 1
+      # AppDatabase.cache_counter["hit"] # => 4
+      # ```
+      def self.cache_counter
+        CACHE_COUNTER
+      end
+
+      # Completely reset both the `cache_vault` and
+      # the `cache_counter`.
+      def self.reset_cache!
+        cache_vault.clear
+        cache_counter.clear
+      end
+
+      # Creates a String based on the keys passed in
+      def build_cache_key(*keys) : String
+        String.build do |io|
+          keys.each do |key|
+            io << key.to_s.strip
+          end
+        end
+      end
+
+      # Checks the cache to see if the key already exists
+      # If it does, it'll increment the cache hit counter,
+      # and return the result.
+      # If the key does not exist, increment the miss counter,
+      # and return the yield from the block
+      def with_cache(key : String) : Avram::ResultSet
+        if CACHE_VAULT.has_key?(key)
+          CACHE_COUNTER["hit"] += 1
+          CACHE_VAULT[key]
+        else
+          CACHE_COUNTER["miss"] += 1
+          CACHE_VAULT[key] = yield
+        end
+      end
+    end
+  end
+end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -252,7 +252,7 @@ module Avram::Queryable(T)
   end
 
   private def exec_query
-    database.query query.statement, args: query.args, queryable: schema_class.name do |rs|
+    database.query_with_cache query.statement, args: query.args, queryable: schema_class.name do |rs|
       schema_class.from_rs(rs)
     end
   end

--- a/src/avram/result_set.cr
+++ b/src/avram/result_set.cr
@@ -1,0 +1,141 @@
+class Avram::ResultSet < ::DB::ResultSet
+  alias AllTypes = (Array(PG::BoolArray) | Array(PG::CharArray) | Array(PG::Float32Array) | Array(PG::Float64Array) | Array(PG::Int16Array) | Array(PG::Int32Array) | Array(PG::Int64Array) | Array(PG::NumericArray) | Array(PG::StringArray) | Array(PG::TimeArray) | Bool | Char | DB::Mappable | Float32 | Float64 | Int16 | Int32 | Int64 | JSON::PullParser | PG::Geo::Box | PG::Geo::Circle | PG::Geo::Line | PG::Geo::LineSegment | PG::Geo::Path | PG::Geo::Point | PG::Geo::Polygon | PG::Interval | PG::Numeric | Slice(UInt8) | String | Time | UInt32 | UUID | Nil)
+  alias ConvertedTypes = (Array(Bool) | Array(Int16) | Array(Int64) | Array(PG::Numeric) | Array(String) | Array(UUID) | Array(PG::BoolArray) | Array(PG::CharArray) | Array(PG::Float32Array) | Array(PG::Float64Array) | Array(PG::Int16Array) | Array(PG::Int32Array) | Array(PG::Int64Array) | Array(PG::NumericArray) | Array(PG::StringArray) | Array(PG::TimeArray) | Bool | Char | DB::Mappable | Float32 | Float64 | Int16 | Int32 | Int64 | JSON::PullParser | PG::Geo::Box | PG::Geo::Circle | PG::Geo::Line | PG::Geo::LineSegment | PG::Geo::Path | PG::Geo::Point | PG::Geo::Polygon | PG::Interval | PG::Numeric | Slice(UInt8) | String | Time | UInt32 | UUID | Nil)
+  # From RS
+  @column_count : Int32
+  @column_names : Array(String)
+
+  # Internal Pointers
+  @current_row_index : Int32 = -1
+  @current_column_index : Int32 = -1
+  @table : Array(Array(ConvertedTypes))
+
+  def initialize(@statement : DB::Statement, @rs : DB::ResultSet)
+    # From RS
+    @column_count = rs.column_count
+    @column_names = rs.column_names
+
+    # Internal Pointers
+    @table = [] of Array(ConvertedTypes)
+    @rs.each do
+      # starting to process a new row
+      row = Array(ConvertedTypes).new
+      @column_count.times do
+        readed_value = @rs.read
+        row << pre_process(readed_value)
+      end
+      @table << row
+    end
+  end
+
+  def pre_process(value : AllTypes)
+    value
+  end
+
+  def pre_process(value : Array(UUID))
+    value.map { |v| UUID.new(v) }
+  end
+
+  def pre_process(value : Array(PG::StringArray))
+    value.map(&.to_s)
+  end
+
+  def pre_process(value : Array(PG::BoolArray))
+    value.map { |x| !!x }
+  end
+
+  protected def do_close
+    statement.release_connection
+  end
+
+  # TODO add_next_result_set : Bool
+
+  # Iterates over all the rows
+  def each
+    while move_next
+      yield
+    end
+  end
+
+  # Iterates over all the columns
+  def each_column
+    column_count.times do |x|
+      yield column_name(x)
+    end
+  end
+
+  # Move the next row in the result.
+  # Return `false` if no more rows are available.
+  # See `#each`
+  def move_next : Bool
+    @current_row_index += 1
+    @current_column_index = -1
+    !!@table[@current_row_index]?
+  end
+
+  # TODO def empty? : Bool, handle internally with move_next (?)
+
+  # Returns the number of columns in the result
+  def column_count : Int32
+    @column_count
+  end
+
+  # Returns the name of the column in `index` 0-based position.
+  def column_name(index : Int32) : String
+    @column_names[index]
+  end
+
+  # Returns the name of the columns.
+  def column_names
+    @column_names
+  end
+
+  # Reads the next column value
+  def read
+    current_row = @table[@current_row_index]?
+
+    if row = current_row
+      @current_column_index += 1
+      row[@current_column_index]?
+    end
+  end
+
+  def read(t : String.class) : String
+    value = read(String | Slice(UInt8))
+
+    case value
+    when Slice(UInt8)
+      String.new(value)
+    else
+      value
+    end
+  end
+
+  def read(t : String?.class) : String?
+    value = read(String | Slice(UInt8) | Nil)
+
+    case value
+    when Slice(UInt8)
+      String.new(value)
+    else
+      value
+    end
+  end
+
+  def read(t : JSON::Any.class) : JSON::Any
+    value = read(JSON::PullParser)
+    JSON::Any.new(value)
+  end
+
+  def read(t : JSON::Any?.class) : JSON::Any?
+    value = read(JSON::PullParser?)
+    JSON::Any.new(value) if value
+  end
+
+  # Returns the column index that corresponds to the next `#read`.
+  #
+  # If the last column of the current row has been read, it must return `#column_count`.
+  def next_column_index : Int32
+    0
+  end
+end


### PR DESCRIPTION
Fixes #63 

This PR adds in query cache. The idea is that if your app runs a query more than once, it shouldn't need to hit the database after the first time. As apps get larger, it becomes a lot more difficult to keep queries all in a single spot. With this, as soon as you make a query, we store that using the SQL as the key, and the ResultSet we get from the database as the value. Then anytime you make that same query, we can instantly return the ResultSet and re-hydrate the object using `SomeModel.from_rs(result_from_cache)`.

Ultimately, if this all gets figured out and sorted, there will be another PR added in to Lucky that would set this up on a per request basis. I don't have any plans for making it pluggable with an alternate cache storage back-end. Maybe in the future, but for now, just in-memory will be a nice first step.


Query cache is not straightforward. I've gone through several different iterations on this, and so far this is the version to come closest. I'll comment on the PR to better explain what I'm doing here. For now, this will be a WIP just to get some more eyes on it.