### PR TITLE
Removes the need for pg client tools

### DIFF
--- a/config/database.cr
+++ b/config/database.cr
@@ -15,6 +15,18 @@ TestDatabase.configure do |settings|
   )
 end
 
+class SampleBackupDatabase < Avram::Database
+end
+
+SampleBackupDatabase.configure do |settings|
+  settings.credentials = Avram::Credentials.parse?(ENV["BACKUP_DATABASE_URL"]?) || Avram::Credentials.new(
+    hostname: "db",
+    database: "sample_backup",
+    username: "lucky",
+    password: "developer"
+  )
+end
+
 DatabaseWithIncorrectSettings.configure do |settings|
   settings.credentials = Avram::Credentials.new(
     hostname: "db",

--- a/spec/avram/migrator/runner_spec.cr
+++ b/spec/avram/migrator/runner_spec.cr
@@ -11,4 +11,37 @@ describe Avram::Migrator::Runner do
       end
     end
   end
+
+  describe ".create_db" do
+    context "when the DB doesn't exist yet" do
+      it "creates the new DB" do
+        Avram.temp_config(database_to_migrate: SampleBackupDatabase) do
+          Avram::Migrator::Runner.create_db(quiet?: true)
+
+          DB.open(SampleBackupDatabase.credentials.url) do |db|
+            results = db.query_all("SELECT datname FROM pg_database WHERE datistemplate = false", as: String)
+            results.should contain("sample_backup")
+          end
+          # ensure it's deleted before moving on to another spec
+          Avram::Migrator::Runner.drop_db(quiet?: true)
+        end
+      end
+    end
+  end
+
+  describe ".drop_db" do
+    context "when it already exists" do
+      it "drops the DB" do
+        Avram.temp_config(database_to_migrate: SampleBackupDatabase) do
+          Avram::Migrator::Runner.create_db(quiet?: true)
+          Avram::Migrator::Runner.drop_db(quiet?: true)
+
+          expect_raises(DB::ConnectionRefused) do
+            DB.open(SampleBackupDatabase.credentials.url) do |_|
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/avram/tasks/db_create_spec.cr
+++ b/spec/avram/tasks/db_create_spec.cr
@@ -1,11 +1,9 @@
 require "../../spec_helper"
 
 describe Db::Create do
-  # This is currently failing with the wrong message.
-  # it may be related to https://github.com/actions/virtual-environments/issues/4269
-  pending "raises a connection error when unable to connect" do
+  it "raises a connection error when unable to connect" do
     Avram.temp_config(database_to_migrate: DatabaseWithIncorrectSettings) do
-      expect_raises(Exception, /It looks like Postgres is not running/) do
+      expect_raises(Avram::ConnectionError, /Failed to connect to database/) do
         Db::Create.new(quiet: true).run_task
       end
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -34,18 +34,6 @@ Spec.before_each do
   Fiber.current.query_cache = LuckyCache::NullStore.new
 end
 
-class SampleBackupDatabase < Avram::Database
-end
-
-SampleBackupDatabase.configure do |settings|
-  settings.credentials = Avram::Credentials.parse?(ENV["BACKUP_DATABASE_URL"]?) || Avram::Credentials.new(
-    hostname: "db",
-    database: "sample_backup",
-    username: "lucky",
-    password: "developer"
-  )
-end
-
 Lucky::Session.configure do |settings|
   settings.key = "_app_session"
 end

--- a/src/avram/connection.cr
+++ b/src/avram/connection.cr
@@ -1,10 +1,17 @@
 # Handles the connection to the DB.
 class Avram::Connection
+  private getter db : DB::Database? = nil
+
   def initialize(@connection_string : String, @database_class : Avram::Database.class)
   end
 
   def open : DB::Database
-    try_connection!
+    @db = try_connection!
+  end
+
+  def close
+    @db.try(&.close)
+    @db = nil
   end
 
   def connect_listen(*channels : String, &block : PQ::Notification ->) : Nil

--- a/src/avram/credentials.cr
+++ b/src/avram/credentials.cr
@@ -80,6 +80,17 @@ class Avram::Credentials
     @query.try(&.strip).presence
   end
 
+  # This is the full connection string used
+  # to connect to the PostgreSQL server.
+  def connection_string : String
+    String.build do |io|
+      set_url_protocol(io)
+      set_url_creds(io)
+      set_url_host(io)
+      set_url_port(io)
+    end
+  end
+
   # Returns the postgres connection string without
   # any query params.
   def url_without_query_params : String
@@ -88,10 +99,7 @@ class Avram::Credentials
 
   private def build_url
     String.build do |io|
-      set_url_protocol(io)
-      set_url_creds(io)
-      set_url_host(io)
-      set_url_port(io)
+      io << connection_string
       set_url_db(io)
       set_url_query(io)
     end

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -158,6 +158,12 @@ abstract class Avram::Database
     end
   end
 
+  # Close all available connections as well as the DB
+  def self.close_connections
+    connections.values.map(&.close)
+    @@db.try(&.close)
+  end
+
   # :nodoc:
   def listen(*channels : String, &block : PQ::Notification ->) : Nil
     connection.connect_listen(*channels, &block)

--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -159,7 +159,7 @@ abstract class Avram::Database
   end
 
   # Close all available connections as well as the DB
-  def self.close_connections
+  def self.close_connections!
     connections.values.map(&.close)
     @@db.try(&.close)
   end

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -48,33 +48,35 @@ class Avram::Migrator::Runner
   end
 
   def self.drop_db(quiet? : Bool = false)
-    run "dropdb #{cmd_args}"
+    DB.connect(credentials.connection_string) do |db|
+      db.exec "DROP DATABASE IF EXISTS #{db_name}"
+    end
     unless quiet?
       puts "Done dropping #{Avram::Migrator::Runner.db_name.colorize(:green)}"
-    end
-  rescue e : Exception
-    if (message = e.message) && message.includes?(%("#{self.db_name}" does not exist))
-      unless quiet?
-        puts "Already dropped #{self.db_name.colorize(:green)}"
-      end
-    else
-      raise e
     end
   end
 
   def self.create_db(quiet? : Bool = false)
-    run "createdb #{cmd_args}"
+    DB.connect(credentials.connection_string) do |db|
+      db.exec "CREATE DATABASE #{db_name} WITH OWNER DEFAULT"
+    end
     unless quiet?
-      puts "Done creating #{Avram::Migrator::Runner.db_name.colorize(:green)}"
+      puts "Done creating #{db_name.colorize(:green)}"
+    end
+  rescue e : DB::ConnectionRefused
+    message = e.message.to_s
+    if message.blank?
+      raise ConnectionError.new(URI.parse(credentials.url_without_query_params), Avram.settings.database_to_migrate)
+    else
+      raise e
     end
   rescue e : Exception
-    if (message = e.message) && message.includes?(%("#{self.db_name}" already exists))
+    message = e.message.to_s
+    if message.includes?(%("#{self.db_name}" already exists))
       unless quiet?
         puts "Already created #{self.db_name.colorize(:green)}"
       end
-    elsif (message = e.message) && (message.includes?("createdb: not found") || message.includes?("No command 'createdb' found"))
-      raise PGClientNotInstalledError.new(message)
-    elsif (message = e.message) && message.includes?("could not connect to database template")
+    elsif message.includes?("Cannot establish connection")
       raise PGNotRunningError.new(message)
     else
       raise e

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -48,7 +48,7 @@ class Avram::Migrator::Runner
   end
 
   def self.drop_db(quiet? : Bool = false)
-    DB.connect(credentials.connection_string) do |db|
+    DB.connect("#{credentials.connection_string}/#{db_user}") do |db|
       db.exec "DROP DATABASE IF EXISTS #{db_name}"
     end
     unless quiet?
@@ -57,7 +57,7 @@ class Avram::Migrator::Runner
   end
 
   def self.create_db(quiet? : Bool = false)
-    DB.connect(credentials.connection_string) do |db|
+    DB.connect("#{credentials.connection_string}/#{db_user}") do |db|
       db.exec "CREATE DATABASE #{db_name} WITH OWNER DEFAULT"
     end
     unless quiet?


### PR DESCRIPTION
Fixes #926

This doesn't fully remove the need for it, but it does remove the need for it when doing `db.create` and `db.drop` tasks.

The two main areas still remaining are `db.schema.dump` and `db.schema.restore` tasks which currently require `psql` and `pg_dump` to exist. I would like to somehow catch those and raise some sort of error before you run them. Right now if you don't have pg client tools installed and try to run either of those, you'll just end up with some exceptions saying it couldn't find those commands. Not horrible, but not great...

After doing this, there was some weird things that came up. Previously you could do this:

```crystal
SomeDatabase.run do |db|
  db.exec "SELECT some_sql"
end

DB::Drop.run_task
```

That seemed to be ok maybe because it was running `dropdb` from the CLI? :man_shrugging:  However, now, this raises an exception saying the that DB is currently in use. I guess this is a good thing, but it required adding a way to ensure all connections and the DB were fully closed. I'll add some more comments on this PR