### PR TITLE
Release connections correctly

### DIFF
--- a/spec/avram/transaction_spec.cr
+++ b/spec/avram/transaction_spec.cr
@@ -66,6 +66,11 @@ describe "Avram::SaveOperation" do
         operation.saved?.should be_true
       end
     end
+
+    it "releases connection after operation finishes and no transactions open", tags: Avram::SpecHelper::TRUNCATE do
+      PostTransactionSaveOperation.create!(title: "New Title", rollback_after_save: false)
+      TestDatabase.connections.should be_empty
+    end
   end
 
   describe "raising an error" do

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -221,8 +221,7 @@ abstract class Avram::Database
   rescue e : Avram::Rollback
     false
   ensure
-    # TODO: not sure of this
-    if current_connection._avram_in_transaction?
+    if !current_connection._avram_in_transaction?
       current_connection.release
       connections.delete(object_id)
     end


### PR DESCRIPTION
Fixes #799

I think the original check was the opposite (if connection has no open transactions) and I forgot to negate when I switched to this method. The specs didn't catch it because almost all specs run within a transaction so they just so happened to always fall into this block 🤦.