### PR TITLE
Adding JSON serialized Array columns

### DIFF
--- a/db/migrations/20230624134902_add_json_array_to_blob.cr
+++ b/db/migrations/20230624134902_add_json_array_to_blob.cr
@@ -1,0 +1,13 @@
+class AddJsonArrayToBlob::V20230624134902 < Avram::Migrator::Migration::V1
+  def migrate
+    alter table_for(Blob) do
+      add servers : JSON::Any, default: JSON::Any.new({} of String => JSON::Any)
+    end
+  end
+
+  def rollback
+    alter table_for(Blob) do
+      remove :servers
+    end
+  end
+end

--- a/db/migrations/20230624134902_add_json_array_to_blob.cr
+++ b/db/migrations/20230624134902_add_json_array_to_blob.cr
@@ -1,7 +1,7 @@
 class AddJsonArrayToBlob::V20230624134902 < Avram::Migrator::Migration::V1
   def migrate
     alter table_for(Blob) do
-      add servers : JSON::Any, default: JSON::Any.new({} of String => JSON::Any)
+      add servers : JSON::Any, default: JSON::Any.new([] of JSON::Any)
     end
   end
 

--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -1151,17 +1151,17 @@ describe Avram::Queryable do
         blob = BlobFactory.new.doc(JSON::Any.new({"foo" => JSON::Any.new("bar")})).create
 
         query = JSONQuery.new.static_foo
-        query.to_sql.should eq ["SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc, blobs.metadata, blobs.media FROM blobs WHERE blobs.doc = $1", "{\"foo\":\"bar\"}"]
+        query.to_sql.should eq ["SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc, blobs.metadata, blobs.media, blobs.servers FROM blobs WHERE blobs.doc = $1", "{\"foo\":\"bar\"}"]
         result = query.first
         result.should eq blob
 
         query2 = JSONQuery.new.foo_with_value("bar")
-        query2.to_sql.should eq ["SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc, blobs.metadata, blobs.media FROM blobs WHERE blobs.doc = $1", "{\"foo\":\"bar\"}"]
+        query2.to_sql.should eq ["SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc, blobs.metadata, blobs.media, blobs.servers FROM blobs WHERE blobs.doc = $1", "{\"foo\":\"bar\"}"]
         result = query2.first
         result.should eq blob
 
         query3 = JSONQuery.new.foo_with_value("baz")
-        query3.to_sql.should eq ["SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc, blobs.metadata, blobs.media FROM blobs WHERE blobs.doc = $1", "{\"foo\":\"baz\"}"]
+        query3.to_sql.should eq ["SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc, blobs.metadata, blobs.media, blobs.servers FROM blobs WHERE blobs.doc = $1", "{\"foo\":\"baz\"}"]
         expect_raises(Avram::RecordNotFoundError) do
           query3.first
         end
@@ -1564,7 +1564,7 @@ describe Avram::Queryable do
       query.to_prepared_sql.should eq(%{SELECT #{Bucket::COLUMN_SQL} FROM buckets WHERE buckets.names = '{"Larry","Moe","Curly"}' AND buckets.numbers = '{1,2,3}'})
 
       query = Blob::BaseQuery.new.doc(JSON::Any.new({"properties" => JSON::Any.new("sold")}))
-      query.to_prepared_sql.should eq(%{SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc, blobs.metadata, blobs.media FROM blobs WHERE blobs.doc = '{"properties":"sold"}'})
+      query.to_prepared_sql.should eq(%{SELECT blobs.id, blobs.created_at, blobs.updated_at, blobs.doc, blobs.metadata, blobs.media, blobs.servers FROM blobs WHERE blobs.doc = '{"properties":"sold"}'})
 
       query = UserQuery.new.name.in(["Don", "Juan"]).age.gt(30)
       query.to_prepared_sql.should eq(%{SELECT #{User::COLUMN_SQL} FROM users WHERE users.name = ANY ('{"Don","Juan"}') AND users.age > '30'})

--- a/spec/support/factories/blob_factory.cr
+++ b/spec/support/factories/blob_factory.cr
@@ -1,7 +1,8 @@
 class BlobFactory < BaseFactory
   def initialize
-    doc JSON::Any.new({"foo" => JSON::Any.new("bar")})
+    doc(JSON::Any.new({"foo" => JSON::Any.new("bar")}))
     metadata(BlobMetadata.from_json({name: "Test", code: 4}.to_json))
-    media nil
+    media(nil)
+    servers(Array(ServerMetadata).from_json(%([{"host":"server.io"}])))
   end
 end

--- a/spec/support/models/blob.cr
+++ b/spec/support/models/blob.cr
@@ -11,10 +11,16 @@ class MediaMetadata
   property image : String?
 end
 
+class ServerMetadata
+  include JSON::Serializable
+  property host : String
+end
+
 class Blob < BaseModel
   table do
     column doc : JSON::Any?
     column metadata : BlobMetadata, serialize: true
-    column media : MediaMetadata?, serialize: true
+    column media : MediaMetadata? = nil, serialize: true
+    column servers : Array(ServerMetadata) = Array(ServerMetadata).from_json("[]"), serialize: true
   end
 end

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -16,13 +16,21 @@ module JSON::Serializable
       value
     end
 
+    def parse(value : Array(JS)) forall JS
+      SuccessfulCast(Array(JS)).new value
+    end
+
     def parse(value : JSON::Serializable)
       SuccessfulCast(JSON::Serializable).new value
     end
 
-    def parse(value)
-      SuccessfulCast(JSON::Serializable).new T.from_json(value)
-    end
+    # def parse(value : String)
+    #   if value.starts_with?('[')
+    #     SuccessfulCast(JSON::Serializable).new Array(T).from_json(value)
+    #   else
+    #     SuccessfulCast(JSON::Serializable).new T.from_json(value)
+    #   end
+    # end
 
     def to_db(value) : String
       value.to_json

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -16,21 +16,13 @@ module JSON::Serializable
       value
     end
 
-    def parse(value : Array(JS)) forall JS
-      SuccessfulCast(Array(JS)).new value
+    def parse(value : Array(T))
+      SuccessfulCast(Array(T)).new value
     end
 
     def parse(value : JSON::Serializable)
       SuccessfulCast(JSON::Serializable).new value
     end
-
-    # def parse(value : String)
-    #   if value.starts_with?('[')
-    #     SuccessfulCast(JSON::Serializable).new Array(T).from_json(value)
-    #   else
-    #     SuccessfulCast(JSON::Serializable).new T.from_json(value)
-    #   end
-    # end
 
     def to_db(value) : String
       value.to_json


### PR DESCRIPTION
Fixes #845

This PR allows you to convert your json arrays in to an array of serialized objects.. One thing to note about this PR is that it's only supporting `'[]'::jsonb` and *not* `[]::jsonb[]`. The distinction here is that the column is still stored as `jsonb`, but it allows that json string to be parsed as an array VS using postgres's ARRAY column to store an array of jsonb objects.

I think we could eventually do that one too by just saying that the column isn't serialized, but that can be for a future PR.

With this, you can now do something like:

```crystal
struct Server
  include JSON::Serializable
  property host : String
end

class Monitor < BaseModel
  table do
    column input_server : Server
    column output_servers : Array(Server)
  end
end

in_server = Server.from_json(%({"host":"x.y.z"}))
out_servers = Array(Server).from_json(%([{"host":"a.b.c"}, {"host":"d.e.f"}]))

SaveMonitor.create!(input_servers: in_server, output_servers: out_servers)

m = MonitorQuery.new.first
m.output_servers.first.host == "a.b.c"
```