### PR TITLE
Update to crystal-pg v0.26.x

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ dependencies:
     version: ~> 0.1.0
   pg:
     github: will/crystal-pg
-    version: ~> 0.24.0
+    version: ~> 0.26.0
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4.7


### PR DESCRIPTION
https://github.com/will/crystal-pg/compare/v0.24.0...v0.26.0
https://github.com/crystal-lang/crystal-db/compare/v0.10.1...v0.11.0

This adds the upstream changes from crystal-pg v0.11

This also allows us to remove the monkey patches required for null array
elements in avram, added/utilized by the bulk upsert functionality #789
