### PR TITLE
Add extract functionality as a new criteria to timestamptz columns

### DIFF
--- a/spec/avram/time_criteria_spec.cr
+++ b/spec/avram/time_criteria_spec.cr
@@ -120,14 +120,14 @@ describe Time::Lucky::Criteria do
 
       it "timezone_hour" do
         output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(timezone_hour from users.activated_at) = $1"
-        activated_at.extract(Avram::ChronoUnits::Timezone_hour).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(Avram::ChronoUnits::TimezoneHour).eq(5).to_sql.should eq [output_query, "5"]
         activated_at.extract(:timezone_hour).eq(5).to_sql.should eq [output_query, "5"]
         activated_at.extract_timezone_hour.eq(5).to_sql.should eq [output_query, "5"]
       end
 
       it "timezone_minute" do
         output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(timezone_minute from users.activated_at) = $1"
-        activated_at.extract(Avram::ChronoUnits::Timezone_minute).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(Avram::ChronoUnits::TimezoneMinute).eq(5).to_sql.should eq [output_query, "5"]
         activated_at.extract(:timezone_minute).eq(5).to_sql.should eq [output_query, "5"]
         activated_at.extract_timezone_minute.eq(5).to_sql.should eq [output_query, "5"]
       end

--- a/spec/avram/time_criteria_spec.cr
+++ b/spec/avram/time_criteria_spec.cr
@@ -13,6 +13,170 @@ describe Time::Lucky::Criteria do
       activated_at.eq(now).to_sql.should eq ["SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE users.activated_at = $1", now.to_s("%F %X.%6N %z")]
     end
   end
+
+  describe "extract" do
+    it "fails with non supported symbol" do
+      expect_raises(ArgumentError) { activated_at.extract(:dayz).eq(5).to_sql }
+    end
+
+    describe "returning integer" do
+      it "century" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(century from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Century).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:century).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_century.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "day" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(day from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Day).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:day).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_day.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "decade" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(decade from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Decade).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:decade).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_decade.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "dow" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(dow from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Dow).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:dow).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_dow.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "doy" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(doy from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Doy).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:doy).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_doy.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "hour" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(hour from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Hour).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:hour).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_hour.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "isodow" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(isodow from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Isodow).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:isodow).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_isodow.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "isoyear" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(isoyear from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Isoyear).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:isoyear).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_isoyear.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "microseconds" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(microseconds from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Microseconds).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:microseconds).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_microseconds.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "millennium" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(millennium from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Millennium).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:millennium).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_millennium.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "minute" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(minute from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Minute).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:minute).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_minute.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "month" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(month from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Month).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:month).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_month.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "quarter" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(quarter from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Quarter).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:quarter).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_quarter.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "timezone" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(timezone from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Timezone).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:timezone).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_timezone.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "timezone_hour" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(timezone_hour from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Timezone_hour).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:timezone_hour).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_timezone_hour.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "timezone_minute" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(timezone_minute from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Timezone_minute).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:timezone_minute).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_timezone_minute.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "week" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(week from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Week).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:week).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_week.eq(5).to_sql.should eq [output_query, "5"]
+      end
+
+      it "year" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(year from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Year).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract(:year).eq(5).to_sql.should eq [output_query, "5"]
+        activated_at.extract_year.eq(5).to_sql.should eq [output_query, "5"]
+      end
+    end
+
+    describe "returning float" do
+      it "epoch" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(epoch from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Epoch).eq(5).to_sql.should eq [output_query, "5.0"]
+        activated_at.extract(:epoch).eq(5).to_sql.should eq [output_query, "5.0"]
+        activated_at.extract_epoch.eq(5).to_sql.should eq [output_query, "5.0"]
+      end
+
+      it "julian" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(julian from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Julian).eq(5).to_sql.should eq [output_query, "5.0"]
+        activated_at.extract(:julian).eq(5).to_sql.should eq [output_query, "5.0"]
+        activated_at.extract_julian.eq(5).to_sql.should eq [output_query, "5.0"]
+      end
+
+      it "milliseconds" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(milliseconds from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Milliseconds).eq(5).to_sql.should eq [output_query, "5.0"]
+        activated_at.extract(:milliseconds).eq(5).to_sql.should eq [output_query, "5.0"]
+        activated_at.extract_milliseconds.eq(5).to_sql.should eq [output_query, "5.0"]
+      end
+
+      it "second" do
+        output_query = "SELECT users.id, users.created_at, users.updated_at, users.activated_at FROM users WHERE extract(second from users.activated_at) = $1"
+        activated_at.extract(Avram::ChronoUnits::Second).eq(5).to_sql.should eq [output_query, "5.0"]
+        activated_at.extract(:second).eq(5).to_sql.should eq [output_query, "5.0"]
+        activated_at.extract_second.eq(5).to_sql.should eq [output_query, "5.0"]
+      end
+    end
+  end
 end
 
 private def activated_at

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -77,6 +77,7 @@ struct Time
 
     class Criteria(T, V) < Avram::Criteria(T, V)
       include Avram::BetweenCriteria(T, V)
