### PR TITLE
Add a default value to the default timestamp columns.

### DIFF
--- a/spec/avram/migrator/create_table_statement_spec.cr
+++ b/spec/avram/migrator/create_table_statement_spec.cr
@@ -29,8 +29,8 @@ describe Avram::Migrator::CreateTableStatement do
     built.statements.first.should eq <<-SQL
     CREATE TABLE users (
       id serial PRIMARY KEY,
-      created_at timestamptz NOT NULL,
-      updated_at timestamptz NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT NOW(),
+      updated_at timestamptz NOT NULL DEFAULT NOW(),
       name text NOT NULL,
       age int NOT NULL,
       completed boolean NOT NULL,

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -82,8 +82,8 @@ class Avram::Migrator::CreateTableStatement
   end
 
   macro add_timestamps
-    add created_at : Time
-    add updated_at : Time
+    add created_at : Time, default: :now
+    add updated_at : Time, default: :now
   end
 
   macro add(type_declaration, default = nil, index = false, unique = false, using = :btree, **type_options)


### PR DESCRIPTION
Fixes #816

When generating a new table and using the `add_timestamps`, this will now generate the `created_at` and `updated_at` columns defaulting to `NOW()`. The values will still come from within Crystal since the SaveOperation will set them, however, this allows you to hop into psql real quick and create a new record without having to worry about setting these.

Updating a record will still require you to update `updated_at` manually since that would require setting up a trigger. 