### PR TITLE
Fixing migration sorting

### DIFF
--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -9,8 +9,8 @@ abstract class Avram::Migrator::Migration::V1
   macro inherited
     Avram::Migrator::Runner.migrations << self
 
-    def version
-      get_version_from_filename
+    def version : Int64
+      get_version_from_filename.to_i64
     end
 
     macro get_version_from_filename
@@ -19,7 +19,7 @@ abstract class Avram::Migrator::Migration::V1
   end
 
   abstract def migrate
-  abstract def version
+  abstract def version : Int64
 
   getter prepared_statements = [] of String
 

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -8,7 +8,7 @@ class Avram::Migrator::Runner
 
   extend LuckyTask::TextHelpers
 
-  @@migrations = [] of Avram::Migrator::Migration::V1.class
+  class_getter migrations = [] of Avram::Migrator::Migration::V1.class
 
   def initialize(@quiet : Bool = false)
   end
@@ -31,10 +31,6 @@ class Avram::Migrator::Runner
 
   def self.db_password
     credentials.password
-  end
-
-  def self.migrations
-    @@migrations
   end
 
   def self.credentials
@@ -166,7 +162,7 @@ class Avram::Migrator::Runner
   def rollback_to(last_version : Int64)
     self.class.setup_migration_tracking_tables
     subset = migrated_migrations.select do |mm|
-      mm.new.version.to_i64 > last_version
+      mm.new.version > last_version
     end
     subset.reverse.each &.new.down
     puts "Done rolling back to #{last_version}".colorize(:green)
@@ -205,7 +201,7 @@ class Avram::Migrator::Runner
   end
 
   private def sorted_migrations
-    @@migrations.sort { |a, b| a.new.version <=> b.new.version }
+    self.class.migrations.sort_by(&.new.version)
   end
 
   private def prepare_for_migration


### PR DESCRIPTION
Fixes #768

I'm trying to fix this CI failure in LuckyCLI https://github.com/luckyframework/lucky_cli/runs/4372596405?check_suite_focus=true#step:9:511 but I'm unable to recreate the same issue locally. Hopefully using `sort_by`, and forcing the `Int64` type should allow the compiler to better know what's going on 🤷‍♂️ 