### PR TITLE
Added the ability to specify Int64 enums for use with Flags. 

### DIFF
--- a/db/migrations/20200324211956_create_issue.cr
+++ b/db/migrations/20200324211956_create_issue.cr
@@ -4,6 +4,7 @@ class CreateIssue::V20200324211956 < Avram::Migrator::Migration::V1
       primary_key id : Int64
       add status : Int32
       add role : Int32
+      add permissions : Int64
       add_timestamps
     end
   end

--- a/spec/avram/type_extensions/enum_spec.cr
+++ b/spec/avram/type_extensions/enum_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 include ParamHelper
 
 private class TestSaveIssue < Issue::SaveOperation
-  permit_columns role, status
+  permit_columns role, status, permissions
 end
 
 describe "models using enums" do
@@ -41,12 +41,14 @@ describe "models using enums" do
   end
 
   it "can use Int values from params" do
-    params = build_params("issue:role=3&issue:status=0")
+    params = build_params("issue:role=3&issue:status=0&issue:permissions=2")
     TestSaveIssue.create!(params)
 
     issue = IssueQuery.new.first
     issue.role.should eq(Issue::Role::Critical)
     issue.status.should eq(Issue::Status::Opened)
+    issue.permissions.includes?(Issue::Permissions::Read).should eq(false)
+    issue.permissions.includes?(Issue::Permissions::Write).should eq(true)
   end
 
   it "can use String values from params" do

--- a/spec/support/factories/issue_factory.cr
+++ b/spec/support/factories/issue_factory.cr
@@ -1,13 +1,15 @@
 class IssueFactory < BaseFactory
   def initialize
     status Issue::Status::Opened
+    permissions Issue::Permissions::Read
   end
 
   def build_model
     Issue.new(
       id: 123_i64,
       status: 0,
-      role: 0
+      role: 0,
+      permissions: 3_i64
     )
   end
 end

--- a/spec/support/models/issue.cr
+++ b/spec/support/models/issue.cr
@@ -13,9 +13,16 @@ class Issue < BaseModel
     Critical = 3
   end
 
+  @[Flags]
+  enum Permissions : Int64
+    Read
+    Write
+  end
+
   table do
     column status : Issue::Status
     column role : Issue::Role = Issue::Role::Issue
+    column permissions : Issue::Permissions = Issue::Permissions::Read | Issue::Permissions::Write
   end
 end
 

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -7,7 +7,7 @@ abstract struct Enum
 
   module Lucky(T)
     include Avram::Type
-    alias ColumnType = Int32
+    alias ColumnType = Int32 | Int64
 
     def parse(value : String)
       is_int = value.to_i?
@@ -20,7 +20,7 @@ abstract struct Enum
       end
     end
 
-    def parse(value : Int32)
+    def parse(value : Int)
       if result = T.from_value?(value)
         SuccessfulCast.new(result)
       else


### PR DESCRIPTION
Fixes #825

This allows you to specify an `Int64` enum in your model for use with things like bitwise permissions. It also allows enums to be supported on cockroachdb. 