### PR TITLE
fixing this typo

### DIFF
--- a/src/lucky/ext/input_helpers.cr
+++ b/src/lucky/ext/input_helpers.cr
@@ -5,7 +5,7 @@ module Lucky::InputHelpers
     {% raise <<-ERROR
       The database attribute for the operation is not permitted and cannot be used in a form.
 
-      Try allowing the attribute to be filled...
+      Try allowing the attribute to be permitted...
 
           class MySaveOperation # SaveUser, SaveTask, etc.
             permit_columns {attribute_name}


### PR DESCRIPTION
The method used to be called `fill_attribute` or something like that, but we never updated the error message. 

Ignore the branch name... it was an attempt to fix #850 which turned out to be irrelevant.