### PR TITLE
Fix error --  cast from Array(String) to String

### DIFF
--- a/db/migrations/20221015145114_create_tokens.cr
+++ b/db/migrations/20221015145114_create_tokens.cr
@@ -1,0 +1,16 @@
+class CreateTokens::V20221015145114 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(Token) do
+      primary_key id : Int64
+
+      add_timestamps
+
+      add name : String
+      add scopes : Array(String)
+    end
+  end
+
+  def rollback
+    drop table_for(Token)
+  end
+end

--- a/spec/avram/operations/define_attribute_spec.cr
+++ b/spec/avram/operations/define_attribute_spec.cr
@@ -156,14 +156,14 @@ describe "attribute in operations" do
   end
 
   it "includes attribute errors when calling SaveOperation#valid?" do
-    params = Avram::Params.new({"terms_of_service" => ["not a boolean"]})
+    params = Avram::Params.new({"terms_of_service" => "not a boolean"})
     operation = SaveOperationWithAttributes.new(params)
     operation.setup_required_database_columns
     operation.valid?.should be_false
   end
 
   it "can still save to the database" do
-    params = Avram::Params.new({"password_confirmation" => ["password"], "terms_of_service" => ["1"]})
+    params = Avram::Params.new({"password_confirmation" => "password", "terms_of_service" => "1"})
     operation = SaveOperationWithAttributes.new(params)
     operation.setup_required_database_columns
     operation.save.should eq true
@@ -204,7 +204,7 @@ describe "file_attribute in operation" do
   end
 
   it "gracefully handles invalid params" do
-    params = Avram::Params.new({"thumb" => ["not a file"]})
+    params = Avram::Params.new({"thumb" => "not a file"})
     operation = OperationWithAttributes.new(params)
     operation.thumb.value.should be_nil
     operation.thumb.errors.first.should eq "is invalid"
@@ -213,7 +213,7 @@ describe "file_attribute in operation" do
     save_operation.thumb.value.should be_nil
     save_operation.thumb.errors.first.should eq "is invalid"
 
-    params = Avram::Params.new({"biometric_confirmation" => ["not a file"]})
+    params = Avram::Params.new({"biometric_confirmation" => "not a file"})
     post = PostFactory.create
     delete_operation = DeleteOperationWithAttributes.new(post, params)
     delete_operation.biometric_confirmation.value.should be_nil
@@ -221,7 +221,7 @@ describe "file_attribute in operation" do
   end
 
   it "includes file attribute errors when calling SaveOperation#valid?" do
-    params = Avram::Params.new({"thumb" => ["not a file"]})
+    params = Avram::Params.new({"thumb" => "not a file"})
     operation = SaveOperationWithAttributes.new(params)
     operation.setup_required_database_columns
     operation.valid?.should be_false

--- a/spec/avram/operations/operation_needs_spec.cr
+++ b/spec/avram/operations/operation_needs_spec.cr
@@ -53,7 +53,7 @@ describe "Avram::Operation needs" do
   end
 
   it "allows params to be passed in along with named args for needs" do
-    params = Avram::Params.new({"title" => ["test"], "published" => ["true"]})
+    params = Avram::Params.new({"title" => "test", "published" => "true"})
 
     OperationWithNeeds.run(params, tags: ["one", "two"], id: 3) do |operation, value|
       value.should eq "one, two"
@@ -74,7 +74,7 @@ end
 
 describe "Avram::SaveOperation needs" do
   it "sets up a method arg for save, update, and new" do
-    params = Avram::Params.new({"name" => ["Paul"]})
+    params = Avram::Params.new({"name" => "Paul"})
     UserFactory.create
     user = UserQuery.new.first
 

--- a/spec/avram/params_spec.cr
+++ b/spec/avram/params_spec.cr
@@ -112,7 +112,7 @@ describe Avram::Params do
     scopes = ["profile", "openid"]
 
     params = Avram::Params.new({
-      "name"   => "Auth token",
+      "name"   => name,
       "scopes" => scopes,
     })
 

