### PR TITLE
Add support for CockrochDB query return

### DIFF
--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -221,7 +221,7 @@ module Avram::Queryable(T)
     cache_store.fetch(cache_key(:any?), as: Bool) do
       queryable = clone
       new_query = queryable.query.limit(1).select("1 AS one")
-      results = database.query_one?(new_query.statement, args: new_query.args, queryable: schema_class.name, as: Int32)
+      results = database.query_one?(new_query.statement, args: new_query.args, queryable: schema_class.name, as: (Int32 | Int64))
       !results.nil?
     end
   end


### PR DESCRIPTION
CockrochDB returns Int64 when checking for email. This fixes that bug.