### PR TITLE
Avoid re-fetching associations that have already been preloaded

### DIFF
--- a/db/migrations/20170127143151_create_sign_in_credentials.cr
+++ b/db/migrations/20170127143151_create_sign_in_credentials.cr
@@ -4,6 +4,7 @@ class CreateSignInCredentials::V20170127143151 < Avram::Migrator::Migration::V1
       primary_key id : Int64
       add_timestamps
       add user_id : Int64
+      add value : String
     end
   end
 

--- a/spec/avram/preloading/preloading_has_many_through_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_through_spec.cr
@@ -138,9 +138,7 @@ describe "Preloading has_many through associations" do
       end
     end
 
-    # TODO: do not refetch if already preloaded
-
-    it "refetches association even if already preloaded" do
+    it "does not refetch association from database if already loaded (even if association has changed)" do
       with_lazy_load(enabled: false) do
         tag = TagFactory.create
         post = PostFactory.create
@@ -150,29 +148,30 @@ describe "Preloading has_many through associations" do
 
         post = Post::BaseQuery.preload_tags(post)
 
-        post.tags.first.name.should eq("THIS IS CHANGED")
+        post.tags.first.name.should_not eq("THIS IS CHANGED")
       end
     end
 
-    it "refetches all in multiple even if already preloaded" do
-      with_lazy_load(enabled: false) do
-        tag1 = TagFactory.create
-        post1 = PostFactory.create
-        TaggingFactory.create &.tag_id(tag1.id).post_id(post1.id)
-        post = Post::BaseQuery.preload_tags(post1)
-        Tag::SaveOperation.update!(tag1, name: "THIS IS CHANGED")
+    # TODO
+    # it "refetches unfetched in multiple" do
+    #   with_lazy_load(enabled: false) do
+    #     tag1 = TagFactory.create
+    #     post1 = PostFactory.create
+    #     TaggingFactory.create &.tag_id(tag1.id).post_id(post1.id)
+    #     post = Post::BaseQuery.preload_tags(post1)
+    #     Tag::SaveOperation.update!(tag1, name: "THIS IS CHANGED")
 
-        tag2 = TagFactory.create
-        post2 = PostFactory.create
-        TaggingFactory.create &.tag_id(tag2.id).post_id(post2.id)
-        Tag::SaveOperation.update!(tag2, name: "THIS IS CHANGED")
+    #     tag2 = TagFactory.create
+    #     post2 = PostFactory.create
+    #     TaggingFactory.create &.tag_id(tag2.id).post_id(post2.id)
+    #     Tag::SaveOperation.update!(tag1, name: "THIS IS CHANGED")
 
-        posts = Post::BaseQuery.preload_tags([post1, post2])
+    #     posts = Post::BaseQuery.preload_tags([post1, post2])
 
-        posts[0].tags.first.name.should eq("THIS IS CHANGED")
-        posts[1].tags.first.name.should eq("THIS IS CHANGED")
-      end
-    end
+    #     posts[0].tags.first.name.should_not eq("THIS IS CHANGED")
+    #     posts[1].tags.first.name.should eq("THIS IS CHANGED")
+    #   end
+    # end
 
     it "allows forcing refetch if already loaded" do
       with_lazy_load(enabled: false) do

--- a/spec/avram/preloading/preloading_has_many_through_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_through_spec.cr
@@ -137,5 +137,75 @@ describe "Preloading has_many through associations" do
         end
       end
     end
