### PR TITLE
Adding new Slugify.generate method to generate a slug value

### DIFF
--- a/spec/avram/slugify_spec.cr
+++ b/spec/avram/slugify_spec.cr
@@ -34,14 +34,6 @@ describe Avram::Slugify do
 
         op.slug.value.should eq("software-developer")
       end
-
-      it "it sets slug from a single string" do
-        op = build_op
-
-        slugify(op.slug, "Software Developer")
-
-        op.slug.value.should eq("software-developer")
-      end
     end
 
     describe "with an array of slug candidates" do
@@ -121,6 +113,40 @@ describe Avram::Slugify do
       op = build_op(title: "The Boss")
       slugify(op.slug, op.title, ArticleQuery.new.title("A"))
       op.slug.value.to_s.should start_with("the-boss-") # Has UUID appended
+    end
+  end
+
+  describe ".generate" do
+    it "skips blank slug candidates" do
+      slug = Avram::Slugify.generate(["", "Software Developer"])
+
+      slug.should eq("software-developer")
+    end
+
+    describe "with a single slug candidate" do
+      it "sets slug from a single attribute" do
+        op = build_op(title: "Software Developer")
+        slug = Avram::Slugify.generate(op.title)
+
+        slug.should eq("software-developer")
+      end
+
+      it "sets slug from a single string" do
+        slug = Avram::Slugify.generate("Software Developer")
+
+        slug.should eq("software-developer")
+      end
+    end
+
+    describe "with an array of slug candidates" do
+      it "sets when using multiple attributes" do
+        op = build_op(title: "How Do Magnets Work?", sub_heading: "And Why?")
+
+        slugify(op.slug, [[op.title, op.sub_heading]])
+        slug = Avram::Slugify.generate([[op.title, op.sub_heading]])
+
+        slug.should eq("how-do-magnets-work-and-why")
+      end
     end
   end
 end

--- a/spec/avram/slugify_spec.cr
+++ b/spec/avram/slugify_spec.cr
@@ -118,7 +118,8 @@ describe Avram::Slugify do
 
   describe ".generate" do
     it "skips blank slug candidates" do
-      slug = Avram::Slugify.generate(["", "Software Developer"])
+      op = build_op(title: "Software Developer")
+      slug = Avram::Slugify.generate(op.slug, ["", "Software Developer"], ArticleQuery.new)
 
       slug.should eq("software-developer")
     end
@@ -126,13 +127,14 @@ describe Avram::Slugify do
     describe "with a single slug candidate" do
       it "sets slug from a single attribute" do
         op = build_op(title: "Software Developer")
-        slug = Avram::Slugify.generate(op.title)
+        slug = Avram::Slugify.generate(op.slug, op.title, ArticleQuery.new)
 
         slug.should eq("software-developer")
       end
 
       it "sets slug from a single string" do
-        slug = Avram::Slugify.generate("Software Developer")
+        op = build_op(title: "Software Developer")
+        slug = Avram::Slugify.generate(op.slug, "Software Developer", ArticleQuery.new)
 
         slug.should eq("software-developer")
       end
@@ -142,8 +144,7 @@ describe Avram::Slugify do
       it "sets when using multiple attributes" do
         op = build_op(title: "How Do Magnets Work?", sub_heading: "And Why?")
 
-        slugify(op.slug, [[op.title, op.sub_heading]])
-        slug = Avram::Slugify.generate([[op.title, op.sub_heading]])
+        slug = Avram::Slugify.generate(op.slug, [[op.title, op.sub_heading]], ArticleQuery.new)
 
         slug.should eq("how-do-magnets-work-and-why")
       end

--- a/src/avram/slugify.cr
+++ b/src/avram/slugify.cr
@@ -72,12 +72,10 @@ module Avram::Slugify
       query.where(slug.name, candidate).none?
     }
 
-    if result.nil?
-      if candidate = slug_candidates.first?
-        "#{candidate}-#{UUID.random}"
-      end
-    else
+    if result
       result
+    elsif candidate = slug_candidates.first?
+      "#{candidate}-#{UUID.random}"
     end
   end
 

--- a/src/avram/slugify.cr
+++ b/src/avram/slugify.cr
@@ -28,14 +28,16 @@
 # been used, and fall back to appending a random UUID to the end. If the `slug`
 # value has already been set, then no new slug will be generated. If you just need
 # the value to set on your own, you can use the `generate` method as an escape hatch.
-# It will be up to you to ensure it's unique.
+# This method returns the String value used in the `set` method.
 #
 # ```
 # class SaveArticle < Article::SaveOperation
 #   before_save do
 #     if title.changed?
-#       slug.value = Avram::Slugify.generate(using: title)
-#       validate_uniqueness_of slug, query: ArticleQuery.new.slug
+#       slug_value = Avram::Slugify.generate(slug,
+#         using: title,
+#         query: ArticleQuery.new)
+#       slug.value = slug_value
 #     end
 #   end
 # end


### PR DESCRIPTION
Fixes #813

This method will generate a String value that can be used for a slug, but without setting any attribute value for you. This would be more used for an escape hatch than anything. Since it's not passing in the slug column, there's no way to query to know if it's been taken already. This means we can't do the query lookup to ensure the value is unique.

```crystal
before_save do
  if title.changed?
    slug.value = Avram::Slugify.generate(using: title)
  end

  validate_uniqueness slug, query: ArticleQuery.new.slug
end
```