+      include Avram::ExtractCriteria
     end
   end
 end

--- a/src/avram/chrono_units.cr
+++ b/src/avram/chrono_units.cr
@@ -1,0 +1,26 @@
+module Avram
+  enum ChronoUnits
+    Century
+    Day
+    Decade
+    Dow
+    Doy
+    Epoch
+    Hour
+    Isodow
+    Isoyear
+    Julian
+    Microseconds
+    Millennium
+    Milliseconds
+    Minute
+    Month
+    Quarter
+    Second
+    Timezone
+    TimezoneHour
+    TimezoneMinute
+    Week
+    Year
+  end
+end

--- a/src/avram/criteria_extensions/extract_criteria.cr
+++ b/src/avram/criteria_extensions/extract_criteria.cr
@@ -1,0 +1,132 @@
+module Avram
+  enum ChronoUnits
+    Century
+    Day
+    Decade
+    Dow
+    Doy
+    Epoch
+    Hour
+    Isodow
+    Isoyear
+    Julian
+    Microseconds
+    Millennium
+    Milliseconds
+    Minute
+    Month
+    Quarter
+    Second
+    Timezone
+    Timezone_hour
+    Timezone_minute
+    Week
+    Year
+  end
+end
+
+module Avram::ExtractCriteria
+  macro included
+    def extract(chrono_unit : Avram::ChronoUnits)
+        applied_operation = "extract(#{chrono_unit.to_s.downcase} from #{@column})"
+        case chrono_unit
+        when .julian?, .second?, .milliseconds?, .epoch?
+            Criteria(T,Float64).new(rows, applied_operation)
+        else Criteria(T,Int32).new(rows, applied_operation)
+        end
+    end
+
+    def extract(symbol : Symbol)
+        extract(Avram::ChronoUnits.parse(symbol.to_s))
+    end
+
+    def extract_day
+        extract(Avram::ChronoUnits::Day)
+    end
+
+    def extract_month
+        extract(Avram::ChronoUnits::Month)
+    end
+
+    def extract_century
+        extract(Avram::ChronoUnits::Century)
+    end
+
+    def extract_decade
+        extract(Avram::ChronoUnits::Decade)
+    end
+
+    def extract_dow
+        extract(Avram::ChronoUnits::Dow)
+    end
+
+    def extract_doy
+        extract(Avram::ChronoUnits::Doy)
+    end
+
+    def extract_epoch
+        extract(Avram::ChronoUnits::Epoch)
+    end
+
+    def extract_hour
+        extract(Avram::ChronoUnits::Hour)
+    end
+
+    def extract_isodow
+        extract(Avram::ChronoUnits::Isodow)
+    end
+
+    def extract_isoyear
+        extract(Avram::ChronoUnits::Isoyear)
+    end
+
+    def extract_julian
+        extract(Avram::ChronoUnits::Julian)
+    end
+
+    def extract_microseconds
+        extract(Avram::ChronoUnits::Microseconds)
+    end
+
+    def extract_millennium
+        extract(Avram::ChronoUnits::Millennium)
+    end
+
+    def extract_milliseconds
+        extract(Avram::ChronoUnits::Milliseconds)
+    end
+
+    def extract_minute
+        extract(Avram::ChronoUnits::Minute)
+    end
+
+    def extract_quarter
+        extract(Avram::ChronoUnits::Quarter)
+    end
+
+    def extract_second
+        extract(Avram::ChronoUnits::Second)
+    end
+
+    def extract_timezone
+        extract(Avram::ChronoUnits::Timezone)
+    end
+
+    def extract_timezone_hour
+        extract(Avram::ChronoUnits::Timezone_hour)
+    end
+
+    def extract_timezone_minute
+        extract(Avram::ChronoUnits::Timezone_minute)
+    end
+
+    def extract_week
+        extract(Avram::ChronoUnits::Week)
+    end
+
+    def extract_year
+        extract(Avram::ChronoUnits::Year)
+    end
+
+end
+end

--- a/src/avram/criteria_extensions/extract_criteria.cr
+++ b/src/avram/criteria_extensions/extract_criteria.cr
@@ -1,34 +1,13 @@
-module Avram
-  enum ChronoUnits
-    Century
-    Day
-    Decade
-    Dow
-    Doy
-    Epoch
-    Hour
-    Isodow
-    Isoyear
-    Julian
-    Microseconds
-    Millennium
-    Milliseconds
-    Minute
-    Month
-    Quarter
-    Second
-    Timezone
-    Timezone_hour
-    Timezone_minute
-    Week
-    Year
-  end
-end
+require "../chrono_units"
 
 module Avram::ExtractCriteria
   macro included
