### PR TITLE
Remove redundant limit from #find

### DIFF
--- a/src/avram/primary_key_queryable.cr
+++ b/src/avram/primary_key_queryable.cr
@@ -7,7 +7,7 @@ module Avram::PrimaryKeyQueryable(T)
     end
 
     def find(id)
-      id(id).limit(1).first? || raise Avram::RecordNotFoundError.new(model: table_name, id: id.to_s)
+      id(id).first? || raise Avram::RecordNotFoundError.new(model: table_name, id: id.to_s)
     end
 
     {% primary_key_name = T.constant("PRIMARY_KEY_NAME") %}


### PR DESCRIPTION
`#first?` already does the limit so this is duplicated

https://github.com/luckyframework/avram/blob/e377697bb562963a1ab2d319c206f2c296e208d5/src/avram/queryable.cr#L196-L201