### PR TITLE
Wrapping update queries with joins in a subquery

### DIFF
--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -1320,6 +1320,15 @@ describe Avram::Queryable do
       bucket = bucket.reload
       bucket.names.should eq(["Rey"])
     end
+
+    it "updates with joins" do
+      manager1 = ManagerFactory.create(&.name("Mr. Krabs"))
+      manager2 = ManagerFactory.create(&.name("Mr. Robot"))
+      EmployeeFactory.create(&.name("Spongebob Alderson").manager_id(manager1.id))
+      Employee::BaseQuery.new.where_manager(Manager::BaseQuery.new.id(manager1.id)).update(manager_id: manager2.id)
+      manager1.employees!.first?.should be_nil
+      manager2.employees!.first.name.should eq("Spongebob Alderson")
+    end
   end
 
   describe "#delete" do


### PR DESCRIPTION
Fixes #827

This changes the syntax of the `UPDATE` sql so when you have a join, it moves the whole `WHERE` clause to a subquery.

Previously, if you tried to bulk update with a join, it would throw a postgres syntax error

```
UPDATE ... SET x = 1 INNER JOIN.....
```

Now this moves it to a subquery with

```
UPDATE ... SET x = 1 WHERE EXISTS (.... INNER JOIN ....);
```