### PR TITLE
Factory callbacks now return self

### DIFF
--- a/spec/avram/factory_spec.cr
+++ b/spec/avram/factory_spec.cr
@@ -70,6 +70,13 @@ describe Avram::Factory do
       scan = factory.create
       scan.line_item_id.should eq line_item_id
     end
+
+    it "returns self and can be chaind" do
+      factory = ScanFactory.new
+      line_item_id = LineItemFactory.create.id
+      scan = factory.before_save { factory.line_item_id(line_item_id) }.create
+      scan.line_item_id.should eq line_item_id
+    end
   end
 
   describe "after_save" do
@@ -80,6 +87,14 @@ describe Avram::Factory do
       end
       line_item = factory.create
 
+      line_item.scans_count.should eq 1
+    end
+
+    it "returns self and can be chained" do
+      line_item = LineItemFactory.create
+      line_item.scans_count.should eq 0
+
+      line_item = LineItemFactory.create &.with_scan
       line_item.scans_count.should eq 1
     end
   end

--- a/spec/support/factories/line_item_factory.cr
+++ b/spec/support/factories/line_item_factory.cr
@@ -2,4 +2,10 @@ class LineItemFactory < BaseFactory
   def initialize
     name "A pair of shoes"
   end
+
+  def with_scan
+    after_save do |line_item|
+      ScanFactory.create &.line_item_id(line_item.id)
+    end
+  end
 end

--- a/src/avram/factory.cr
+++ b/src/avram/factory.cr
@@ -38,14 +38,18 @@ abstract class Avram::Factory
 
   macro setup_callbacks(model_name)
     # Run `block` before the record is created
-    def before_save(&block : -> Nil) : Nil
+    def before_save(&block : -> Nil) : self
       @before_saves << block
+
+      self
     end
 
     # Run `block` after the record is created.
     # The block will yield the created record instance
-    def after_save(&block : {{ model_name.id }} -> Nil) : Nil
+    def after_save(&block : {{ model_name.id }} -> Nil) : self
       @after_saves << block
+
+      self
     end
 
     private def run_before_save_callbacks


### PR DESCRIPTION
Fixes #865

You can now use these like this:

```crystal
class UserFactory < Avram::Factory
  def with_friends
    after_save do |user|
      FriendFactory.create &.user_id(user.id)
    end
  end
end

UserFactory.create &.with_friends
```


