### PR TITLE
Make all default times store in the DB with milliseconds down to 6point.

### DIFF
--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -1460,7 +1460,7 @@ describe Avram::Queryable do
       posts = Post::BaseQuery.new.published_at.between(start_date, end_date)
 
       posts.query.statement.should eq "SELECT posts.custom_id, posts.created_at, posts.updated_at, posts.title, posts.published_at FROM posts WHERE posts.published_at >= $1 AND posts.published_at <= $2"
-      posts.query.args.should eq [start_date.to_s("%Y-%m-%d %H:%M:%S %:z"), end_date.to_s("%Y-%m-%d %H:%M:%S %:z")]
+      posts.query.args.should eq [start_date.to_s("%Y-%m-%d %H:%M:%S.%6N %z"), end_date.to_s("%Y-%m-%d %H:%M:%S.%6N %z")]
       posts.first.should eq post
     end
 
@@ -1576,7 +1576,7 @@ describe Avram::Queryable do
         .available_for_hire(true)
         .created_at(a_day)
 
-      query.to_prepared_sql.should eq(%{SELECT users.id, users.created_at, users.updated_at, users.name, users.age, users.year_born, users.nickname, users.joined_at, users.total_score, users.average_score, users.available_for_hire FROM users WHERE users.name = 'Don' AND users.age > '21' AND users.age < '99' AND users.nickname ILIKE 'j%' AND users.nickname ILIKE '%y' AND users.joined_at > '#{a_week}' AND users.joined_at < '#{an_hour}' AND users.average_score > '1.2' AND users.average_score < '4.9' AND users.available_for_hire = 'true' AND users.created_at = '#{a_day}'})
+      query.to_prepared_sql.should eq(%{SELECT users.id, users.created_at, users.updated_at, users.name, users.age, users.year_born, users.nickname, users.joined_at, users.total_score, users.average_score, users.available_for_hire FROM users WHERE users.name = 'Don' AND users.age > '21' AND users.age < '99' AND users.nickname ILIKE 'j%' AND users.nickname ILIKE '%y' AND users.joined_at > '#{a_week.to_s("%F %X.%6N %z")}' AND users.joined_at < '#{an_hour.to_s("%F %X.%6N %z")}' AND users.average_score > '1.2' AND users.average_score < '4.9' AND users.available_for_hire = 'true' AND users.created_at = '#{a_day.to_s("%F %X.%6N %z")}'})
     end
   end
 

--- a/spec/avram/time_criteria_spec.cr
+++ b/spec/avram/time_criteria_spec.cr
@@ -10,7 +10,7 @@ describe Time::Lucky::Criteria do
   describe "is" do
     it "=" do
       now = Time.utc
-      activated_at.eq(now).to_sql.should eq ["SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE users.activated_at = $1", now.to_s]
+      activated_at.eq(now).to_sql.should eq ["SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE users.activated_at = $1", now.to_s("%F %X.%6N %z")]
     end
   end
 end

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -72,7 +72,7 @@ struct Time
     end
 
     def to_db(value : Time)
-      value.to_s
+      value.to_s("%F %X.%6N %z")
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)


### PR DESCRIPTION
Fixes #727

This makes all `Time` columns store with milliseconds. The tough part is if you're trying to do exact comparison with time, it's a bit harder now, but the benefit is if you need to sort by a time column, you'll get a more accurate sorting. This is especially common with UUID based tables that sort by `created_at`.

Also to note that out of the box default with postgres seems to use this same format for time columns:

```
development=# select now();
              now              
-------------------------------
 2022-03-12 18:02:14.760713+00
(1 row)
```