### PR TITLE
Errors should have the variables as properties (#819)

### DIFF
--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -14,40 +14,53 @@ module Avram
   # Raised when trying to access a record that was not preloaded and lazy load
   # is disabled.
   class LazyLoadError < AvramError
-    def initialize(model : String, association : String)
+    getter model
+    getter association
+
+    def initialize(@model : String, @association : String)
       super "#{association} for #{model} must be preloaded with 'preload_#{association}'"
     end
   end
 
   # Raised when Avram cannot find a record by given id
   class RecordNotFoundError < AvramError
-    def initialize(model : TableName, id : String)
+    getter model
+    getter id = nil
+    getter query = nil
+
+    def initialize(@model : TableName, @id : String)
       super "Could not find #{model} with id of #{id}"
     end
 
-    def initialize(model : TableName, query : Symbol)
+    def initialize(@model : TableName, @query : Symbol)
       super "Could not find #{query} record in #{model}"
     end
   end
 
   class MissingRequiredAssociationError < AvramError
-    def initialize(model : Avram::Model.class, association : Avram::Model.class)
+    getter model
+    getter association
+
+    def initialize(@model : Avram::Model.class, @association : Avram::Model.class)
       super "Expected #{model} to have an association with #{association} but one was not found."
     end
   end
 
   # Raised when a validation is expecting an impossible constraint
   class ImpossibleValidation < AvramError
-    def initialize(attribute : Symbol, message = "an impossible validation")
+    getter attribute
+
+    def initialize(@attribute : Symbol, message = "an impossible validation")
       super "Validation for #{attribute} can never satisfy #{message}"
     end
   end
 
   # Raised when using the create!, update!, or delete! methods on an operation when it does not have the proper attributes
-  class InvalidOperationError < AvramError
+  class InvalidOperationError(T) < AvramError
+    getter operation
     getter errors : Hash(Symbol, Array(String))
 
-    def initialize(operation)
+    def initialize(@operation : T)
       message = String.build do |string|
         string << "Could not perform #{operation.class.name}."
         string << "\n"
@@ -71,7 +84,10 @@ module Avram
   class ConnectionError < AvramError
     DEFAULT_PG_PORT = 5432
 
-    def initialize(connection_details : URI, database_class : Avram::Database.class)
+    getter connection_details
+    getter database_class
+
+    def initialize(@connection_details : URI, @database_class : Avram::Database.class)
       error = String.build do |message|
         message << "#{database_class.name}: Failed to connect to database '#{connection_details.path.try(&.[1..-1])}' with username '#{connection_details.user}'.\n"
         message << "Try this..."
@@ -144,7 +160,10 @@ module Avram
   end
 
   class FailedMigration < AvramError
-    def initialize(@migration : String, statements : Array(String), cause : Exception)
+    getter migration
+    getter statements
+
+    def initialize(@migration : String, @statements : Array(String), cause : Exception)
       super(message(statements), cause)
     end
 


### PR DESCRIPTION
* Added constructor arguments as properties
* Made `InvalidOperationError` generic since there seems no common parent class for operations
    * Is there a better way in Crystal?