### PR TITLE
Refine CRUD templates

### DIFF
--- a/src/lucky/tasks/gen/templates/resource/pages/edit_page.cr.ecr
+++ b/src/lucky/tasks/gen/templates/resource/pages/edit_page.cr.ecr
@@ -4,7 +4,7 @@ class <%= pluralized_name %>::EditPage < MainLayout
   quick_def page_title, "Edit <%= resource %> with id: #{<%= underscored_resource %>.id}"
 
   def content
-    link "Back to all <%= pluralized_name %>", <%= pluralized_name %>::Index
+    link "Back to all <%= pluralized_name %>", to: <%= pluralized_name %>::Index
     h1 "Edit <%= resource %> with id: #{<%= underscored_resource %>.id}"
     render_<%= underscored_resource %>_form(operation)
   end

--- a/src/lucky/tasks/gen/templates/resource/pages/index_page.cr.ecr
+++ b/src/lucky/tasks/gen/templates/resource/pages/index_page.cr.ecr
@@ -12,7 +12,7 @@ class <%= pluralized_name %>::IndexPage < MainLayout
     ul do
       <%= pluralized_name.underscore %>.each do |<%= underscored_resource %>|
         li do
-          link <%= underscored_resource %>.<%= columns.first.name %>, <%= pluralized_name %>::Show.with(<%= underscored_resource %>)
+          link <%= underscored_resource %>.<%= columns.first.name %>, to: <%= pluralized_name %>::Show.with(<%= underscored_resource %>)
         end
       end
     end

--- a/src/lucky/tasks/gen/templates/resource/pages/show_page.cr.ecr
+++ b/src/lucky/tasks/gen/templates/resource/pages/show_page.cr.ecr
@@ -3,7 +3,7 @@ class <%= pluralized_name %>::ShowPage < MainLayout
   quick_def page_title, "<%= resource %> with id: #{<%= underscored_resource %>.id}"
 
   def content
-    link "Back to all <%= pluralized_name %>", <%= pluralized_name %>::Index
+    link "Back to all <%= pluralized_name %>", to: <%= pluralized_name %>::Index
     h1 "<%= resource %> with id: #{<%= underscored_resource %>.id}"
     render_actions
     render_<%= underscored_resource %>_fields
@@ -11,10 +11,10 @@ class <%= pluralized_name %>::ShowPage < MainLayout
 
   def render_actions
     section do
-      link "Edit", <%= pluralized_name %>::Edit.with(<%= underscored_resource %>.id)
+      link "Edit", to: <%= pluralized_name %>::Edit.with(<%= underscored_resource %>.id)
       text " | "
       link "Delete",
-        <%= pluralized_name %>::Delete.with(<%= underscored_resource %>.id),
+        to: <%= pluralized_name %>::Delete.with(<%= underscored_resource %>.id),
         data_confirm: "Are you sure?"
     end
   end


### PR DESCRIPTION
1. links use non keyword argument form.
2. Remove unnecessary namespaces.
