### PR TITLE
Adding an overload for this validation with a Range

### DIFF
--- a/spec/avram/validations_spec.cr
+++ b/spec/avram/validations_spec.cr
@@ -260,6 +260,11 @@ describe Avram::Validations do
       result.should eq(true)
       allowed_name.valid?.should be_true
 
+      allowed_number = attribute(4)
+      result = Avram::Validations.validate_inclusion_of(allowed_number, in: 0..5)
+      result.should eq(true)
+      allowed_number.valid?.should eq(true)
+
       forbidden_name = attribute("123123123")
       result = Avram::Validations.validate_inclusion_of(forbidden_name, in: ["Jamie"])
       result.should eq(false)

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -145,6 +145,43 @@ module Avram::Validations
     no_errors
   end
 
+  def validate_inclusion_of(
+    attribute : Avram::Attribute(T),
+    in allowed_values : Range(T, T),
+    message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_inclusion_of)
+  ) : Bool forall T
+    no_errors = true
+    if value = attribute.value
+      if !allowed_values.includes?(value)
+        attribute.add_error(message)
+        no_errors = false
+      end
+    else
+      attribute.add_error(message)
+      no_errors = false
+    end
+
+    no_errors
+  end
+
+  def validate_inclusion_of(
+    attribute : Avram::Attribute(T),
+    in allowed_values : Range(T, T),
+    allow_nil : Bool,
+    message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_inclusion_of)
+  ) : Bool forall T
+    {%
+      raise <<-ERROR
+      Ranges do not support `nil`.
+      If you need to allow nil values, call `validate_inclusion_of` with an Array instead.
+
+      Try this...
+
+        ▸ validate_inclusion_of attr, in: [1, 2, 3], allow_nil: true
+      ERROR
+    %}
+  end
+
   # Validates that the attribute value is in a list of allowed values
   #
   # ```

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -148,7 +148,8 @@ module Avram::Validations
   def validate_inclusion_of(
     attribute : Avram::Attribute(T),
     in allowed_values : Range(T, T),
-    message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_inclusion_of)
+    message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_inclusion_of),
+    allow_nil : Bool = false
   ) : Bool forall T
     no_errors = true
     if value = attribute.value
@@ -157,29 +158,13 @@ module Avram::Validations
         no_errors = false
       end
     else
-      attribute.add_error(message)
-      no_errors = false
+      if !allow_nil
+        attribute.add_error(message)
+        no_errors = false
+      end
     end
 
     no_errors
-  end
-
-  def validate_inclusion_of(
-    attribute : Avram::Attribute(T),
-    in allowed_values : Range(T, T),
-    allow_nil : Bool,
-    message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_inclusion_of)
-  ) : Bool forall T
-    {%
-      raise <<-ERROR
-      Ranges do not support `nil`.
-      If you need to allow nil values, call `validate_inclusion_of` with an Array instead.
-
-      Try this...
-
-        ▸ validate_inclusion_of attr, in: [1, 2, 3], allow_nil: true
-      ERROR
-    %}
   end
 
   # Validates that the attribute value is in a list of allowed values

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -145,28 +145,6 @@ module Avram::Validations
     no_errors
   end
 
-  def validate_inclusion_of(
-    attribute : Avram::Attribute(T),
-    in allowed_values : Range(T, T),
-    message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_inclusion_of),
-    allow_nil : Bool = false
-  ) : Bool forall T
-    no_errors = true
-    if value = attribute.value
-      if !allowed_values.includes?(value)
-        attribute.add_error(message)
-        no_errors = false
-      end
-    else
-      if !allow_nil
-        attribute.add_error(message)
-        no_errors = false
-      end
-    end
-
-    no_errors
-  end
-
   # Validates that the attribute value is in a list of allowed values
   #
   # ```
@@ -181,8 +159,13 @@ module Avram::Validations
     allow_nil : Bool = false
   ) : Bool forall T
     no_errors = true
-    if !allowed_values.includes?(attribute.value)
-      if !(allow_nil && attribute.value.nil?)
+    if value = attribute.value
+      if !allowed_values.includes?(value)
+        attribute.add_error(message)
+        no_errors = false
+      end
+    else
+      if !allow_nil
         attribute.add_error(message)
         no_errors = false
       end


### PR DESCRIPTION
Fixes #563

Since you can't allow nil, I've added a method overload that raises a compile-time error letting you know that you can't allow nil with ranges. 