+
+    # TODO: do not refetch if already preloaded
+
+    it "refetches association even if already preloaded" do
+      with_lazy_load(enabled: false) do
+        tag = TagFactory.create
+        post = PostFactory.create
+        TaggingFactory.create &.tag_id(tag.id).post_id(post.id)
+        post = Post::BaseQuery.preload_tags(post)
+        Tag::SaveOperation.update!(tag, name: "THIS IS CHANGED")
+
+        post = Post::BaseQuery.preload_tags(post)
+
+        post.tags.first.name.should eq("THIS IS CHANGED")
+      end
+    end
+
+    it "refetches all in multiple even if already preloaded" do
+      with_lazy_load(enabled: false) do
+        tag1 = TagFactory.create
+        post1 = PostFactory.create
+        TaggingFactory.create &.tag_id(tag1.id).post_id(post1.id)
+        post = Post::BaseQuery.preload_tags(post1)
+        Tag::SaveOperation.update!(tag1, name: "THIS IS CHANGED")
+
+        tag2 = TagFactory.create
+        post2 = PostFactory.create
+        TaggingFactory.create &.tag_id(tag2.id).post_id(post2.id)
+        Tag::SaveOperation.update!(tag2, name: "THIS IS CHANGED")
+
+        posts = Post::BaseQuery.preload_tags([post1, post2])
+
+        posts[0].tags.first.name.should eq("THIS IS CHANGED")
+        posts[1].tags.first.name.should eq("THIS IS CHANGED")
+      end
+    end
+
+    it "allows forcing refetch if already loaded" do
+      with_lazy_load(enabled: false) do
+        tag = TagFactory.create
+        post = PostFactory.create
+        TaggingFactory.create &.tag_id(tag.id).post_id(post.id)
+        post = Post::BaseQuery.preload_tags(post)
+        Tag::SaveOperation.update!(tag, name: "THIS IS CHANGED")
+
+        post = Post::BaseQuery.preload_tags(post, force: true)
+
+        post.tags.first.name.should eq("THIS IS CHANGED")
+      end
+    end
+
+    it "allows forcing refetch if already loaded with multiple" do
+      with_lazy_load(enabled: false) do
+        tag1 = TagFactory.create
+        post1 = PostFactory.create
+        TaggingFactory.create &.tag_id(tag1.id).post_id(post1.id)
+        post = Post::BaseQuery.preload_tags(post1)
+        Tag::SaveOperation.update!(tag1, name: "THIS IS CHANGED")
+
+        tag2 = TagFactory.create
+        post2 = PostFactory.create
+        TaggingFactory.create &.tag_id(tag2.id).post_id(post2.id)
+        Tag::SaveOperation.update!(tag2, name: "THIS IS CHANGED")
+
+        posts = Post::BaseQuery.preload_tags([post1, post2], force: true)
+
+        posts[0].tags.first.name.should eq("THIS IS CHANGED")
+        posts[1].tags.first.name.should eq("THIS IS CHANGED")
+      end
+    end
   end
 end

--- a/spec/avram/preloading/preloading_has_many_through_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_through_spec.cr
@@ -158,7 +158,7 @@ describe "Preloading has_many through associations" do
     #     tag1 = TagFactory.create
     #     post1 = PostFactory.create
     #     TaggingFactory.create &.tag_id(tag1.id).post_id(post1.id)
-    #     post = Post::BaseQuery.preload_tags(post1)
+    #     post1 = Post::BaseQuery.preload_tags(post1)
     #     Tag::SaveOperation.update!(tag1, name: "THIS IS CHANGED")
 
     #     tag2 = TagFactory.create
@@ -192,7 +192,7 @@ describe "Preloading has_many through associations" do
         tag1 = TagFactory.create
         post1 = PostFactory.create
         TaggingFactory.create &.tag_id(tag1.id).post_id(post1.id)
-        post = Post::BaseQuery.preload_tags(post1)
+        post1 = Post::BaseQuery.preload_tags(post1)
         Tag::SaveOperation.update!(tag1, name: "THIS IS CHANGED")
 
         tag2 = TagFactory.create

--- a/spec/support/factories/sign_in_credential_factory.cr
+++ b/spec/support/factories/sign_in_credential_factory.cr
@@ -1,4 +1,5 @@
 class SignInCredentialFactory < BaseFactory
   def initialize
+    value "fake value"
   end
 end

--- a/spec/support/models/sign_in_credential.cr
+++ b/spec/support/models/sign_in_credential.cr
@@ -1,5 +1,7 @@
 class SignInCredential < BaseModel
   table do
+    column value : String
+
     belongs_to user : User
   end
 end

--- a/src/avram/associations.cr
+++ b/src/avram/associations.cr
@@ -19,8 +19,7 @@ module Avram::Associations
       get_{{ assoc_name.id }}
     end
 
-    @_{{ assoc_name }}_preloaded : Bool = false
-    private getter? _{{ assoc_name }}_preloaded
+    protected getter? _{{ assoc_name }}_preloaded : Bool = false
     private getter _preloaded_{{ assoc_name }} : {{ model }}?
   end
 

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -25,7 +25,7 @@ module Avram::Associations::BelongsTo
     define_belongs_to_private_assoc_getter({{ assoc_name }}, {{ model }}, {{ foreign_key.id }}, {{ nilable }})
     Avram::Associations.__define_public_preloaded_getters({{ assoc_name }}, {{ model }}, {{ nilable }})
     Avram::Associations.__define_preloaded_setter({{ assoc_name }}, {{ model }}, {{ nilable }})
