### PR TITLE
Attempt parsing raw string before calling to_json

### DIFF
--- a/spec/avram/json_column_spec.cr
+++ b/spec/avram/json_column_spec.cr
@@ -70,6 +70,25 @@ describe "JSON Columns" do
     })
   end
 
+  it "should convert pre-stringified json objects" do
+    form = SaveBlob.new
+    form.set_doc_from_param({"foo" => {"bar" => "baz"}}.to_json)
+    form.set_metadata_from_param(BlobMetadata.from_json("{}"))
+    form.doc.value.should eq JSON::Any.new({
+      "foo" => JSON::Any.new({
+        "bar" => JSON::Any.new("baz"),
+      }),
+    })
+    form.save!
+
+    blob = BlobQuery.new.last
+    blob.doc.should eq JSON::Any.new({
+      "foo" => JSON::Any.new({
+        "bar" => JSON::Any.new("baz"),
+      }),
+    })
+  end
+
   describe "serialized" do
     it "saves the serialized value" do
       SaveBlob.create(metadata: BlobMetadata.from_json("{}")) do |operation, blob|

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -54,6 +54,15 @@ struct JSON::Any
       SuccessfulCast(JSON::Any).new value
     end
 
+    def parse(value : String)
+      value = begin
+        JSON.parse(value)
+      rescue JSON::ParseException
+        JSON.parse(value.to_json)
+      end
+      SuccessfulCast(JSON::Any).new value
+    end
+
     def parse(value)
       SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
     end


### PR DESCRIPTION
Connected to https://github.com/luckyframework/lucky/pull/1661

When we call `params.nested(:user)` we get back a `Hash(String, String)`. The String value is a stringified version of the json object which the current implementation would not parse correctly. This new overload attempts to parse the raw string value before calling `.to_json` on it.

This does change behavior:

```crystal
JSON::Any.adapter.parse("true") #=> "true" : JSON::Any (before)
JSON::Any.adapter.parse("true") #=> true : JSON::Any (after)

JSON::Any.adapter.parse("1") #=> "1" : JSON::Any (before)
JSON::Any.adapter.parse("1") #=> 1 : JSON::Any (after)

JSON::Any.adapter.parse("{\"foo\":\"bar\"}") #=> "{\"foo\":\"bar\"}" : JSON::Any (before)
JSON::Any.adapter.parse("{\"foo\":\"bar\"}") #=> {"foo" => "bar"} : JSON::Any
```

I believe these tradeoffs are acceptable because most `JSON::Any` columns aren't doing scalar values anyways and this new way is more true to intention especially being constrained by how `Lucky::Params` works.