### PR TITLE
Removing the default logging initializing for flexibiltiy

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -19,6 +19,8 @@ backend = Log::IOBackend.new(STDERR)
 backend.formatter = Dexter::JSONLogFormatter.proc
 Log.builder.bind("avram.*", :error, backend)
 
+Avram.initialize_logging
+
 Db::Create.new(quiet: true).run_task
 Db::Migrate.new(quiet: true).run_task
 Db::VerifyConnection.new(quiet: true).run_task

--- a/src/avram.cr
+++ b/src/avram.cr
@@ -36,6 +36,9 @@ module Avram
 
   alias TableName = String | Symbol
 
+  # This subscribes to several `Pulsar` events.
+  # These events are triggered during query and
+  # operation events
   def self.initialize_logging
     Avram::Events::QueryEvent.subscribe do |event, duration|
       next if event.query.starts_with?("TRUNCATE")
@@ -83,5 +86,3 @@ module Avram
     end
   end
 end
-
-Avram.initialize_logging


### PR DESCRIPTION
Fixes #966

Normally this is enabled the instant you `require "avram"`, but this means you don't have an option to disable this. I think a better spot for your Lucky apps would be to just add that line to your `config/log.cr`. Then if you want to skip these logging events, you can just remove that line. 

This is technically a "breaking change", but it's an easy fix for anyone that needs it just by adding 

```
Avram.initialize_logging
```

somewhere at the start of your app.
