### PR TITLE
Adding a new belongs_to association for factories.

### DIFF
--- a/spec/avram/factory_spec.cr
+++ b/spec/avram/factory_spec.cr
@@ -1,5 +1,24 @@
 require "../spec_helper"
 
+class TempComment < BaseModel
+  skip_default_columns
+  table :comments do
+    primary_key custom_id : Int64
+    timestamps
+    column body : String
+    belongs_to post : Post
+  end
+end
+
+class TempCommentFactory < Avram::Factory
+  belongs_to post : PostFactory
+
+  def initialize
+    body("Test Comment")
+    create_post(&.title("Test Post"))
+  end
+end
+
 describe Avram::Factory do
   it "can create a model without additional columns" do
     PlainModelFactory.create.id.should_not be_nil
@@ -96,6 +115,23 @@ describe Avram::Factory do
 
       line_item = LineItemFactory.create &.with_scan
       line_item.scans_count.should eq 1
+    end
+  end
+
+  describe "belongs_to" do
+    it "creates an associated record" do
+      factory = TempCommentFactory.new
+      factory.body("a comment")
+      comment = factory.create
+      comment.body.should eq("a comment")
+      comment.post.title.should eq("Test Post")
+    end
+    it "allows overriding the association" do
+      post = PostFactory.create &.title("some title")
+      comment = TempCommentFactory.create &.post(post).body("some body")
+      comment.body.should eq("some body")
+      comment.post_id.should eq(post.id)
+      comment.post.title.should eq("some title")
     end
   end
 end


### PR DESCRIPTION
Fixes #385

This PR adds in a new `belongs_to` association macro for Factory that allows you to association another model and build on demand.

```crystal
class ProductFactory < Avram::Factory
  belongs_to store : StoreFactory

  def initialize
    title "Cool Thing"
    create_store(&.name("Example Store"))
  end
end

# You can use it many different ways

product = ProductFactory.create
product.store.name == "Example Store"

product = ProductFactory.create(&.create_store(&.name("Different Store")))
product.store.name == "Different Store"

store = StoreFactory.create(&.name("Evil Store"))
product = ProductFactory.create &.store(store)
product.store_id == store.id
```

One weird thing I ran in to is naming order with requires, but I think that's just a Crystal thing...

For example, with a `require "./factories/**"`, doing this will throw a `undefined constant PostFactory` because in alphabetical order, "PostFactory" comes after "CommentFactory", so the file hasn't been loaded. You'd just need to do an extra `require "./post_factory"` at the top if that's the case...

```crystal
class CommentFactory < BaseFactory
  belongs_to post : PostFactory
end
```