### PR TITLE
Fix compilation issue with InvalidOperationError

### DIFF
--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -56,11 +56,11 @@ module Avram
   end
 
   # Raised when using the create!, update!, or delete! methods on an operation when it does not have the proper attributes
-  class InvalidOperationError(AvramOperationType) < AvramError
+  class InvalidOperationError < AvramError
     getter errors : Hash(Symbol, Array(String))
-    getter operation : AvramOperationType
+    getter operation : OperationErrors
 
-    def initialize(@operation : AvramOperationType)
+    def initialize(@operation)
       message = String.build do |string|
         string << "Could not perform #{operation.class.name}."
         string << "\n"

--- a/src/lucky/ext/avram/errors.cr
+++ b/src/lucky/ext/avram/errors.cr
@@ -1,5 +1,5 @@
 module Avram
-  class InvalidOperationError(AvramOperationType) < AvramError
+  class InvalidOperationError < AvramError
     include Lucky::RenderableError
 
     def renderable_status : Int32


### PR DESCRIPTION
Connected to:
- https://github.com/luckyframework/avram/pull/879
- https://github.com/luckyframework/avram/pull/868
- https://github.com/luckyframework/avram/issues/819

Before this change, I was getting one of those "you've found a bug in the Crystal compiler errors" with this as the first line

`BUG: trying to downcast Avram::InvalidOperationError(AvramOperationType) (Crystal::GenericClassType) <- Exception+ (Crystal::VirtualType) (Exception)`

Something about the generics just didn't seem to work, so I found a solution that works without generics. It's not ideal since there's very little on the `Avram::OperationErrors` interface, I just don't know of another way to solve this.