### PR TITLE
Add random_order method to query objects

### DIFF
--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -14,6 +14,10 @@ class Avram::Criteria(T, V)
     rows.order_by(Avram::OrderBy.new(column, :asc, null_sorting))
   end
 
+  def random_order : T
+    rows.order_by(Avram::OrderByRandom.new)
+  end
+
   def eq(value) : T
     check_just_nil!(typeof(value))
     check_nilable!(value)

--- a/src/avram/order_by_clause.cr
+++ b/src/avram/order_by_clause.cr
@@ -1,7 +1,7 @@
 module Avram
   abstract class OrderByClause
+    abstract def column : String | Symbol
     abstract def prepare : String
     abstract def reversed : self
-    abstract def uid : String
   end
 end

--- a/src/avram/order_by_clause.cr
+++ b/src/avram/order_by_clause.cr
@@ -1,0 +1,7 @@
+module Avram
+  abstract class OrderByClause
+    abstract def prepare : String
+    abstract def reversed : self
+    abstract def uid : String
+  end
+end

--- a/src/avram/order_by_clause/order_by.cr
+++ b/src/avram/order_by_clause/order_by.cr
@@ -17,7 +17,7 @@ module Avram
 
     def_clone
 
-    getter column
+    getter column : String | Symbol
     getter direction
     getter nulls
 
@@ -38,10 +38,6 @@ module Avram
     def reversed : self
       @direction = @direction.asc? ? Direction::DESC : Direction::ASC
       self
-    end
-
-    def uid : String
-      "#{column}_column"
     end
   end
 end

--- a/src/avram/order_by_clause/order_by.cr
+++ b/src/avram/order_by_clause/order_by.cr
@@ -1,5 +1,5 @@
 module Avram
-  class OrderBy
+  class OrderBy < OrderByClause
     enum NullSorting
       DEFAULT
       NULLS_FIRST
@@ -21,19 +21,27 @@ module Avram
     getter direction
     getter nulls
 
-    def initialize(@column : String | Symbol, @direction : Direction, @nulls : NullSorting = :default)
+    def initialize(
+      @column : String | Symbol,
+      @direction : Direction,
+      @nulls : NullSorting = :default
+    )
     end
 
-    def reversed
-      @direction = @direction.asc? ? Direction::DESC : Direction::ASC
-      self
-    end
-
-    def prepare
+    def prepare : String
       String.build do |str|
         str << "#{column} #{direction}"
         str << " #{nulls}" unless nulls.default?
       end
+    end
+
+    def reversed : self
+      @direction = @direction.asc? ? Direction::DESC : Direction::ASC
+      self
+    end
+
+    def uid : String
+      "#{column}_column"
     end
   end
 end

--- a/src/avram/order_by_clause/order_by_random.cr
+++ b/src/avram/order_by_clause/order_by_random.cr
@@ -1,0 +1,17 @@
+module Avram
+  class OrderByRandom < OrderByClause
+    def_clone
+
+    def prepare : String
+      "RANDOM ()"
+    end
+
+    def reversed : self
+      self
+    end
+
+    def uid : String
+      "random"
+    end
+  end
+end

--- a/src/avram/order_by_clause/order_by_random.cr
+++ b/src/avram/order_by_clause/order_by_random.cr
@@ -2,16 +2,14 @@ module Avram
   class OrderByRandom < OrderByClause
     def_clone
 
+    getter column : String | Symbol = "*"
+
     def prepare : String
       "RANDOM ()"
     end
 
     def reversed : self
       self
-    end
-
-    def uid : String
-      "random"
     end
   end
 end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -183,7 +183,7 @@ class Avram::QueryBuilder
   end
 
   def orders
-    @orders.uniq!(&.uid)
+    @orders.uniq!(&.column)
   end
 
   def group_by(column : ColumnName)

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -168,8 +168,12 @@ module Avram::Queryable(T)
     raise "#{e.message}. Accepted values are: :asc, :desc"
   end
 
-  def order_by(order : Avram::OrderBy) : self
+  def order_by(order : Avram::OrderByClause) : self
     clone.tap &.query.order_by(order)
+  end
+
+  def random_order : self
+    clone.tap &.query.random_order
   end
 
   def group(&block) : self


### PR DESCRIPTION
Here's a proposal for the `random_order` implementation (https://github.com/luckyframework/avram/issues/755).

Initially, I tried to add a `:random` option to `Avram::OrderBy` but a few things were bad about that approach:
- too many if statements to switch between _order by random_ and _order by column_ clauses
- unnecessary attributes for the random option
- unused `column` argument in the initializer, requiring the `column` attribute to be nilable
- clunky internal API (e.g. `Avram::OrderBy.new(nil, :random)`)

That's why I decided to create an abstract class called `Avram::OrderByClause` and split out the two different order methods into two subclasses called `Avram::OrderBy` and `Avram::OrderByRandom`. The `Avram::OrderBy` class could have been renamed to `Avram::OrderByColumn` for consistency, but by keeping the old name, we're not breaking anything.

Having multiple _order by_ classes also will make it easier to add more order methods later on. Like ordering by an array for example, which is something I've needed in the past. For example, we could also add an `Avram::OrderByArray` class, generating the following clause:

```sql
ORDER BY array_position('{5,1,4,3,2}'::int[], item.id::int)
```

Which could look like:

```crystal
Avram::OrderByArray.new(:id, [5,1,4,3,2], :nulls_last)
```
