### PR TITLE
Adding IF EXISTS and IF NOT EXISTS for migrations

### DIFF
--- a/spec/avram/migrator/alter_table_statement_spec.cr
+++ b/spec/avram/migrator/alter_table_statement_spec.cr
@@ -186,4 +186,24 @@ describe Avram::Migrator::AlterTableStatement do
       end
     end
   end
+
+  context "IF EXISTS" do
+    it "adds the option to the table" do
+      built = Avram::Migrator::AlterTableStatement.new(:users, if_exists: true).build do
+        add name : String?
+        rename :old_name, :new_name
+        rename_belongs_to :owner, :boss
+      end
+
+      built.statements.size.should eq 3
+
+      built.statements[0].should eq "ALTER TABLE IF EXISTS users RENAME COLUMN old_name TO new_name;"
+      built.statements[1].should eq "ALTER TABLE IF EXISTS users RENAME COLUMN owner_id TO boss_id;"
+
+      built.statements[2].should eq <<-SQL
+      ALTER TABLE IF EXISTS users
+        ADD name text;
+      SQL
+    end
+  end
 end

--- a/spec/avram/migrator/create_table_statement_spec.cr
+++ b/spec/avram/migrator/create_table_statement_spec.cr
@@ -236,4 +236,16 @@ describe Avram::Migrator::CreateTableStatement do
       end
     end
   end
+
+  context "IF NOT EXISTS" do
+    it "adds the option to the table" do
+      built = Avram::Migrator::CreateTableStatement.new(:users, if_not_exists: true).build do
+      end
+
+      built.statements.size.should eq 1
+      built.statements.first.should eq <<-SQL
+      CREATE TABLE IF NOT EXISTS users (\n);
+      SQL
+    end
+  end
 end

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -7,8 +7,9 @@ class Avram::Migrator::CreateTableStatement
 
   private getter rows = [] of String
   private getter constraints = [] of String
+  private getter? if_not_exists : Bool = false
 
-  def initialize(@table_name : TableName)
+  def initialize(@table_name : TableName, *, @if_not_exists : Bool = false)
   end
 
   # Accepts a block to build a table and indices using `add` and `add_index` methods.
@@ -54,7 +55,7 @@ class Avram::Migrator::CreateTableStatement
 
   private def table_statement
     String.build do |statement|
-      statement << initial_table_statement
+      initial_table_statement(statement)
       statement << rows.join(",\n")
       statement << ",\n" if !constraints.empty?
       statement << constraints.join(", \n")
@@ -62,10 +63,11 @@ class Avram::Migrator::CreateTableStatement
     end
   end
 
-  private def initial_table_statement
-    <<-SQL
-    CREATE TABLE #{@table_name} (\n
-    SQL
+  private def initial_table_statement(io)
+    io << "CREATE TABLE "
+    io << "IF NOT EXISTS " if if_not_exists?
+    io << @table_name
+    io << " (\n"
   end
 
   macro primary_key(type_declaration)

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -4,8 +4,8 @@ module Avram::Migrator::StatementHelpers
   include Avram::Migrator::IndexStatementHelpers
   include Avram::TableFor
 
-  macro create(table_name)
-    statements = Avram::Migrator::CreateTableStatement.new({{ table_name }}).build do
+  macro create(table_name, *, if_not_exists = false)
+    statements = Avram::Migrator::CreateTableStatement.new({{ table_name }}, if_not_exists: {{ if_not_exists }}).build do
       {{ yield }}
     end.statements
 
@@ -18,8 +18,8 @@ module Avram::Migrator::StatementHelpers
     prepared_statements << Avram::Migrator::DropTableStatement.new(table_name).build
   end
 
-  macro alter(table_name)
-    statements = Avram::Migrator::AlterTableStatement.new({{ table_name }}).build do
+  macro alter(table_name, *, if_exists = false)
+    statements = Avram::Migrator::AlterTableStatement.new({{ table_name }}, if_exists: {{ if_exists }}).build do
       {{ yield }}
     end.statements
 


### PR DESCRIPTION
Fixes #988

This adds in the option to specify `if_not_exists` for the `create` table macro and `if_exists` for the `alter` table macro

```crystal
def migrate
  create :reports, if_not_exists: true do
    # ...
  end
end

def migrate
  alter :reports, if_exists: true do
    # ...
  end
end
```