### PR TITLE
Revert #868

### DIFF
--- a/spec/lucky/ext/avram/errors_spec.cr
+++ b/spec/lucky/ext/avram/errors_spec.cr
@@ -7,22 +7,13 @@ describe "Errors" do
       operation.valid?.should be_false
 
       error = Avram::InvalidOperationError.new(operation)
+      error.message.to_s.should start_with("Could not perform User::SaveOperation.\n\n")
 
       error.should be_a(Lucky::RenderableError)
       error.invalid_attribute_name.should eq("name")
       error.renderable_status.should eq(400)
       error.renderable_message.should contain("Invalid params")
       error.renderable_details.should eq("name is required")
-    end
-
-    it "includes an escape hatch for a custom error" do
-      operation = User::SaveOperation.new
-
-      error = Avram::InvalidOperationError.new(operation)
-      error.message.should eq("Could not perform User::SaveOperation.\n\n")
-
-      error = Avram::InvalidOperationError.new(operation, "operation go boom")
-      error.message.should eq("operation go boom")
     end
   end
 end

--- a/spec/lucky/ext/avram/errors_spec.cr
+++ b/spec/lucky/ext/avram/errors_spec.cr
@@ -7,13 +7,22 @@ describe "Errors" do
       operation.valid?.should be_false
 
       error = Avram::InvalidOperationError.new(operation)
-      error.operation.should eq(operation)
 
       error.should be_a(Lucky::RenderableError)
       error.invalid_attribute_name.should eq("name")
       error.renderable_status.should eq(400)
       error.renderable_message.should contain("Invalid params")
       error.renderable_details.should eq("name is required")
+    end
+
+    it "includes an escape hatch for a custom error" do
+      operation = User::SaveOperation.new
+
+      error = Avram::InvalidOperationError.new(operation)
+      error.message.should eq("Could not perform User::SaveOperation.\n\n")
+
+      error = Avram::InvalidOperationError.new(operation, "operation go boom")
+      error.message.should eq("operation go boom")
     end
   end
 end

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -1,6 +1,6 @@
 module Avram
   # Generic Avram exception class.
-  class AvramError < Exception
+  class AvramError < ::Exception
   end
 
   # Raise to rollback a transaction.
@@ -56,15 +56,13 @@ module Avram
   end
 
   # Raised when using the create!, update!, or delete! methods on an operation when it does not have the proper attributes
-  class InvalidOperationError(AvramOperationType) < AvramError
+  class InvalidOperationError < AvramError
     getter errors : Hash(Symbol, Array(String))
-    getter operation : AvramOperationType
 
-    def initialize(@operation : AvramOperationType)
-      message = String.build do |string|
-        string << "Could not perform #{operation.class.name}."
-        string << "\n"
-        string << "\n"
+    def initialize(operation, error_message : String? = nil)
+      message = error_message || String.build do |string|
+        string << "Could not perform #{operation.class.name}.\n\n"
+
         operation.errors.each do |attribute_name, errors|
           string << "  ▸ #{attribute_name}: #{errors.join(", ")}\n"
         end

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -59,8 +59,8 @@ module Avram
   class InvalidOperationError < AvramError
     getter errors : Hash(Symbol, Array(String))
 
-    def initialize(operation, error_message : String? = nil)
-      message = error_message || String.build do |string|
+    def initialize(operation)
+      message = String.build do |string|
         string << "Could not perform #{operation.class.name}.\n\n"
 
         operation.errors.each do |attribute_name, errors|

--- a/src/lucky/ext/avram/errors.cr
+++ b/src/lucky/ext/avram/errors.cr
@@ -1,5 +1,5 @@
 module Avram
-  class InvalidOperationError(AvramOperationType) < AvramError
+  class InvalidOperationError < AvramError
     include Lucky::RenderableError
 
     def renderable_status : Int32


### PR DESCRIPTION
This is the second time I've attempted this PR and had to revert it... It's a bit complicated to explain, but I'll try....

Related: https://github.com/crystal-lang/crystal/issues/12472

This PR was originally intended to add an escape hatch for a user that wanted to customize the error message in the case of displaying an alternate language. They wanted access to the operation to customize what it said and have it in another language. To do this, we needed to make the error a Generic since you could have several different types of operations; however, there is a bug in Crystal that would cause the compiler to tank.

Originally I was able to fix this by telling the generated Lucky apps in `Errors::Show` action that the render call just assigned `forall T`. I made a comment here https://github.com/luckyframework/avram/pull/880#issuecomment-1249997847 and as @matthewmcgarvey confirmed, it did "fix" the error...

I noticed that the LuckyCLI specs were still failing, and it turned out to be caused from this issue. Here's an example:

```crystal
# failing action
SignInUser.run(params) do |operation, _|
  # this gets called triggering the errors show action
  raise Avram::InvalidOperation.new(operation)
end
```

```crystal
# actions/errors/show.cr
def render(error : Avram::InvalidOperation(T)) forall T
 # you'd expect it to hit this method, but `typeof(error)` was a massive Union
end

def render(error : Lucky::RenderableError)
 # so it his this line instead causing the spec to fail
end
```

This was an easy fix, because we can just remove the `(T) .. forall T` bit, and all specs pass, and Crystal is happy.... until...

The catch is that, the actual Crystal compilation error is caused when a method that takes a generic type never gets called. This means that when you would generate a new Lucky app using `--no-auth`, then no Operations would defined, and the `Avram::InvalidOperation` render would never be called. This would lead to the compiler tanking.

In the end, I decided that this isn't worth fighting. Since the original request was just an escape hatch, I added one here... though, I'm curious if https://github.com/luckyframework/avram/pull/880 might be a better option? 

@matthewmcgarvey would love your input on this.