### PR TITLE
Fix `TypeCastError` with `#select_sum` in CockroachDB

### DIFF
--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -47,7 +47,12 @@ struct Int16
       include Avram::BetweenCriteria(T, V)
 
       def select_sum : Int64?
-        super.as(Int64?)
+        case sum = super
+        when PG::Numeric
+          sum.to_f.to_i64
+        when Int
+          sum.to_i64
+        end
       end
 
       def select_sum! : Int64

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -48,7 +48,12 @@ struct Int32
       include Avram::IncludesCriteria(T, V)
 
       def select_sum : Int64?
-        super.as(Int64?)
+        case sum = super
+        when PG::Numeric
+          sum.to_f.to_i64
+        when Int
+          sum.to_i64
+        end
       end
 
       def select_sum! : Int64

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -46,8 +46,11 @@ struct Int64
       include Avram::IncludesCriteria(T, V)
 
       def select_sum : Int64?
-        if sum = super
-          sum.as(PG::Numeric).to_f.to_i64
+        case sum = super
+        when PG::Numeric
+          sum.to_f.to_i64
+        when Int
+          sum.to_i64
         end
       end
 


### PR DESCRIPTION
Related to #920

```
cast from PG::Numeric to (Int64 | Nil) failed, at /path/to/lib/avram/src/avram/charms/int32_extensions.cr:51:9:51 (TypeCastError)
    from lib/avram/src/avram/charms/int32_extensions.cr:51:9 in 'select_sum'
    from lib/avram/src/avram/charms/int32_extensions.cr:55:9 in 'select_sum!'
    # ...
```