### PR TITLE
Reverting part of #823 due to a Crystal compiler bug

### DIFF
--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -56,11 +56,10 @@ module Avram
   end
 
   # Raised when using the create!, update!, or delete! methods on an operation when it does not have the proper attributes
-  class InvalidOperationError(T) < AvramError
-    getter operation
+  class InvalidOperationError < AvramError
     getter errors : Hash(Symbol, Array(String))
 
-    def initialize(@operation : T)
+    def initialize(operation)
       message = String.build do |string|
         string << "Could not perform #{operation.class.name}."
         string << "\n"


### PR DESCRIPTION
Fixes #834

Using Crystal 1.2.2, I wasn't able to compile a Lucky project with this. This PR reverts only the part that added the generic. 