-    define_belongs_to_base_query({{ assoc_name }}, {{ model }}, {{ foreign_key.id }})
+    define_belongs_to_base_query({{ @type }}, {{ assoc_name }}, {{ model }}, {{ foreign_key.id }})
   end
 
   private macro define_belongs_to_private_assoc_getter(assoc_name, model, foreign_key, nilable)
@@ -46,31 +46,31 @@ module Avram::Associations::BelongsTo
     end
   end
 
-  private macro define_belongs_to_base_query(assoc_name, model, foreign_key)
+  private macro define_belongs_to_base_query(class_type, assoc_name, model, foreign_key)
     class BaseQuery
-      def self.preload_{{ assoc_name }}(record)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }})
         preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new)
       end
 
-      def self.preload_{{ assoc_name }}(record)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }})
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(record: record, preload_query: modified_query)
       end
 
-      def self.preload_{{ assoc_name }}(record, preload_query)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery)
         preload_{{ assoc_name }}(records: [record], preload_query: preload_query).first
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}))
         preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}))
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(records: records, preload_query: modified_query)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery)
         ids = records.compact_map(&.{{ foreign_key }})
         empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
         {{ assoc_name }} = ids.empty? ? empty_results  : preload_query.id.in(ids).results.group_by(&.id)

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -48,16 +48,16 @@ module Avram::Associations::BelongsTo
 
   private macro define_belongs_to_base_query(class_type, assoc_name, model, foreign_key)
     class BaseQuery
-      def self.preload_{{ assoc_name }}(record : {{ class_type }}, force : Bool = false)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, force : Bool = false) : {{ class_type }}
         preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new, force: force)
       end
 
-      def self.preload_{{ assoc_name }}(record : {{ class_type }}, force : Bool = false)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, force : Bool = false) : {{ class_type }}
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(record: record, preload_query: modified_query, force: force)
       end
 
-      def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery, force : Bool = false)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery, force : Bool = false) : {{ class_type }}
         return record if record._{{ assoc_name }}_preloaded? && !force
 
         new_record = record.dup
@@ -66,16 +66,16 @@ module Avram::Associations::BelongsTo
         new_record
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), force : Bool = false)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), force : Bool = false) : Array({{ class_type }})
         preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new, force: force)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), force : Bool = false)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), force : Bool = false) : Array({{ class_type }})
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(records: records, preload_query: modified_query, force: force)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery, force : Bool = false)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery, force : Bool = false) : Array({{ class_type }})
         ids = records.compact_map do |record|
           if record._{{ assoc_name }}_preloaded? && !force
             nil
@@ -98,16 +98,16 @@ module Avram::Associations::BelongsTo
         end
       end
 
-      def preload_{{ assoc_name }}
+      def preload_{{ assoc_name }} : self
         preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end
 
-      def preload_{{ assoc_name }}
+      def preload_{{ assoc_name }} : self
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(modified_query)
       end
 
-      def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery)
+      def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery) : self
         add_preload do |records|
           ids = records.compact_map(&.{{ foreign_key }})
           empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})

--- a/src/avram/associations/belongs_to.cr
+++ b/src/avram/associations/belongs_to.cr
@@ -48,38 +48,54 @@ module Avram::Associations::BelongsTo
 
   private macro define_belongs_to_base_query(class_type, assoc_name, model, foreign_key)
     class BaseQuery
-      def self.preload_{{ assoc_name }}(record : {{ class_type }})
-        preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, force : Bool = false)
+        preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new, force: force)
       end
 
-      def self.preload_{{ assoc_name }}(record : {{ class_type }})
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, force : Bool = false)
         modified_query = yield {{ model }}::BaseQuery.new
-        preload_{{ assoc_name }}(record: record, preload_query: modified_query)
+        preload_{{ assoc_name }}(record: record, preload_query: modified_query, force: force)
       end
 
-      def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery)
-        preload_{{ assoc_name }}(records: [record], preload_query: preload_query).first
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery, force : Bool = false)
+        return record if record._{{ assoc_name }}_preloaded? && !force
+
+        new_record = record.dup
+        assoc = preload_query.id(record.{{ foreign_key }}).first?
+        new_record.__set_preloaded_{{ assoc_name }}(assoc)
+        new_record
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}))
-        preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), force : Bool = false)
+        preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new, force: force)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}))
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), force : Bool = false)
         modified_query = yield {{ model }}::BaseQuery.new
