### PR TITLE
Compare array attribute values for select options correctly

### DIFF
--- a/spec/lucky/ext/select_helpers_spec.cr
+++ b/spec/lucky/ext/select_helpers_spec.cr
@@ -53,6 +53,15 @@ class SomeFormWithCompany
       param_key: "company"
     )
   end
+
+  def numbers
+    Avram::PermittedAttribute(Array(Int32)).new(
+      name: :numbers,
+      param: "",
+      value: [1, 2],
+      param_key: "company"
+    )
+  end
 end
 
 describe Lucky::SelectHelpers do
@@ -79,6 +88,13 @@ describe Lucky::SelectHelpers do
     view.render_options(form.tags, [{"One", "one"}, {"Two", "two"}, {"Three", "three"}])
       .html.to_s.should eq <<-HTML
       <option value="one" selected>One</option><option value="two" selected>Two</option><option value="three">Three</option>
+      HTML
+  end
+
+  it "renders multi-select Int32 options" do
+    view.render_options(form.numbers, [{"One", 1}, {"Two", 2}, {"Three", 3}])
+      .html.to_s.should eq <<-HTML
+      <option value="1" selected>One</option><option value="2" selected>Two</option><option value="3">Three</option>
       HTML
   end
 

--- a/src/lucky/ext/select_helpers.cr
+++ b/src/lucky/ext/select_helpers.cr
@@ -29,7 +29,7 @@ module Lucky::SelectHelpers
       bool_attrs = [] of Symbol
 
       if value = field.value
-        is_selected = value.includes?(option_value.to_s)
+        is_selected = value.includes?(option_value)
         bool_attrs << :selected if is_selected
       end
 


### PR DESCRIPTION
Fixes #896 

The other method overload calls `.to_s` on both values because it uses `Avram::PermittedAttribute#param` instead of `Avram::PermittedAttribute#value`. The difference is that `#param` only provides string values while `#value` is the same type as the attribute (but always nilable).