### PR TITLE
Adding support for bytea columns with Bytes

### DIFF
--- a/db/migrations/20220720013254_create_beats.cr
+++ b/db/migrations/20220720013254_create_beats.cr
@@ -1,0 +1,13 @@
+class CreateBeats::V20220720013254 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(Beat) do
+      primary_key id : Int64
+      add_timestamps
+      add hash : Bytes
+    end
+  end
+
+  def rollback
+    drop table_for(Beat)
+  end
+end

--- a/spec/avram/operations/save_operation_spec.cr
+++ b/spec/avram/operations/save_operation_spec.cr
@@ -620,6 +620,18 @@ describe "Avram::SaveOperation" do
         record.admin.should eq false
       end
     end
+
+    context "with bytes" do
+      it "saves the byte column" do
+        Beat::SaveOperation.create(hash: "boots and pants".to_slice) do |op, beat|
+          op.saved?.should eq(true)
+          beat.should_not be_nil
+          beat.not_nil!.hash.blank?.should eq(false)
+          beat.not_nil!.hash.should eq(Bytes[98, 111, 111, 116, 115, 32, 97, 110, 100, 32, 112, 97, 110, 116, 115])
+          String.new(beat.not_nil!.hash).should eq("boots and pants")
+        end
+      end
+    end
   end
 
   describe ".create!" do

--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -1219,6 +1219,18 @@ describe Avram::Queryable do
     end
   end
 
+  context "when querying bytes" do
+    context "simple where query" do
+      it "returns the correct result" do
+        BeatFactory.create &.hash("test".to_slice)
+
+        Beat::BaseQuery.new.hash("test").select_count.should eq(1)
+        Beat::BaseQuery.new.hash(Bytes[116, 101, 115, 116]).select_count.should eq(1)
+        Beat::BaseQuery.new.hash(Bytes.empty).select_count.should eq(0)
+      end
+    end
+  end
+
   describe ".truncate" do
     it "truncates the table" do
       10.times { UserFactory.create }

--- a/spec/avram/type_extensions/bytes_spec.cr
+++ b/spec/avram/type_extensions/bytes_spec.cr
@@ -11,4 +11,16 @@ describe "Bytes" do
     result.should be_a(Avram::Type::SuccessfulCast(Bytes))
     result.value.should eq(Bytes[10, 10, 10])
   end
+
+  describe "blank?" do
+    it "returns true" do
+      result = Bytes.adapter.parse(Bytes.empty)
+      result.value.blank?.should eq(true)
+    end
+
+    it "returns false" do
+      result = Bytes.adapter.parse("100".to_slice)
+      result.value.blank?.should eq(false)
+    end
+  end
 end

--- a/spec/avram/type_extensions/bytes_spec.cr
+++ b/spec/avram/type_extensions/bytes_spec.cr
@@ -3,8 +3,12 @@ require "../../spec_helper"
 describe "Bytes" do
   it "parses Bytes from String" do
     result = Bytes.adapter.parse("10")
-    result.value.should eq(10)
+    result.value.should eq(Bytes[49, 48])
   end
 
-
+  it "returns SuccessfulCast for Bytes" do
+    result = Bytes.adapter.parse(Bytes[10, 10, 10])
+    result.should be_a(Avram::Type::SuccessfulCast(Bytes))
+    result.value.should eq(Bytes[10, 10, 10])
+  end
 end

--- a/spec/avram/type_extensions/bytes_spec.cr
+++ b/spec/avram/type_extensions/bytes_spec.cr
@@ -1,0 +1,10 @@
+require "../../spec_helper"
+
+describe "Bytes" do
+  it "parses Bytes from String" do
+    result = Bytes.adapter.parse("10")
+    result.value.should eq(10)
+  end
+
+
+end

--- a/spec/support/factories/beat_factory.cr
+++ b/spec/support/factories/beat_factory.cr
@@ -1,0 +1,5 @@
+class BeatFactory < BaseFactory
+  def initialize
+    hash(Random.new.random_bytes(4))
+  end
+end

--- a/spec/support/models/beat.cr
+++ b/spec/support/models/beat.cr
@@ -1,0 +1,10 @@
+class Beat < BaseModel
+  COLUMN_SQL = "beats.id, beats.created_at, beats.updated_at, beats.hash"
+
+  table do
+    column hash : Bytes
+  end
+end
+
+class BeatQuery < Beat::BaseQuery
+end

--- a/src/avram/blank_extensions.cr
+++ b/src/avram/blank_extensions.cr
@@ -57,3 +57,9 @@ class Array(T)
     empty?
   end
 end
+
+struct Slice(T)
+  def blank?
+    empty?
+  end
+end

--- a/src/avram/charms/slice_extensions.cr
+++ b/src/avram/charms/slice_extensions.cr
@@ -24,6 +24,10 @@ struct Slice(T)
     end
 
     def to_db(value : Bytes)
+      String.new(value)
+    end
+
+    def to_db(value : String)
       value
     end
 

--- a/src/avram/charms/slice_extensions.cr
+++ b/src/avram/charms/slice_extensions.cr
@@ -1,0 +1,29 @@
+struct Slice(T)
+  def self.adapter
+    Lucky
+  end
+
+  module Lucky
+    alias ColumnType = Bytes
+    include Avram::Type
+
+    def self.criteria(query : T, column) forall T
+      Criteria(T, Bytes).new(query, column)
+    end
+
+    def from_db!(value : Bytes)
+      value
+    end
+
+    def parse(value : Bytes)
+      SuccessfulCast(Bytes).new(value)
+    end
+
+    def to_db(value : Bytes)
+      value
+    end
+
+    class Criteria(T, V) < Avram::Criteria(T, V)
+    end
+  end
+end

--- a/src/avram/charms/slice_extensions.cr
+++ b/src/avram/charms/slice_extensions.cr
@@ -15,6 +15,10 @@ struct Slice(T)
       value
     end
 
+    def parse(value : String)
+      parse(value.to_slice)
+    end
+
     def parse(value : Bytes)
       SuccessfulCast(Bytes).new(value)
     end

--- a/src/avram/migrator/columns/bytes_column.cr
+++ b/src/avram/migrator/columns/bytes_column.cr
@@ -1,0 +1,14 @@
+require "./base"
+
+module Avram::Migrator::Columns
+  class BytesColumn(T) < Base
+    @default : T | Bytes | Nil = nil
+
+    def initialize(@name, @nilable, @default)
+    end
+
+    def column_type : String
+      "bytea"
+    end
+  end
+end


### PR DESCRIPTION
Fixes #762

Questions I need an answer for:

* How do you query for this in raw postgres? Postgres will let you query by the original string, or a hexbytes representation. I couldn't get the hexbytes query to work, but regular bytes and the raw string both work.
* What does an insert SQL with this column type look like? `values ('raw string')` or `values ('\xabc123')`. 
* How would you use this in a HTML form or API? I assume you'd pass a String and then call `to_slice`?  You can just use a normal text field and insert a string like a normal String field. Postgres will handle the conversion under the hood.