### PR TITLE
Add updated? and created? methods on SaveOperations

### DIFF
--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -132,6 +132,14 @@ abstract class Avram::SaveOperation(T)
     save_status == OperationStatus::Saved
   end
 
+  def created?
+    saved? && new_record?
+  end
+
+  def updated?
+    saved? && !new_record?
+  end
+
   # Return true if the operation has run and the record failed to save
   def save_failed?
     save_status == OperationStatus::SaveFailed


### PR DESCRIPTION
Implements #888.
Adds two new boolean methods to `SaveOperation`.
They work similarly to `new_record?` but always return false if the record was not persisted (e.g: failed save or not-yet-performed operation)