### PR TITLE
Lock down Crystal to version 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.3.2
+          crystal: 1.4.1
       - name: Install shards
         run: shards install
       - name: Format
@@ -36,7 +36,7 @@ jobs:
           - 13
           - 14
         crystal_version:
-          - 1.0.0
+          - 1.4.0
           - latest
         experimental:
           - false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.0.0
+FROM crystallang/crystal:1.4.1
 WORKDIR /data
 
 # install base dependencies
@@ -12,7 +12,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Lucky cli
-RUN git clone https://github.com/luckyframework/lucky_cli --branch v0.27.0 --depth 1 /usr/local/lucky_cli && \
+RUN git clone https://github.com/luckyframework/lucky_cli --branch v0.30.0 --depth 1 /usr/local/lucky_cli && \
   cd /usr/local/lucky_cli && \
   shards install && \
   crystal build src/lucky.cr -o /usr/local/bin/lucky

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: avram
 version: 0.23.0
 
-crystal: ">= 1.0.0"
+crystal: ">= 1.4.0"
 
 license: MIT
 
@@ -44,7 +44,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.4
+    version: ~> 1.0.0
   lucky:
     github: luckyframework/lucky
     branch: main


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