+
+    {% chrono_units_as_names = Avram::ChronoUnits.constants.map(&.underscore) %}
+
     def extract(chrono_unit : Avram::ChronoUnits)
-        applied_operation = "extract(#{chrono_unit.to_s.downcase} from #{@column})"
+        chrono_unit_in_sql_format=chrono_unit.to_s.underscore
+        applied_operation = "extract(#{chrono_unit_in_sql_format} from #{@column})"
         case chrono_unit
         when .julian?, .second?, .milliseconds?, .epoch?
             Criteria(T,Float64).new(rows, applied_operation)
@@ -37,96 +16,16 @@ module Avram::ExtractCriteria
     end
 
     def extract(symbol : Symbol)
-        extract(Avram::ChronoUnits.parse(symbol.to_s))
+        raise ArgumentError.new("Illegal value #{symbol} as a chrono unit. Allowed values are {{chrono_units_as_names}}") unless {{chrono_units_as_names.stringify}}.includes?(symbol.to_s)
+        chrono_unit_enum_member = symbol.to_s.camelcase
+        extract(Avram::ChronoUnits.parse(chrono_unit_enum_member))
     end
 
-    def extract_day
-        extract(Avram::ChronoUnits::Day)
-    end
+    {% for chrono_unit in chrono_units_as_names %}
+        def extract_{{chrono_unit}}
+            extract(:{{chrono_unit}})
+        end
+    {% end %}
 
-    def extract_month
-        extract(Avram::ChronoUnits::Month)
-    end
-
-    def extract_century
-        extract(Avram::ChronoUnits::Century)
-    end
-
-    def extract_decade
-        extract(Avram::ChronoUnits::Decade)
-    end
-
-    def extract_dow
-        extract(Avram::ChronoUnits::Dow)
-    end
-
-    def extract_doy
-        extract(Avram::ChronoUnits::Doy)
-    end
-
-    def extract_epoch
-        extract(Avram::ChronoUnits::Epoch)
-    end
-
-    def extract_hour
-        extract(Avram::ChronoUnits::Hour)
-    end
-
-    def extract_isodow
-        extract(Avram::ChronoUnits::Isodow)
-    end
-
-    def extract_isoyear
-        extract(Avram::ChronoUnits::Isoyear)
-    end
-
-    def extract_julian
-        extract(Avram::ChronoUnits::Julian)
-    end
-
-    def extract_microseconds
-        extract(Avram::ChronoUnits::Microseconds)
-    end
-
-    def extract_millennium
-        extract(Avram::ChronoUnits::Millennium)
-    end
-
-    def extract_milliseconds
-        extract(Avram::ChronoUnits::Milliseconds)
-    end
-
-    def extract_minute
-        extract(Avram::ChronoUnits::Minute)
-    end
-
-    def extract_quarter
-        extract(Avram::ChronoUnits::Quarter)
-    end
-
-    def extract_second
-        extract(Avram::ChronoUnits::Second)
-    end
-
-    def extract_timezone
-        extract(Avram::ChronoUnits::Timezone)
-    end
-
-    def extract_timezone_hour
-        extract(Avram::ChronoUnits::Timezone_hour)
-    end
-
-    def extract_timezone_minute
-        extract(Avram::ChronoUnits::Timezone_minute)
-    end
-
-    def extract_week
-        extract(Avram::ChronoUnits::Week)
-    end
-
-    def extract_year
-        extract(Avram::ChronoUnits::Year)
-    end
-
-end
+  end
 end


### PR DESCRIPTION
This PR concerns the extract info from date mentioned in issue #857.

It provides a way to be able to extract specific fields from a `timestamptz` column and compare it with some numerical values.
For all the fields implemented till now (see `Avram::ChronoUnits` in the `extract_criteria.cr` or the relevant postgresql documentation), three possible methods are provided:

- `column.extract(Avram::ChronoUnits::<enum_value>)`
             e.g: `some_table.created_on.extract(Avram::ChronoUnits::Day)`
- `column.extract(<enum_value_as_symbol>)`
             e.g: `some_table.created_on.extract(:day)`
- `column.extract_<enum_value>`
             e.g: `some_table.created_on.extract_day`

Functionality can be used as:
- column.extract_year.eq(2022)

Most values returned are ints, but 4 of them which return floats
- julian
- epoch
- second
- milliseconds

I am still not able to do the whole script/setup script/test stuff due to the M1 usual issue, but relevant specs pass..