### PR TITLE
Make script/setup work for main branch on crystal v1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ WORKDIR /data
 
 # install base dependencies
 RUN apt-get update && \
-  apt-get install -y libgconf-2-4 curl libreadline-dev && \
+  apt-get install -y gnupg libgconf-2-4 curl libreadline-dev && \
   # postgres 11 installation
   curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-  echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" | tee /etc/apt/sources.list.d/postgres.list && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/postgres.list && \
   apt-get update && \
   apt-get install -y postgresql-11 && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This PR fixes (or at least tries to fix) an issue that I had while running on main branch the `script/setup` command.

First issue that i found was 
`gnupg, gnupg2 and gnupg1 do not seem to be installed`
and adding it was resulting into this error:
```
#6 57.14 The following packages have unmet dependencies:
#6 57.43  postgresql-11 : Depends: libicu60 (>= 60.1-1~) but it is not installable
#6 57.43                  Recommends: sysstat but it is not going to be installed
```

This issue was not present in v0.23, so my guess is that the crystal image from v1.0 to v1.4 moved from Bionic Beaver to Focal Fossa, thus invalidating the postgresql repo.

```
root@c39583203fd7:/data# cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.4 LTS (Focal Fossa)"
```

*HOWEVER*, I am not able to still run the script/setup, as I am really lucky to have a M1 Mac, and falling into this issue when running `shards install`: https://github.com/crystal-lang/crystal/issues/11703

```#7 7.015 Failed postinstall of ameba on make bin && make run_file:
#7 7.015 shards build
#7 7.015 Dependencies are satisfied
#7 7.015 Building: ameba
#7 7.015 Error target ameba failed to compile:
#7 7.015 Missing executable path to expand $ORIGIN path (Exception)
#7 7.015   from ???
...
#7 7.015   from ???
#7 7.015 Error: you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/crystal-lang/crystal/issues
#7 7.015
#7 7.015 make: *** [Makefile:8: bin/ameba] Error 1```