### PR TITLE
Allows named args to take precendence over param values.

### DIFF
--- a/spec/avram/operations/save_operation_spec.cr
+++ b/spec/avram/operations/save_operation_spec.cr
@@ -619,6 +619,25 @@ describe "Avram::SaveOperation" do
         record.greeting.should eq "Hi"
         record.admin.should eq false
       end
+
+      it "lets named args take precedence over param values" do
+        params = build_params("model_with_default_values:greeting=Hi")
+        OverrideDefaults.create(params, greeting: "sup") do |_operation, record|
+          record.should_not eq nil
+          r = record.not_nil!
+          r.greeting.should eq "sup"
+        end
+
+        model = ModelWithDefaultValues::SaveOperation.create!
+        model.greeting.should eq("Hello there!")
+
+        params = build_params("model_with_default_values:greeting=Hi")
+        OverrideDefaults.update(model, params, greeting: "General Kenobi") do |_operation, record|
+          record.should_not eq nil
+          r = record.not_nil!
+          r.greeting.should eq "General Kenobi"
+        end
+      end
     end
   end
 

--- a/src/avram/needy_initializer_and_delete_methods.cr
+++ b/src/avram/needy_initializer_and_delete_methods.cr
@@ -165,6 +165,7 @@ module Avram::NeedyInitializerAndDeleteMethods
     end
 
     def set_attributes({{ attribute_method_args.id }})
+      extract_changes_from_params
       {% if @type.constant :COLUMN_ATTRIBUTES %}
         {% for attribute in COLUMN_ATTRIBUTES.uniq %}
           unless {{ attribute[:name] }}.is_a? Avram::Nothing
@@ -178,7 +179,6 @@ module Avram::NeedyInitializerAndDeleteMethods
           self.{{ attribute.var }}.value = {{ attribute.var }}
         end
       {% end %}
-      extract_changes_from_params
     end
   end
 end

--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -225,6 +225,7 @@ module Avram::NeedyInitializerAndSaveMethods
     end
 
     def set_attributes({{ attribute_method_args.id }})
+      extract_changes_from_params
       {% if @type.constant :COLUMN_ATTRIBUTES %}
         {% for attribute in COLUMN_ATTRIBUTES.uniq %}
           unless {{ attribute[:name] }}.is_a? Avram::Nothing
@@ -238,7 +239,6 @@ module Avram::NeedyInitializerAndSaveMethods
           self.{{ attribute.var }}.value = {{ attribute.var }}
         end
       {% end %}
-      extract_changes_from_params
     end
   end
 end


### PR DESCRIPTION
Fixes #764

This flips extracting param values first before setting named args. There could be a case where you might have a "admin" field that's technically permitted, but you want the initial value to be `false`. So you set a named arg value to be false. Currently, if a user updated the params to manually push that through, it would be set to what they set it to. Now it'll be set to your named arg value. 