### PR TITLE
Talking errors in casting failures

### DIFF
--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -374,7 +374,7 @@ describe Avram::Queryable do
     end
 
     it "raises PQ::PQError if no record is found with letter-only id (String)" do
-      expect_raises(Exception, "FailedCast") do
+      expect_raises(Avram::FailedCastError) do
         UserQuery.find("id")
       end
     end
@@ -401,7 +401,7 @@ describe Avram::Queryable do
     end
 
     it "raises PQ::PQError if no record is found with letter-only id (String)" do
-      expect_raises(Exception, "FailedCast") do
+      expect_raises(Avram::FailedCastError) do
         UserQuery.new.find("id")
       end
     end

--- a/spec/avram/type_extensions/bool_spec.cr
+++ b/spec/avram/type_extensions/bool_spec.cr
@@ -6,4 +6,21 @@ describe Bool do
       true.blank?.should be_false
     end
   end
+
+  describe "parsing value" do
+    it "works with correct strings" do
+      correct_values = %w(true 1 false 0)
+      expected = [true, true, false, false]
+      correct_values.each_with_index do |val, ix|
+        Bool.adapter.parse(val).value.should eq expected[ix]
+      end
+    end
+
+    it "fails with malformed strings" do
+      wrong_value = "fAl;se"
+      expect_raises(Avram::FailedCastError) {
+        Bool.adapter.parse(wrong_value).value
+      }
+    end
+  end
 end

--- a/spec/avram/type_extensions/enum_spec.cr
+++ b/spec/avram/type_extensions/enum_spec.cr
@@ -32,6 +32,21 @@ describe "models using enums" do
     query.status(0).first.should eq(issue)
   end
 
+  it "fails when querying for non defined enum constants" do
+    issue = IssueFactory.create
+    query = IssueQuery.new
+    error_message = ->(x : String | Int32) { "Value ->#{x}<- is not a valid constant for enum Issue::Status" }
+
+    wrong_enum_constant = "oh no!"
+    expect_raises(Avram::FailedCastError, error_message.call(wrong_enum_constant)) {
+      query.status(wrong_enum_constant)
+    }
+    wrong_enum_constant = 999
+    expect_raises(Avram::FailedCastError, error_message.call(wrong_enum_constant)) {
+      query.status(wrong_enum_constant)
+    }
+  end
+
   it "handles other queries" do
     IssueFactory.create &.role(Issue::Role::Issue)
     IssueFactory.create &.role(Issue::Role::Critical)

--- a/spec/avram/type_extensions/enum_spec.cr
+++ b/spec/avram/type_extensions/enum_spec.cr
@@ -33,7 +33,6 @@ describe "models using enums" do
   end
 
   it "fails when querying for non defined enum constants" do
-    issue = IssueFactory.create
     query = IssueQuery.new
     error_message = ->(x : String | Int32) { "Value ->#{x}<- is not a valid constant for enum Issue::Status" }
 

--- a/spec/avram/type_extensions/int32_spec.cr
+++ b/spec/avram/type_extensions/int32_spec.cr
@@ -13,7 +13,7 @@ describe "Int32" do
 
   it "returns FailedCast when overflow from Int64 to Int32" do
     result = Int32.adapter.parse(2147483648)
-    result.value.should eq(nil)
     result.should be_a(Avram::Type::FailedCast)
+    expect_raises(Avram::FailedCastError) { result.value }
   end
 end

--- a/src/avram/charms/bool_extensions.cr
+++ b/src/avram/charms/bool_extensions.cr
@@ -12,12 +12,14 @@ struct Bool
     end
 
     def parse(value : String)
-      if %w(true 1).includes? value
+      true_vals = %w(true 1)
+      false_vals = %w(false 0)
+      if true_vals.includes? value
         SuccessfulCast(Bool).new true
-      elsif %w(false 0).includes? value
+      elsif false_vals.includes? value
         SuccessfulCast(Bool).new false
       else
-        FailedCast.new
+        FailedCast.new("Value ->#{value}<- could not be converted to boolean - allowed values: #{true_vals + false_vals}")
       end
     end
 

--- a/src/avram/charms/enum_extensions.cr
+++ b/src/avram/charms/enum_extensions.cr
@@ -16,7 +16,7 @@ abstract struct Enum
       if result = T.parse?(value)
         SuccessfulCast.new(result)
       else
