### PR TITLE
Raise error if required association not loaded in preload

### DIFF
--- a/spec/avram/preloading/preloading_belongs_to_spec.cr
+++ b/spec/avram/preloading/preloading_belongs_to_spec.cr
@@ -97,7 +97,7 @@ describe "Preloading belongs_to associations" do
 
   it "raises error if association not nilable but no record found" do
     post = PostFactory.create &.title("Title A")
-    comment = CommentFactory.create &.post_id(post.id)
+    CommentFactory.create &.post_id(post.id)
 
     expect_raises(Avram::MissingRequiredAssociationError) do
       Comment::BaseQuery.new.preload_post(Post::BaseQuery.new.title("Title B")).results

--- a/spec/avram/preloading/preloading_belongs_to_spec.cr
+++ b/spec/avram/preloading/preloading_belongs_to_spec.cr
@@ -95,6 +95,15 @@ describe "Preloading belongs_to associations" do
     Post::BaseQuery.times_called.should eq 0
   end
 
+  it "raises error if association not nilable but no record found" do
+    post = PostFactory.create &.title("Title A")
+    comment = CommentFactory.create &.post_id(post.id)
+
+    expect_raises(Avram::MissingRequiredAssociationError) do
+      Comment::BaseQuery.new.preload_post(Post::BaseQuery.new.title("Title B")).results
+    end
+  end
+
   context "with existing record" do
     it "works" do
       with_lazy_load(enabled: false) do

--- a/spec/avram/preloading/preloading_has_one_spec.cr
+++ b/spec/avram/preloading/preloading_has_one_spec.cr
@@ -57,11 +57,12 @@ describe "Preloading has_one associations" do
   end
 
   it "does not fail when getting results multiple times" do
-    AdminFactory.create
+    admin = AdminFactory.create
+    SignInCredentialFactory.create &.user_id(admin.id)
 
-    admin = Admin::BaseQuery.new.preload_sign_in_credential
+    admin_query = Admin::BaseQuery.new.preload_sign_in_credential
 
-    2.times { admin.results }
+    2.times { admin_query.results }
   end
 
   it "lazy loads if nothing is preloaded" do
@@ -77,6 +78,12 @@ describe "Preloading has_one associations" do
     admin.results
 
     SignInCredential::BaseQuery.times_called.should eq 0
+  end
+
+  it "raises error if association not nilable but no record found" do
+    admin = AdminFactory.create
+
+    expect_raises(Avram::MissingRequiredAssociationError) { Admin::BaseQuery.new.preload_sign_in_credential.results }
   end
 
   context "with existing record" do

--- a/spec/avram/preloading/preloading_has_one_spec.cr
+++ b/spec/avram/preloading/preloading_has_one_spec.cr
@@ -81,7 +81,7 @@ describe "Preloading has_one associations" do
   end
 
   it "raises error if association not nilable but no record found" do
-    admin = AdminFactory.create
+    AdminFactory.create
 
     expect_raises(Avram::MissingRequiredAssociationError) { Admin::BaseQuery.new.preload_sign_in_credential.results }
   end

--- a/src/avram/associations.cr
+++ b/src/avram/associations.cr
@@ -25,9 +25,12 @@ module Avram::Associations
   end
 
   # :nodoc:
-  macro __define_preloaded_setter(assoc_name, model)
+  macro __define_preloaded_setter(assoc_name, model, nilable)
     # :nodoc:
     def __set_preloaded_{{ assoc_name }}(record : {{ model }}?)
+      {% if !nilable %}
+      raise Avram::MissingRequiredAssociationError.new(self.class, {{ model }}) if record.nil?
+      {% end %}
       @_{{ assoc_name }}_preloaded = true
       @_preloaded_{{ assoc_name }} = record
     end

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -24,7 +24,7 @@ module Avram::Associations::BelongsTo
 
     define_belongs_to_private_assoc_getter({{ assoc_name }}, {{ model }}, {{ foreign_key.id }}, {{ nilable }})
     Avram::Associations.__define_public_preloaded_getters({{ assoc_name }}, {{ model }}, {{ nilable }})
-    Avram::Associations.__define_preloaded_setter({{ assoc_name }}, {{ model }})
+    Avram::Associations.__define_preloaded_setter({{ assoc_name }}, {{ model }}, {{ nilable }})
     define_belongs_to_base_query({{ assoc_name }}, {{ model }}, {{ foreign_key.id }})
   end
 

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -23,7 +23,7 @@ module Avram::Associations::HasOne
       relationship_type: :has_one
 
     Avram::Associations.__define_public_preloaded_getters({{ assoc_name }}, {{ model }}, {{ nilable }})
-    Avram::Associations.__define_preloaded_setter({{ assoc_name }}, {{ model }})
+    Avram::Associations.__define_preloaded_setter({{ assoc_name }}, {{ model }}, {{ nilable }})
     define_has_one_private_assoc_getter({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ nilable }})
     define_has_one_base_query({{ assoc_name }}, {{ model }}, {{ foreign_key }})
   end

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -30,6 +30,12 @@ module Avram
     end
   end
 
+  class MissingRequiredAssociationError < AvramError
+    def initialize(model : Avram::Model.class, association : Avram::Model.class)
+      super "Expected #{model} to have an association with #{association} but one was not found."
+    end
+  end
+
   # Raised when a validation is expecting an impossible constraint
   class ImpossibleValidation < AvramError
     def initialize(attribute : Symbol, message = "an impossible validation")


### PR DESCRIPTION
Related #672 

If a model defines a required belongs to association and the record isn't retrieved in a preload, this raises an appropriate error. Also added for required has one associations.

Applying this to the related issue, in the scenario where you have soft deletes, the solution now becomes making what was a required association optional since it might not always be loaded. This doesn't change whether or not it is loaded but will guarantee an error unless you change the association. Before, the error only occurred if you tried to access the association on the particular record.