### PR TITLE
Rename Status enums in operations.

### DIFF
--- a/spec/operations/delete_operation_spec.cr
+++ b/spec/operations/delete_operation_spec.cr
@@ -30,7 +30,7 @@ describe "Avram::DeleteOperation" do
 
       BasicDeleteUser.delete(user) do |operation, deleted_user|
         operation.valid?.should be_true
-        operation.delete_status.should eq BasicDeleteUser::DeleteStatus::Deleted
+        operation.delete_status.should eq BasicDeleteUser::OperationStatus::Deleted
         deleted_user.not_nil!.name.should eq user.name
         UserQuery.new.select_count.should eq 0
       end
@@ -41,7 +41,7 @@ describe "Avram::DeleteOperation" do
 
       FailedToDeleteUser.delete(user) do |operation, deleted_user|
         operation.valid?.should be_false
-        operation.delete_status.should eq FailedToDeleteUser::DeleteStatus::DeleteFailed
+        operation.delete_status.should eq FailedToDeleteUser::OperationStatus::DeleteFailed
         deleted_user.should eq nil
         operation.errors[:nope].should contain "not today"
         UserQuery.new.select_count.should eq 1

--- a/spec/operations/operation_errors_spec.cr
+++ b/spec/operations/operation_errors_spec.cr
@@ -55,7 +55,7 @@ describe Avram::OperationErrors do
       value.should eq nil
       op.valid?.should eq false
       op.errors[:failure].should eq ["This failed quick", "Like, really quick"]
-      op.save_status.should eq SaveUserButNotReally::SaveStatus::SaveFailed
+      op.save_status.should eq SaveUserButNotReally::OperationStatus::SaveFailed
     end
   end
 end

--- a/spec/operations/save_operation_spec.cr
+++ b/spec/operations/save_operation_spec.cr
@@ -329,7 +329,7 @@ describe "Avram::SaveOperation" do
       operation.save
 
       operation.save_failed?.should be_true
-      operation.save_status.should eq(Avram::SaveOperation::SaveStatus::SaveFailed)
+      operation.save_status.should eq(SaveUser::OperationStatus::SaveFailed)
       operation.valid?.should be_false
     end
 
@@ -338,7 +338,7 @@ describe "Avram::SaveOperation" do
       operation = SaveUser.new(params)
 
       operation.save_failed?.should be_false
-      operation.save_status.should eq(Avram::SaveOperation::SaveStatus::Unperformed)
+      operation.save_status.should eq(SaveUser::OperationStatus::Unperformed)
       operation.saved?.should be_false
       operation.valid?.should be_false
     end

--- a/src/avram/delete_operation.cr
+++ b/src/avram/delete_operation.cr
@@ -15,7 +15,7 @@ abstract class Avram::DeleteOperation(T)
   include Avram::Callbacks
   include Avram::InheritColumnAttributes
 
-  enum DeleteStatus
+  enum OperationStatus
     Deleted
     DeleteFailed
     Unperformed
@@ -27,7 +27,7 @@ abstract class Avram::DeleteOperation(T)
     @record : T
     @params : Avram::Paramable
     getter :record, :params
-    property delete_status : DeleteStatus = DeleteStatus::Unperformed
+    property delete_status : OperationStatus = OperationStatus::Unperformed
   end
 
   def self.param_key
@@ -84,17 +84,17 @@ abstract class Avram::DeleteOperation(T)
   end
 
   def mark_as_deleted
-    self.delete_status = DeleteStatus::Deleted
+    self.delete_status = OperationStatus::Deleted
     true
   end
 
   # Returns true if the operation has run and saved the record successfully
   def deleted?
-    delete_status == DeleteStatus::Deleted
+    delete_status == OperationStatus::Deleted
   end
 
   def mark_as_failed
-    self.delete_status = DeleteStatus::DeleteFailed
+    self.delete_status = OperationStatus::DeleteFailed
     false
   end
 

--- a/src/avram/mark_as_failed.cr
+++ b/src/avram/mark_as_failed.cr
@@ -1,5 +1,5 @@
 module Avram::MarkAsFailed
   def mark_as_failed
-    self.save_status = Avram::SaveOperation::SaveStatus::SaveFailed
+    self.save_status = Avram::SaveOperation::OperationStatus::SaveFailed
   end
 end

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -23,7 +23,7 @@ abstract class Avram::SaveOperation(T)
   include Avram::InheritColumnAttributes
   include Avram::Upsert
 
-  enum SaveStatus
+  enum OperationStatus
     Saved
     SaveFailed
     Unperformed
@@ -39,7 +39,7 @@ abstract class Avram::SaveOperation(T)
   # :nodoc:
   setter :record
   getter :params, :record
-  property save_status : SaveStatus = SaveStatus::Unperformed
+  property save_status : OperationStatus = OperationStatus::Unperformed
 
   abstract def attributes
 
@@ -238,12 +238,12 @@ abstract class Avram::SaveOperation(T)
 
   # Returns true if the operation has run and saved the record successfully
   def saved?
-    save_status == SaveStatus::Saved
+    save_status == OperationStatus::Saved
   end
 
   # Return true if the operation has run and the record failed to save
   def save_failed?
-    save_status == SaveStatus::SaveFailed
+    save_status == OperationStatus::SaveFailed
   end
 
   macro permit_columns(*attribute_names)
@@ -323,7 +323,7 @@ abstract class Avram::SaveOperation(T)
       end
 
       if transaction_committed
-        self.save_status = SaveStatus::Saved
+        self.save_status = OperationStatus::Saved
         after_commit(record.not_nil!)
         Avram::Events::SaveSuccessEvent.publish(
           operation_class: self.class.name,


### PR DESCRIPTION
Fixes #758

This helps to avoid name collisions if you happen to create a model named `Status`