### PR TITLE
support enums in cockroachdb

### DIFF
--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -7,7 +7,7 @@ abstract struct Enum
 
   module Lucky(T)
     include Avram::Type
-    alias ColumnType = Int32
+    alias ColumnType = Int32 | Int64
 
     def parse(value : String)
       is_int = value.to_i?
@@ -20,7 +20,7 @@ abstract struct Enum
       end
     end
 
-    def parse(value : Int32)
+    def parse(value : Int32 | Int64)
       if result = T.from_value?(value)
         SuccessfulCast.new(result)
       else


### PR DESCRIPTION
This adds support for cockroach DB.

Cockroach DB mostly uses Int64 in return types.