-        FailedCast.new
+        FailedCast.new("Value ->#{value}<- is not a valid constant for enum #{T}")
       end
     end
 
@@ -24,7 +24,7 @@ abstract struct Enum
       if result = T.from_value?(value)
         SuccessfulCast.new(result)
       else
-        FailedCast.new
+        FailedCast.new("Value ->#{value}<- is not a valid constant for enum #{T}")
       end
     end
 

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -38,7 +38,7 @@ struct Float64
     def parse(value : String)
       SuccessfulCast(Float64).new value.to_f64
     rescue ArgumentError
-      FailedCast.new
+      FailedCast.new("Value ->#{value}<- could not be converted to Float64")
     end
 
     def parse(value : Int32)

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -26,13 +26,13 @@ struct Int16
     def parse(value : String)
       SuccessfulCast(Int16).new value.to_i16
     rescue ArgumentError
-      FailedCast.new
+      FailedCast.new("Value ->#{value}<- could not be converted to Int16")
     end
 
     def parse(value : Int32)
       SuccessfulCast(Int16).new value.to_i16
     rescue OverflowError
-      FailedCast.new
+      FailedCast.new("Value ->#{value}<- overflowed while being converted to Int16")
     end
 
     def to_db(value : Int16)

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -18,7 +18,7 @@ struct Int32
     def parse(value : String)
       SuccessfulCast(Int32).new value.to_i
     rescue ArgumentError
-      FailedCast.new
+      FailedCast.new("Value ->#{value}<- could not be converted to Int32")
     end
 
     def parse(value : Int32)
@@ -28,7 +28,7 @@ struct Int32
     def parse(value : Int64)
       SuccessfulCast(Int32).new value.to_i32
     rescue OverflowError
-      FailedCast.new
+      FailedCast.new("Value ->#{value}<- overflowed while being converted to Int32")
     end
 
     def parse(values : Array(Int32))

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -26,7 +26,7 @@ struct Int64
     def parse(value : String)
       SuccessfulCast(Int64).new value.to_i64
     rescue ArgumentError
-      FailedCast.new
+      FailedCast.new("Value ->#{value}<- could not be cast to Int64")
     end
 
     def parse(value : Int32)

--- a/src/avram/charms/time_extensions.cr
+++ b/src/avram/charms/time_extensions.cr
@@ -36,7 +36,7 @@ struct Time
         # Then try default formats
         try_parsing_with_default_formatters(value) ||
         # Fail if none of them work
-        FailedCast.new
+        FailedCast.new("->#{value}<- cannot be parsed with current formatters to Time")
     end
 
     def self.try_parsing_with_default_formatters(value : String)

--- a/src/avram/charms/uuid_extensions.cr
+++ b/src/avram/charms/uuid_extensions.cr
@@ -22,7 +22,7 @@ struct UUID
     def parse(value : String)
       SuccessfulCast(UUID).new(UUID.new(value))
     rescue
-      FailedCast.new
+      FailedCast.new("->#{value}<- is not a valid UUID")
     end
 
     def to_db(value : UUID)

--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -153,6 +153,10 @@ module Avram
   class InvalidQueryError < AvramError
   end
 
+  # Used when there is a failed cast. E.g: overflowing, failed time parsing, etc...
+  class FailedCastError < AvramError
+  end
+
   # Used when `Avram::Operation` fails.
   class FailedOperation < AvramError
   end

--- a/src/avram/uploadable.cr
+++ b/src/avram/uploadable.cr
@@ -22,11 +22,11 @@ module Avram::Uploadable
     end
 
     def parse(value : String?)
-      FailedCast.new
+      FailedCast.new("Cannot parse an uploadeable")
     end
 
     def parse(values : Array(String))
-      FailedCast.new
+      FailedCast.new("Cannot parse an array of uploadeable")
     end
   end
 end


### PR DESCRIPTION
Implements #893. There is a breaking change, though. Previously, calling FailedCast#value would always return a nil value, without providing any clue on which value was actually breaking.
Now, it raises a FailCastError with a talking error message, in the form of - for instance - "Value ->Invalid<- is not a valid constant for enum WhateverEnum".

Btw,  is there an "easy" way to test avram modifications in a dummy lucky app?