### PR TITLE
Use actual names for Generics instead of T

### DIFF
--- a/src/avram/database_validations.cr
+++ b/src/avram/database_validations.cr
@@ -1,6 +1,6 @@
 require "./validations/**"
 
-module Avram::DatabaseValidations(T)
+module Avram::DatabaseValidations(AvramModel)
   # Validates that the given attribute is unique in the database
   # All validation methods return `Bool`. `false` if any error is added, otherwise `true`
   #
@@ -25,7 +25,7 @@ module Avram::DatabaseValidations(T)
   # pass and Avram tries to save the record.
   private def validate_uniqueness_of(
     attribute : Avram::Attribute,
-    query : Avram::Criteria(T::BaseQuery, _),
+    query : Avram::Criteria(AvramModel::BaseQuery, _),
     message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_uniqueness_of)
   ) : Bool
     no_errors = true
@@ -64,7 +64,7 @@ module Avram::DatabaseValidations(T)
   # ```
   private def validate_uniqueness_of(
     attribute : Avram::Attribute,
-    query : T::BaseQuery,
+    query : AvramModel::BaseQuery,
     message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_uniqueness_of)
   ) : Bool
     no_errors = true
@@ -100,7 +100,7 @@ module Avram::DatabaseValidations(T)
     attribute : Avram::Attribute,
     message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_uniqueness_of)
   ) : Bool
-    validate_uniqueness_of(attribute: attribute, query: T::BaseQuery.new, message: message)
+    validate_uniqueness_of(attribute: attribute, query: AvramModel::BaseQuery.new, message: message)
   end
 
   private def limit_query(query)

--- a/src/avram/delete_operation.cr
+++ b/src/avram/delete_operation.cr
@@ -6,7 +6,7 @@ require "./param_key_override"
 require "./inherit_column_attributes"
 require "./needy_initializer_and_delete_methods"
 
-abstract class Avram::DeleteOperation(T)
+abstract class Avram::DeleteOperation(AvramModel)
   include Avram::NeedyInitializerAndDeleteMethods
   include Avram::DefineAttribute
   include Avram::Validations
@@ -25,14 +25,14 @@ abstract class Avram::DeleteOperation(T)
   macro inherited
     @@permitted_param_keys = [] of String
 
-    @record : T
+    @record : AvramModel
     @params : Avram::Paramable
     getter :record, :params
     property delete_status : OperationStatus = OperationStatus::Unperformed
   end
 
   def self.param_key
-    T.name.underscore
+    AvramModel.name.underscore
   end
 
   def delete : Bool
@@ -85,7 +85,7 @@ abstract class Avram::DeleteOperation(T)
 
   def before_delete; end
 
-  def after_delete(_record : T); end
+  def after_delete(_record : AvramModel); end
 
   # :nodoc:
   def publish_delete_failed_event
@@ -102,7 +102,7 @@ abstract class Avram::DeleteOperation(T)
     )
   end
 
-  private def delete_or_soft_delete(record : T) : T
+  private def delete_or_soft_delete(record : AvramModel) : AvramModel
     if record.is_a?(Avram::SoftDelete::Model)
       record.soft_delete
     else


### PR DESCRIPTION
Fixes #836

There's a ton of places where `T` gets used, so I'll have to take some time to think out if all of them are necessary to change, or if just the ones where named collisions can happen....