### PR TITLE
Don't extract params if no permitted columns

### DIFF
--- a/spec/lucky/ext/avram/operation_params_spec.cr
+++ b/spec/lucky/ext/avram/operation_params_spec.cr
@@ -21,6 +21,9 @@ private class AMixedBag < Bucket::SaveOperation
   attribute brand : String
 end
 
+private class AnEmptyBag < Bucket::SaveOperation
+end
+
 describe "OperationParams" do
   it "passes permitted params to the save operation with no arrays" do
     req = build_request(method: "POST", body: "oooo:name=Dandy&oooo:nickname=mmmm&oooo:joined_at=2020-02-02T20:20:02&oooo:age=49&oooo:extra=cheers")
@@ -63,5 +66,12 @@ describe "OperationParams" do
     expect_raises(Lucky::MissingNestedParamError) do
       AMixedBag.new(params)
     end
+  end
+
+  it "does not fail when params are passed in with invalid param keys if no attributes are extracted" do
+    req = build_request(method: "POST", body: "names[]=None&boop:names[]=Bool&berp:names[]=Berp&blep:names[]=Blep")
+    params = Lucky::Params.new(req)
+
+    AnEmptyBag.new(params)
   end
 end

--- a/src/avram/add_column_attributes.cr
+++ b/src/avram/add_column_attributes.cr
@@ -20,7 +20,9 @@ module Avram::AddColumnAttributes
       end
     end
 
-    def permitted_params
+    def permitted_params : Hash(String, Array(String) | String)
+      return {} of String => Array(String) | String if @@permitted_param_keys.empty?
+
       single_values = @params.nested(self.class.param_key).reject {|k,v| k.ends_with?("[]")}
       array_values = @params.nested_arrays?(self.class.param_key) || {} of String => Array(String)
       new_params = single_values.merge(array_values)


### PR DESCRIPTION
Fixes #891 

This avoids the situations where you don't have any `permit_columns` and the request data isn't what the operation is normally expecting. This is the case when you are only submitting a file and no other form data.