### PR TITLE
Release v1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: avram
-version: 1.0.0-rc1
+version: 1.0.0
 
 crystal: ">= 1.6.0"
 

--- a/shard.yml
+++ b/shard.yml
@@ -47,8 +47,7 @@ development_dependencies:
     version: ~> 1.3
   lucky:
     github: luckyframework/lucky
-    #version: ">= 1.0.0-rc1"
-    branch: main
+    version: ">= 1.0.0"
 
 scripts:
   postinstall: BUILD_WITHOUT_DEVELOPMENT=true script/precompile_tasks

--- a/src/avram/version.cr
+++ b/src/avram/version.cr
@@ -1,3 +1,3 @@
 module Avram
-  VERSION = "1.0.0-rc1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
At this point, I don't think anything is holding back just calling it 1.0.0. There's been several fixes and additions to really make this version more solid. We can now lock in this interface and start thinking about changes to the structure for a 2.0 in the future.