### PR TITLE
Fix `DB::ColumnTypeMismatchError` for `Int32` columns in CockroachDB

### DIFF
--- a/spec/avram/migrator/alter_table_statement_spec.cr
+++ b/spec/avram/migrator/alter_table_statement_spec.cr
@@ -32,7 +32,7 @@ describe Avram::Migrator::AlterTableStatement do
       ADD name text,
       ADD email text,
       ADD nickname text NOT NULL,
-      ADD age int NOT NULL DEFAULT '1',
+      ADD age int4 NOT NULL DEFAULT '1',
       ADD num bigint NOT NULL DEFAULT '1',
       ADD amount_paid decimal(10,5) NOT NULL DEFAULT '1.0',
       ADD completed boolean NOT NULL DEFAULT 'false',
@@ -41,7 +41,7 @@ describe Avram::Migrator::AlterTableStatement do
       ADD updated_at timestamptz,
       ADD future_time timestamptz NOT NULL DEFAULT '#{Time.local.to_utc}',
       ADD new_id uuid NOT NULL DEFAULT '46d9b2f0-0718-4d4c-a5a1-5af81d5b11e0',
-      ADD numbers int[],
+      ADD numbers int4[],
       DROP old_column,
       DROP employee_id;
     SQL
@@ -73,7 +73,7 @@ describe Avram::Migrator::AlterTableStatement do
     built.statements[0].should eq "ALTER TABLE users ALTER COLUMN id SET DATA TYPE bigint;"
     built.statements[1].should eq "ALTER TABLE users ALTER COLUMN age SET DATA TYPE decimal(1,2);"
     built.statements[2].should eq "ALTER TABLE users ALTER COLUMN name SET DATA TYPE citext;"
-    built.statements[3].should eq "ALTER TABLE users ALTER COLUMN total_score SET DATA TYPE int;"
+    built.statements[3].should eq "ALTER TABLE users ALTER COLUMN total_score SET DATA TYPE int4;"
   end
 
   it "can change column defaults" do

--- a/spec/avram/migrator/create_table_statement_spec.cr
+++ b/spec/avram/migrator/create_table_statement_spec.cr
@@ -28,11 +28,11 @@ describe Avram::Migrator::CreateTableStatement do
     built.statements.size.should eq 1
     built.statements.first.should eq <<-SQL
     CREATE TABLE users (
-      id serial PRIMARY KEY,
+      id serial4 PRIMARY KEY,
       created_at timestamptz NOT NULL DEFAULT NOW(),
       updated_at timestamptz NOT NULL DEFAULT NOW(),
       name text NOT NULL,
-      age int NOT NULL,
+      age int4 NOT NULL,
       completed boolean NOT NULL,
       joined_at timestamptz NOT NULL,
       amount_paid decimal(10,2) NOT NULL,
@@ -130,7 +130,7 @@ describe Avram::Migrator::CreateTableStatement do
     CREATE TABLE users (
       name text NOT NULL DEFAULT 'name',
       email text DEFAULT 'optional',
-      age int NOT NULL DEFAULT '1',
+      age int4 NOT NULL DEFAULT '1',
       num bigint NOT NULL DEFAULT '1',
       amount_paid decimal NOT NULL DEFAULT '1.0',
       completed boolean NOT NULL DEFAULT 'false',
@@ -157,7 +157,7 @@ describe Avram::Migrator::CreateTableStatement do
       built.statements.first.should eq <<-SQL
       CREATE TABLE users (
         name text NOT NULL,
-        age int NOT NULL,
+        age int4 NOT NULL,
         email text NOT NULL);
       SQL
       built.statements[1].should eq "CREATE INDEX users_name_index ON users USING btree (name);"

--- a/src/avram/migrator/columns/int32_column.cr
+++ b/src/avram/migrator/columns/int32_column.cr
@@ -8,7 +8,7 @@ module Avram::Migrator::Columns
     end
 
     def column_type : String
-      "int"
+      "int4"
     end
   end
 end

--- a/src/avram/migrator/columns/primary_keys/int32_primary_key.cr
+++ b/src/avram/migrator/columns/primary_keys/int32_primary_key.cr
@@ -6,7 +6,7 @@ module Avram::Migrator::Columns::PrimaryKeys
     end
 
     def column_type : String
-      "serial"
+      "serial4"
     end
   end
 end


### PR DESCRIPTION
Fixes #919

There's no specs, though; can't think of any.