--- a/spec/avram/params_spec.cr
+++ b/spec/avram/params_spec.cr
@@ -39,37 +39,37 @@ end
 describe Avram::Paramable do
   describe "#has_key_for?" do
     it "returns true for the Operation with the proper key" do
-      params = NestedParams.new({"test_operation_with_default_param_key:title" => ["Test"]})
+      params = NestedParams.new({"test_operation_with_default_param_key:title" => "Test"})
 
       params.has_key_for?(TestOperationWithDefaultParamKey).should be_true
     end
 
     it "returns true for the Operation with a custom key" do
-      params = NestedParams.new({"test_op:title" => ["Test"]})
+      params = NestedParams.new({"test_op:title" => "Test"})
 
       params.has_key_for?(TestOperationWithCustomParamKey).should be_true
     end
 
     it "returns false for the Operation with the improper key" do
-      params = NestedParams.new({"bad_key:title" => ["Test"]})
+      params = NestedParams.new({"bad_key:title" => "Test"})
 
       params.has_key_for?(TestOperationWithDefaultParamKey).should be_false
     end
 
     it "returns false for the Operation with no key" do
-      params = NestedParams.new({"title" => ["Test"]})
+      params = NestedParams.new({"title" => "Test"})
 
       params.has_key_for?(TestOperationWithDefaultParamKey).should be_false
     end
 
     it "returns true for the SaveOperation with the proper key" do
-      params = NestedParams.new({"user:name" => ["Test"]})
+      params = NestedParams.new({"user:name" => "Test"})
 
       params.has_key_for?(SaveUser).should be_true
     end
 
     it "returns false for the SaveOperation with the improper key" do
-      params = NestedParams.new({"author:name" => ["Test"]})
+      params = NestedParams.new({"author:name" => "Test"})
 
       params.has_key_for?(SaveUser).should be_false
     end

--- a/spec/avram/params_spec.cr
+++ b/spec/avram/params_spec.cr
@@ -75,3 +75,54 @@ describe Avram::Paramable do
     end
   end
 end
+
+private class SaveToken < Token::SaveOperation
+  permit_columns :name, :scopes
+end
+
+describe Avram::Params do
+  it "accepts hashes with all string values" do
+    name = "Auth token"
+    params = Avram::Params.new({"name" => name})
+
+    SaveToken.create(params) do |_, token|
+      token.should be_a(Token)
+
+      token.try do |_token|
+        _token.name.should eq(name)
+      end
+    end
+  end
+
+  it "accepts hashes with all array values" do
+    scopes = ["profile", "openid"]
+    params = Avram::Params.new({"scopes" => scopes})
+
+    SaveToken.create(params) do |_, token|
+      token.should be_a(Token)
+
+      token.try do |_token|
+        _token.scopes.should eq(scopes)
+      end
+    end
+  end
+
+  it "accepts hashes with a mixture of array and string values" do
+    name = "Auth token"
+    scopes = ["profile", "openid"]
+
+    params = Avram::Params.new({
+      "name"   => "Auth token",
+      "scopes" => scopes,
+    })
+
+    SaveToken.create(params) do |_, token|
+      token.should be_a(Token)
+
+      token.try do |_token|
+        _token.name.should eq(name)
+        _token.scopes.should eq(scopes)
+      end
+    end
+  end
+end

--- a/spec/support/models/token.cr
+++ b/spec/support/models/token.cr
@@ -1,0 +1,9 @@
+class Token < BaseModel
+  table do
+    column name : String = "Secret"
+    column scopes : Array(String) = ["email"]
+  end
+end
+
+class TokenQuery < Token::BaseQuery
+end

--- a/src/avram/params.cr
+++ b/src/avram/params.cr
@@ -1,8 +1,8 @@
 class Avram::Params
   include Avram::Paramable
 
-  @hash : Hash(String, Array(String) | String) | \
-    Hash(String, Array(String)) | \
+  @hash : Hash(String, Array(String) | String) |  \
+    Hash(String, Array(String)) |  \
     Hash(String, String)
 
   def initialize


### PR DESCRIPTION
Fixes #884

You can now instantiate `Avram::Params` passing a hash with array values or string values or a mixture of both.