### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v4
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
@@ -62,7 +62,7 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{matrix.crystal_version}}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: crystal-lang/install-crystal@v1

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -54,7 +54,7 @@ class Avram::Migrator::AlterTableStatement
       name: {{ type_declaration.var.stringify }},
       nilable: {{ nilable }},
       default: nil,
-      {{ **type_options }}
+      {{ type_options.double_splat }}
     )
     add_change_type_statement %column
   end
@@ -226,7 +226,7 @@ class Avram::Migrator::AlterTableStatement
       name: {{ type_declaration.var.stringify }},
       nilable: {{ nilable || should_fill_existing }},
       default: {{ default }},
-      {{ **type_options }}
+      {{ type_options.double_splat }}
     )
     {% if array %}
     .array!

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -119,7 +119,7 @@ class Avram::Migrator::CreateTableStatement
       name: {{ type_declaration.var.stringify }},
       nilable: {{ nilable }},
       default: {{ default }},
-      {{ **type_options }}
+      {{ type_options.double_splat }}
     )
     {% if array %}
     .array!


### PR DESCRIPTION
This fixes some deprecation warnings that came up in the CI from Github Actions and Crystal 1.10 deprecation before Crystal 1.11