### PR TITLE
Adding support for citext[] arrays.

### DIFF
--- a/db/migrations/20230912145332_add_array_citext_to_buckets.cr
+++ b/db/migrations/20230912145332_add_array_citext_to_buckets.cr
@@ -1,0 +1,13 @@
+class AddArrayCitextToBuckets::V20230912145332 < Avram::Migrator::Migration::V1
+  def migrate
+    alter table_for(Bucket) do
+      add tags : Array(String), default: [] of String, case_sensitive: false
+    end
+  end
+
+  def rollback
+    alter table_for(Bucket) do
+      remove :tags
+    end
+  end
+end

--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -1203,6 +1203,14 @@ describe Avram::Queryable do
         query.select_count.should eq(1)
         query.first.id.should eq(bucket2.id)
       end
+
+      it "queries with citext strings" do
+        BucketFactory.create &.tags(["ONE", "two", "tHrEe"])
+
+        BucketQuery.new.tags.includes("one").select_count.should eq(1)
+        BucketQuery.new.tags.includes("tWo").select_count.should eq(1)
+        BucketQuery.new.tags.includes("THRee").select_count.should eq(1)
+      end
     end
   end
 

--- a/spec/support/models/bucket.cr
+++ b/spec/support/models/bucket.cr
@@ -8,5 +8,8 @@ class Bucket < BaseModel
     column names : Array(String) = [] of String
     column floaty_numbers : Array(Float64) = [] of Float64
     column oody_things : Array(UUID) = [] of UUID
+
+    # These are citext strings
+    column tags : Array(String) = [] of String
   end
 end


### PR DESCRIPTION
Fixes #970

This PR will add support for `citext[]` which is an array of case-insensitive strings. This would allow you to store an array of strings in a column, and query against it without worrying about the casing (e.g. tags)

```crystal
UserQuery.new.tags.includes("aNyCasE")
```

Currently putting this in WIP because Crystal PG doesn't have array decoder support for citext

Ref: https://github.com/will/crystal-pg/pull/250

From what I can tell, when you add in the citext extension, that postgres server will assign citext a custom OID which means the OID may be different on every project, server, etc... Since CrystalPG can't just determine what the type is when using a StringDecoder, it ends up raising an exception.

My guess is once CrystalPG supports it, most of this code will "just work"... However, one tricky part is postgres doesn't seem to auto-cast between `text` and `citext` when it comes to arrays :stuck_out_tongue_closed_eyes:  It can do `WHERE email = 'SuPpOr@blah.COM'` but it can't do `WHERE tags @> array['Crystal']`. You have to cast the array like `array['Crystal']::citext[]`. So if that doesn't auto happen through crystal PG, then we may need to make sure your column definition knows it's a citext somehow. 