-        preload_{{ assoc_name }}(records: records, preload_query: modified_query)
+        preload_{{ assoc_name }}(records: records, preload_query: modified_query, force: force)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery)
-        ids = records.compact_map(&.{{ foreign_key }})
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery, force : Bool = false)
+        ids = records.compact_map do |record|
+          if record._{{ assoc_name }}_preloaded? && !force
+            nil
+          else
+            record.{{ foreign_key }}
+          end
+        end
         empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
         {{ assoc_name }} = ids.empty? ? empty_results  : preload_query.id.in(ids).results.group_by(&.id)
-        records.map(&.dup)
-          .map do |record|
-            id = record.{{ foreign_key }}
-            assoc = id.nil? ? nil : {{ assoc_name }}[id]?.try(&.first?)
-            record.tap(&.__set_preloaded_{{ assoc_name }}(assoc))
+        records.map do |record|
+          if record._{{ assoc_name }}_preloaded? && !force
+            next record
           end
+
+          record = record.dup
+          id = record.{{ foreign_key }}
+          assoc = id.nil? ? nil : {{ assoc_name }}[id]?.try(&.first?)
+          record.__set_preloaded_{{ assoc_name }}(assoc)
+          record
+        end
       end
 
       def preload_{{ assoc_name }}

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -42,35 +42,35 @@ module Avram::Associations::HasMany
     {% model = type_declaration.type %}
 
     define_has_many_lazy_loading({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ through }})
-    define_has_many_base_query({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ through }})
+    define_has_many_base_query({{ @type }}, {{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ through }})
   end
 
-  private macro define_has_many_base_query(assoc_name, model, foreign_key, through)
+  private macro define_has_many_base_query(class_type, assoc_name, model, foreign_key, through)
     class BaseQuery
-      def self.preload_{{ assoc_name }}(record)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}) : {{ class_type }}
         preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new)
       end
 
-      def self.preload_{{ assoc_name }}(record)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}) : {{ class_type }}
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(record: record, preload_query: modified_query)
       end
 
-      def self.preload_{{ assoc_name }}(record, preload_query)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery) : {{ class_type }}
         preload_{{ assoc_name }}(records: [record], preload_query: preload_query).first
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }})) : Array({{ class_type }})
         preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }})) : Array({{ class_type }})
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(records: records, preload_query: modified_query)
       end
 
       {% if through %}
-      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery) : Array({{ class_type }})
         intermediary_records = preload_{{ through.first.id }}(records) do |through_query|
           through_query.preload_{{ through[1].id }}(preload_query)
         end
@@ -87,7 +87,7 @@ module Avram::Associations::HasMany
           end
       end
       {% else %}
-      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery) : Array({{ class_type }})
         ids = records.map(&.id)
         empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
         {{ assoc_name }} = ids.empty? ? empty_results  : preload_query.{{ foreign_key }}.in(ids).results.group_by(&.{{ foreign_key }})
@@ -99,17 +99,17 @@ module Avram::Associations::HasMany
       end
       {% end %}
 
-      def preload_{{ assoc_name }}
+      def preload_{{ assoc_name }} : self
         preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end
 
-      def preload_{{ assoc_name }}
+      def preload_{{ assoc_name }} : self
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(modified_query)
       end
 
       {% if through %}
-        def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery)
+        def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery) : self
           preload_{{ through.first.id }} do |through_query|
             through_query.preload_{{ through[1].id }}(preload_query)
           end
@@ -126,7 +126,7 @@ module Avram::Associations::HasMany
           self
         end
       {% else %}
-        def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery)
+        def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery) : self
           add_preload do |records|
             ids = records.map(&.id)
             if ids.empty?

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -57,8 +57,9 @@ module Avram::Associations::HasMany
       end
 
       {% if through %}
-      # force is an accepted argument, but is ignored
       def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery, force : Bool = false) : {{ class_type }}
+        return record if record._{{ assoc_name }}_preloaded? && !force
+
         preload_{{ assoc_name }}(records: [record], preload_query: preload_query, force: force).first
       end
       {% else %}

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -57,6 +57,7 @@ module Avram::Associations::HasMany
       end
 
       {% if through %}
+      # force is an accepted argument, but is ignored
       def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery, force : Bool = false) : {{ class_type }}
         preload_{{ assoc_name }}(records: [record], preload_query: preload_query, force: force).first
       end
@@ -80,8 +81,9 @@ module Avram::Associations::HasMany
       end
 
       {% if through %}
+      # force is an accepted argument, but is ignored
       def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery, force : Bool = false) : Array({{ class_type }})
