### PR TITLE
Ensure matching column message when missing Enum

### DIFF
--- a/spec/avram/schema_enforcer/ensure_matching_columns_spec.cr
+++ b/spec/avram/schema_enforcer/ensure_matching_columns_spec.cr
@@ -6,6 +6,18 @@ private class ModelWithMissingButSimilarlyNamedColumn < BaseModel
   end
 end
 
+private class ModelWithMissingColumn < BaseModel
+  table :users do
+    column first_name : String
+  end
+end
+
+private class ModelWithMissingEnumColumn < BaseModel
+  table :users do
+    column gender : Enum
+  end
+end
+
 private class ModelWithOptionalAttributeOnRequiredColumn < BaseModel
   table :users do
     column name : String?
@@ -24,6 +36,16 @@ describe Avram::SchemaEnforcer::EnsureMatchingColumns do
   it "raises on tables with missing columns" do
     expect_schema_mismatch "wants to use the column 'mickname' but it does not exist. Did you mean 'nickname'?" do
       ModelWithMissingButSimilarlyNamedColumn.ensure_correct_column_mappings!
+    end
+
+    # Partial message assertion for brevity
+    expect_schema_mismatch "wants to use the column 'first_name' but it does not exist." do
+      ModelWithMissingColumn.ensure_correct_column_mappings!
+    end
+
+    # Partial message assertion for brevity
+    expect_schema_mismatch "add gender : Int32" do
+      ModelWithMissingEnumColumn.ensure_correct_column_mappings!
     end
   end
 

--- a/src/avram/schema_enforcer/ensure_matching_columns.cr
+++ b/src/avram/schema_enforcer/ensure_matching_columns.cr
@@ -49,6 +49,8 @@ class Avram::SchemaEnforcer::EnsureMatchingColumns < Avram::SchemaEnforcer::Vali
     if best_match
       message += " Did you mean '#{best_match.colorize.yellow.bold}'?\n\n"
     else
+      # Enum column are mapped to Int32 in the database layer
+      missing_attribute_type_hint = "#{missing_attribute[:name]} : #{missing_attribute[:type].sub("Enum", "Int32")}"
       message += <<-TEXT
 
 
@@ -62,10 +64,10 @@ class Avram::SchemaEnforcer::EnsureMatchingColumns < Avram::SchemaEnforcer::Vali
 
             alter :#{table_name} do
               #{"# Add the column:".colorize.dim}
-              add #{missing_attribute[:name]} : #{missing_attribute[:type]}
+              add #{missing_attribute_type_hint}
 
               #{"# Or if this is a column for a belongs_to relationship:".colorize.dim}
-              add_belongs_to #{missing_attribute[:name]} : #{missing_attribute[:type]}
+              add_belongs_to #{missing_attribute_type_hint}
             end
 
       Or, you can skip schema checks for this model:


### PR DESCRIPTION
First PR here :wave: 

### What
When we declare an Enum field in the models, it should be referenced as Int32 in the migration file (https://luckyframework.org/guides/database/models#using-enums).

The current message was instead suggesting to type it as Enum in the migration which doesn't work.

### How it has been tested
- Added one missing test for the missing column
- Added the specific UT for the Enum case

I didn't assert the full message for brevity of UT on hint messages. I thought it may become too verbose for a not critical function but feel free to request if needed.

Example of full message 
```
ModelWithMissingEnumColumn wants to use the column 'gender' but it does not exist.
Try adding the column to the table...
       
         ▸ Generate a migration:
       
             lucky gen.migration AddGenderToModelWithMissingEnumColumns
       
         ▸ Add the column to the migration:
       
             alter :users do
               # Add the column:
               add gender : Int32
       
               # Or if this is a column for a belongs_to relationship:
               add_belongs_to choices : Int32
             end
       
       Or, you can skip schema checks for this model:
       
           class ModelWithMissingEnumColumn < BaseModel
             # Great for models used in migrations, or for legacy schemas
             skip_schema_enforcer
           end
```