### PR TITLE
Fix default call on change_type. Added new change_default

### DIFF
--- a/spec/avram/migrator/alter_table_statement_spec.cr
+++ b/spec/avram/migrator/alter_table_statement_spec.cr
@@ -65,11 +65,26 @@ describe Avram::Migrator::AlterTableStatement do
     built = Avram::Migrator::AlterTableStatement.new(:users).build do
       change_type id : Int64
       change_type age : Float64, precision: 1, scale: 2
+      change_type name : String, case_sensitive: false
     end
 
-    built.statements.size.should eq 2
+    built.statements.size.should eq 3
     built.statements[0].should eq "ALTER TABLE users ALTER COLUMN id SET DATA TYPE bigint;"
     built.statements[1].should eq "ALTER TABLE users ALTER COLUMN age SET DATA TYPE decimal(1,2);"
+    built.statements[2].should eq "ALTER TABLE users ALTER COLUMN name SET DATA TYPE citext;"
+  end
+
+  it "can change column defaults" do
+    built = Avram::Migrator::AlterTableStatement.new(:test_defaults).build do
+      change_default greeting : String, default: "General Kenobi"
+      change_default published_at : Time, default: :now
+      change_default money : Float64, default: 29.99
+    end
+
+    built.statements.size.should eq 3
+    built.statements[0].should eq "ALTER TABLE ONLY test_defaults ALTER COLUMN greeting SET DEFAULT 'General Kenobi';"
+    built.statements[1].should eq "ALTER TABLE ONLY test_defaults ALTER COLUMN published_at SET DEFAULT NOW();"
+    built.statements[2].should eq "ALTER TABLE ONLY test_defaults ALTER COLUMN money SET DEFAULT '29.99';"
   end
 
   describe "fill_existing_with" do

--- a/src/avram/migrator/columns/base.cr
+++ b/src/avram/migrator/columns/base.cr
@@ -34,6 +34,10 @@ abstract class Avram::Migrator::Columns::Base
     "ALTER TABLE #{table_name} ALTER COLUMN #{name} SET DATA TYPE #{column_type};"
   end
 
+  def build_change_default_statement(table_name : TableName) : String
+    "ALTER TABLE ONLY #{table_name} ALTER COLUMN #{name} SET#{default_fragment};"
+  end
+
   def build_add_statement_for_alter : String
     "  ADD " + build_add_statement
   end


### PR DESCRIPTION
Fixes #791

This adds a new `change_default` macro since you couldn't add a default when calling `change_type`. Before that would just throw an error saying "duplicate argument". Now it'll tell you to use the `change_default` macro instead.

```crystal
alter table_for(Message) do
  change_default visible : Bool, default: true
end
```