### PR TITLE
Adding missing boolean attributes arg for select input methods.

### DIFF
--- a/spec/lucky/ext/select_helpers_spec.cr
+++ b/spec/lucky/ext/select_helpers_spec.cr
@@ -14,8 +14,20 @@ private class TestPage
     self
   end
 
+  def render_disabled_select(field)
+    select_input field, attrs: [:disabled] do
+    end
+    self
+  end
+
   def render_multi_select(field)
     multi_select_input field do
+    end
+    self
+  end
+
+  def render_disabled_multi_select(field)
+    multi_select_input field, attrs: [:disabled] do
     end
     self
   end
@@ -69,11 +81,19 @@ describe Lucky::SelectHelpers do
     view.render_select(form.company_id).html.to_s.should eq <<-HTML
     <select name="company:company_id"></select>
     HTML
+
+    view.render_disabled_select(form.company_id).html.to_s.should eq <<-HTML
+    <select name="company:company_id" disabled></select>
+    HTML
   end
 
   it "renders multi-select" do
     view.render_multi_select(form.tags).html.to_s.should eq <<-HTML
     <select name="company:tags[]" multiple></select>
+    HTML
+
+    view.render_disabled_multi_select(form.tags).html.to_s.should eq <<-HTML
+    <select name="company:tags[]" multiple disabled></select>
     HTML
   end
 

--- a/src/lucky/ext/select_helpers.cr
+++ b/src/lucky/ext/select_helpers.cr
@@ -1,12 +1,13 @@
 module Lucky::SelectHelpers
-  def select_input(field : Avram::PermittedAttribute, **html_options, &) : Nil
-    select_tag merge_options(html_options, {"name" => input_name(field)}) do
+  def select_input(field : Avram::PermittedAttribute, attrs : Array(Symbol) = [] of Symbol, **html_options, &) : Nil
+    select_tag attrs, merge_options(html_options, {"name" => input_name(field)}) do
       yield
     end
   end
 
-  def multi_select_input(field : Avram::PermittedAttribute(Array), **html_options, &) : Nil
-    select_tag [:multiple], merge_options(html_options, {"name" => input_name(field)}) do
+  def multi_select_input(field : Avram::PermittedAttribute(Array), attrs : Array(Symbol) = [] of Symbol, **html_options, &) : Nil
+    merged_attrs = [:multiple].concat(attrs)
+    select_tag merged_attrs, merge_options(html_options, {"name" => input_name(field)}) do
       yield
     end
   end


### PR DESCRIPTION
Fixes #977

All of the Lucky HTML methods allow for boolean attributes, but the `select_input` and `multi_select_input` were missing them.

```crystal
select_input op.theme, attrs: [:disabled] do

end
```