### PR TITLE
Suppress logging in migrator

### DIFF
--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -28,15 +28,17 @@ abstract class Avram::Migrator::Migration::V1
   # @prepared_statements array. Each statement is then executed in  a
   # transaction and tracked upon completion.
   def up(quiet = false)
-    if migrated?
-      puts "Already migrated #{self.class.name.colorize(:cyan)}"
-    else
-      reset_prepared_statements
-      migrate
-      execute_in_transaction @prepared_statements do |tx|
-        track_migration(tx)
-        unless quiet
-          puts "Migrated #{self.class.name.colorize(:green)}"
+    suppress_logging do
+      if migrated?
+        puts "Already migrated #{self.class.name.colorize(:cyan)}"
+      else
+        reset_prepared_statements
+        migrate
+        execute_in_transaction @prepared_statements do |tx|
+          track_migration(tx)
+          unless quiet
+            puts "Migrated #{self.class.name.colorize(:green)}"
+          end
         end
       end
     end
@@ -44,15 +46,17 @@ abstract class Avram::Migrator::Migration::V1
 
   # Same as #up except calls rollback method in migration.
   def down(quiet = false)
-    if pending?
-      puts "Already rolled back #{self.class.name.colorize(:cyan)}"
-    else
-      reset_prepared_statements
-      rollback
-      execute_in_transaction @prepared_statements do |tx|
-        untrack_migration(tx)
-        unless quiet
-          puts "Rolled back #{self.class.name.colorize(:green)}"
+    suppress_logging do
+      if pending?
+        puts "Already rolled back #{self.class.name.colorize(:cyan)}"
+      else
+        reset_prepared_statements
+        rollback
+        execute_in_transaction @prepared_statements do |tx|
+          untrack_migration(tx)
+          unless quiet
+            puts "Rolled back #{self.class.name.colorize(:green)}"
+          end
         end
       end
     end
@@ -63,9 +67,11 @@ abstract class Avram::Migrator::Migration::V1
   end
 
   def migrated?
-    Avram.settings
-      .database_to_migrate
-      .query_one? "SELECT id FROM migrations WHERE version = $1", version, as: MigrationId
+    suppress_logging do
+      Avram.settings
+        .database_to_migrate
+        .query_one? "SELECT id FROM migrations WHERE version = $1", version, as: MigrationId
+    end
   end
 
   private def track_migration(db : Avram::Database.class)
@@ -103,5 +109,11 @@ abstract class Avram::Migrator::Migration::V1
 
   def reset_prepared_statements
     @prepared_statements = [] of String
+  end
+
+  private def suppress_logging
+    Avram::QueryLog.dexter.temp_config(level: :none) do
+      yield
+    end
   end
 end

--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -112,6 +112,8 @@ abstract class Avram::Migrator::Migration::V1
   end
 
   private def suppress_logging(&block)
-    Avram::QueryLog.dexter.temp_config(level: :none, &block)
+    Avram::QueryLog.dexter.temp_config(level: :none) do
+      return yield
+    end
   end
 end

--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -111,7 +111,7 @@ abstract class Avram::Migrator::Migration::V1
     @prepared_statements = [] of String
   end
 
-  private def suppress_logging(&block)
+  private def suppress_logging(&)
     Avram::QueryLog.dexter.temp_config(level: :none) do
       return yield
     end

--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -111,9 +111,7 @@ abstract class Avram::Migrator::Migration::V1
     @prepared_statements = [] of String
   end
 
-  private def suppress_logging
-    Avram::QueryLog.dexter.temp_config(level: :none) do
-      yield
-    end
+  private def suppress_logging(&block)
+    Avram::QueryLog.dexter.temp_config(level: :none, &block)
   end
 end

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -138,7 +138,7 @@ class Avram::Migrator::Runner
     end
   end
 
-  private def self.suppress_logging(&block)
+  private def self.suppress_logging(&)
     Avram::QueryLog.dexter.temp_config(level: :none) do
       return yield
     end

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -139,7 +139,9 @@ class Avram::Migrator::Runner
   end
 
   private def self.suppress_logging(&block)
-    Avram::QueryLog.dexter.temp_config(level: :none, &block)
+    Avram::QueryLog.dexter.temp_config(level: :none) do
+      return yield
+    end
   end
 
   def run_pending_migrations

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -138,10 +138,8 @@ class Avram::Migrator::Runner
     end
   end
 
-  private def self.suppress_logging
-    Avram::QueryLog.dexter.temp_config(level: :none) do
-      yield
-    end
+  private def self.suppress_logging(&block)
+    Avram::QueryLog.dexter.temp_config(level: :none, &block)
   end
 
   def run_pending_migrations


### PR DESCRIPTION
Fixes #937

The initializer of `Avram::Migrator::Runner` re-configures the avram logger to be level `:none`. The runner is instantiated in development during `start_server.cr` to ensure that migrations have been run (after configuration has been loaded). The change was introduced in https://github.com/luckyframework/avram/pull/780

I am assuming the intention was to suppress the logging when the migrator is checking if migrations have run, creating schema tables etc. Instead I have added `suppress_logging` method that uses dexter to temporarily set the level to `:none` and reset after. There might be a nicer way of doing this but there doesn't appear to be a single entrypoint into the migrator that can be configured. 
