### PR TITLE
Revert and cleanup the verify_connection task

### DIFF
--- a/spec/avram/tasks/db_verify_connection_spec.cr
+++ b/spec/avram/tasks/db_verify_connection_spec.cr
@@ -1,11 +1,18 @@
 require "../../spec_helper"
 
 describe Db::VerifyConnection do
+  it "runs a test connection" do
+    task = Db::VerifyConnection.new
+    task.output = IO::Memory.new
+    task.run_task
+    task.output.to_s.should contain "Connection verified"
+  end
+
   it "throws a helpful error" do
     creds = Avram::Credentials.parse("postgres://eat@joes/crab_shack")
     TestDatabase.temp_config(credentials: creds) do
       expect_raises Exception, /Unable to connect to Postgres for database 'TestDatabase'/ do
-        Db::VerifyConnection.new.run_task
+        task = Db::VerifyConnection.new.run_task
       end
     end
   end

--- a/spec/avram/tasks/db_verify_connection_spec.cr
+++ b/spec/avram/tasks/db_verify_connection_spec.cr
@@ -12,7 +12,7 @@ describe Db::VerifyConnection do
     creds = Avram::Credentials.parse("postgres://eat@joes/crab_shack")
     TestDatabase.temp_config(credentials: creds) do
       expect_raises Exception, /Unable to connect to Postgres for database 'TestDatabase'/ do
-        task = Db::VerifyConnection.new.run_task
+        Db::VerifyConnection.new.run_task
       end
     end
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -23,7 +23,6 @@ Avram.initialize_logging
 
 Db::Create.new(quiet: true).run_task
 Db::Migrate.new(quiet: true).run_task
-Db::VerifyConnection.new(quiet: true).run_task
 
 Avram::SpecHelper.use_transactional_specs(TestDatabase)
 


### PR DESCRIPTION
Fixes #902

We've had users in the past that get started with Lucky and have a horrible first experience because their setup script never completes. In this last case, it was only the `verify_connection` task that was failing, but not very apparent. We used to have the code work this way, but changed it to call `open.close`. Somehow, that must be causing some sort of race condition and randomly fails for some people.

I wasn't ever able to recreate the issue, but I'd rather give people a nice first experience, so I'm just reverting this for now.