### PR TITLE
Updates ci.yml to test crystal 1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
+          - 1.0
+          - 1.1
+          - 1.2
+          - 1.3
         experimental:
           - false
         include:
@@ -43,9 +44,10 @@ jobs:
           - 12
           - 13
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
+          - 1.0
+          - 1.1
+          - 1.2
+          - 1.3
         experimental:
           - false
         include:


### PR DESCRIPTION
Also provides implicit "latest patch" crystal versions so that any patches to releases are picked up. Given the change in luckyframework/lucky, I'm not sure if the inbetweenst versions should be kept or just 1.0 and latest.