### PR TITLE
Don't wrap nil in JSON::Any on nilable columns

### DIFF
--- a/spec/avram/json_column_spec.cr
+++ b/spec/avram/json_column_spec.cr
@@ -22,6 +22,7 @@ describe "JSON Columns" do
     SaveBlob.update!(blob, doc: nil)
     blob = BlobQuery.new.first
     blob.doc.should eq nil
+    blob.doc.class.should eq Nil
   end
 
   it "should convert scalars and save forms" do

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -63,6 +63,10 @@ struct JSON::Any
       SuccessfulCast(JSON::Any).new value
     end
 
+    def parse(value : Nil)
+      SuccessfulCast(Nil).new nil
+    end
+
     def parse(value)
       SuccessfulCast(JSON::Any).new JSON.parse(value.to_json)
     end


### PR DESCRIPTION
Fixes #877

This hasn't really caused issues for people because `JSON::Any` wrapping `nil` still returns true for `.nil?` which seems weird.