### PR TITLE
Add support for other postgres index types.

### DIFF
--- a/spec/avram/migrator/create_index_statement_spec.cr
+++ b/spec/avram/migrator/create_index_statement_spec.cr
@@ -9,6 +9,20 @@ describe Avram::Migrator::CreateIndexStatement do
     statement.should eq "CREATE UNIQUE INDEX users_email_index ON users USING btree (email);"
   end
 
+  it "supports other index types" do
+    statement = Avram::Migrator::CreateIndexStatement.new(:users, columns: :tags, using: :hash).build
+    statement.should eq "CREATE INDEX users_tags_index ON users USING hash (tags);"
+
+    statement = Avram::Migrator::CreateIndexStatement.new(:users, columns: :tags, using: :gist).build
+    statement.should eq "CREATE INDEX users_tags_index ON users USING gist (tags);"
+
+    statement = Avram::Migrator::CreateIndexStatement.new(:users, columns: :tags, using: :gin).build
+    statement.should eq "CREATE INDEX users_tags_index ON users USING gin (tags);"
+
+    statement = Avram::Migrator::CreateIndexStatement.new(:users, columns: :tags, using: :brin).build
+    statement.should eq "CREATE INDEX users_tags_index ON users USING brin (tags);"
+  end
+
   it "generates correct multi-column index sql" do
     statement = Avram::Migrator::CreateIndexStatement.new(:users, columns: [:email, :username], using: :btree, unique: true).build
     statement.should eq "CREATE UNIQUE INDEX users_email_username_index ON users USING btree (email, username);"

--- a/spec/avram/migrator/create_table_statement_spec.cr
+++ b/spec/avram/migrator/create_table_statement_spec.cr
@@ -166,9 +166,9 @@ describe Avram::Migrator::CreateTableStatement do
     end
 
     it "raises error on columns with non allowed index types" do
-      expect_raises Exception, "index type 'gist' not supported" do
+      expect_raises Exception, "index type 'sp_gist' not supported" do
         Avram::Migrator::CreateTableStatement.new(:users).build do
-          add email : String, index: true, using: :gist
+          add email : String, index: true, using: :sp_gist
         end
       end
     end


### PR DESCRIPTION
Fixes #969

While I was in there already, I just decided to add a few other supported index types. The only one I didn't add was the `sp-gist` which seems to be like `gist` but slightly more limited? I guess if anyone really wants it, we can add it in, but just made the code more complex since I couldn't just `SpGist.to_s.downcase` :grimacing: 