-        intermediary_records = preload_{{ through.first.id }}(records) do |through_query|
+        intermediary_records = preload_{{ through.first.id }}(records, force: true) do |through_query|
           through_query.preload_{{ through[1].id }}(preload_query)
         end
         intermediary_records.map(&.dup)

--- a/src/avram/associations/has_one.cr
+++ b/src/avram/associations/has_one.cr
@@ -25,7 +25,7 @@ module Avram::Associations::HasOne
     Avram::Associations.__define_public_preloaded_getters({{ assoc_name }}, {{ model }}, {{ nilable }})
     Avram::Associations.__define_preloaded_setter({{ assoc_name }}, {{ model }}, {{ nilable }})
     define_has_one_private_assoc_getter({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ nilable }})
-    define_has_one_base_query({{ assoc_name }}, {{ model }}, {{ foreign_key }})
+    define_has_one_base_query({{ @type }}, {{ assoc_name }}, {{ model }}, {{ foreign_key }})
   end
 
   private macro define_has_one_private_assoc_getter(assoc_name, model, foreign_key, nilable)
@@ -42,31 +42,31 @@ module Avram::Associations::HasOne
     end
   end
 
-  private macro define_has_one_base_query(assoc_name, model, foreign_key)
+  private macro define_has_one_base_query(class_type, assoc_name, model, foreign_key)
     class BaseQuery
-      def self.preload_{{ assoc_name }}(record)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}) : {{ class_type }}
         preload_{{ assoc_name }}(record: record, preload_query: {{ model }}::BaseQuery.new)
       end
 
-      def self.preload_{{ assoc_name }}(record)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}) : {{ class_type }}
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(record: record, preload_query: modified_query)
       end
 
-      def self.preload_{{ assoc_name }}(record, preload_query)
+      def self.preload_{{ assoc_name }}(record : {{ class_type }}, preload_query : {{ model }}::BaseQuery) : {{ class_type }}
         preload_{{ assoc_name }}(records: [record], preload_query: preload_query).first
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }})) : Array({{ class_type }})
         preload_{{ assoc_name }}(records: records, preload_query: {{ model }}::BaseQuery.new)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }})) : Array({{ class_type }})
         modified_query = yield {{ model }}::BaseQuery.new
         preload_{{ assoc_name }}(records: records, preload_query: modified_query)
       end
 
-      def self.preload_{{ assoc_name }}(records : Enumerable, preload_query)
+      def self.preload_{{ assoc_name }}(records : Enumerable({{ class_type }}), preload_query : {{ model }}::BaseQuery) : Array({{ class_type }})
         ids = records.map(&.id)
         empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})
         {{ assoc_name }} = ids.empty? ? empty_results : preload_query.{{ foreign_key }}.in(ids).results.group_by(&.{{ foreign_key }})
@@ -77,11 +77,11 @@ module Avram::Associations::HasOne
           end
       end
 
-      def preload_{{ assoc_name }}
+      def preload_{{ assoc_name }} : self
         preload_{{ assoc_name }}({{ model }}::BaseQuery.new)
       end
 
-      def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery)
+      def preload_{{ assoc_name }}(preload_query : {{ model }}::BaseQuery) : self
         add_preload do |records|
           ids = records.map(&.id)
           empty_results = {} of {{ model }}::PrimaryKeyType => Array({{ model }})


### PR DESCRIPTION
This updates the class-level preload functions to check if the association has already been loaded before redoing the process. Now you don't have to worry about making unnecessary SQL queries when you don't have to.

**TODO** Support has many through passing multiple records.

Honestly, has many through has been the most difficult part of the codebase **by far** and this is no different. The problem is when the intermediary association is loaded but not the one in the has many through. Since we pass that we want the has many through association preloaded in the query that loads the intermediary, if it is loaded that call to preload is completely ignored.

The fix is to rethink how we make that query. Instead of loading the intermediaries, just set up fancy joins to only query for the has many through association. But how do we do that? 🤷 

Also, this preload stuff is very broken for a has many through with more than one intermediary (a through list with more than 2 items)

I figure that this is good enough to include without that handling for the has many through. This stuff should be mostly invisible to end-users, anyways.

```crystal
user = UserQuery.find(123)
user = UserQuery.preload_subscription(user) # <--- Query happens here to load the subscription
user = UserQuery.preload_subscription(user) # <--- User already has subscription loaded, nothing happens
user = UserQuery.preload_subscription(user, force: true) # <--- Force query to refetch association
user = UserQuery.preload_subscription(user, &.renewal("monthly") # <--- The actual query we pass in doesn't matter, we still don't fetch the subscription again
```