### PR TITLE
Allow skipping the index when using add_belongs_to in migrations

### DIFF
--- a/spec/avram/migrator/alter_table_statement_spec.cr
+++ b/spec/avram/migrator/alter_table_statement_spec.cr
@@ -185,6 +185,16 @@ describe Avram::Migrator::AlterTableStatement do
         built.statements[2].should eq "UPDATE comments SET line_item_id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';"
       end
     end
+
+    it "skips creating the index" do
+      built = Avram::Migrator::AlterTableStatement.new(:challenges).build do
+        add_belongs_to host : User?, on_delete: :cascade, fill_existing_with: :nothing, index: false
+        add_belongs_to guest : User?, on_delete: :cascade, fill_existing_with: :nothing
+      end
+
+      built.statements[1].should eq "CREATE INDEX challenges_guest_id_index ON challenges USING btree (guest_id);"
+      built.statements.size.should eq(2)
+    end
   end
 
   context "IF EXISTS" do

--- a/spec/avram/migrator/create_table_statement_spec.cr
+++ b/spec/avram/migrator/create_table_statement_spec.cr
@@ -235,6 +235,16 @@ describe Avram::Migrator::CreateTableStatement do
         end
       end
     end
+
+    it "skips creating the index" do
+      built = Avram::Migrator::CreateTableStatement.new(:challenges).build do
+        add_belongs_to host : User, on_delete: :cascade, index: false
+        add_belongs_to guest : User, on_delete: :cascade
+      end
+
+      built.statements[1].should eq "CREATE INDEX challenges_guest_id_index ON challenges USING btree (guest_id);"
+      built.statements.size.should eq(2)
+    end
   end
 
   context "IF NOT EXISTS" do

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -139,7 +139,7 @@ class Avram::Migrator::AlterTableStatement
   end
 
   # Adds a references column and index given a model class and references option.
-  macro add_belongs_to(type_declaration, on_delete, references = nil, foreign_key_type = Int64, fill_existing_with = nil, unique = false)
+  macro add_belongs_to(type_declaration, on_delete, references = nil, foreign_key_type = Int64, fill_existing_with = nil, unique = false, index = true)
     {% unless type_declaration.is_a?(TypeDeclaration) %}
       {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
     {% end %}
@@ -182,7 +182,9 @@ class Avram::Migrator::AlterTableStatement
       )
     {% end %}
 
+    {% if index %}
     add_index :{{ foreign_key_name }}, unique: {{ unique }}
+    {% end %}
   end
 
   macro add(type_declaration, index = false, using = :btree, unique = false, default = nil, fill_existing_with = nil, **type_options)

--- a/src/avram/migrator/create_table_statement.cr
+++ b/src/avram/migrator/create_table_statement.cr
@@ -134,7 +134,7 @@ class Avram::Migrator::CreateTableStatement
   end
 
   # Adds a references column and index given a model class and references option.
-  macro add_belongs_to(type_declaration, on_delete, references = nil, foreign_key_type = Int64, unique = false)
+  macro add_belongs_to(type_declaration, on_delete, references = nil, foreign_key_type = Int64, unique = false, index = true)
     {% unless type_declaration.is_a?(TypeDeclaration) %}
       {% raise "add_belongs_to expected a type declaration like 'user : User', instead got: '#{type_declaration}'" %}
     {% end %}
@@ -168,7 +168,9 @@ class Avram::Migrator::CreateTableStatement
     .set_references(references: %table_name.to_s, on_delete: {{ on_delete }})
     .build_add_statement_for_create
 
+    {% if index %}
     add_index :{{ foreign_key_name }}, unique: {{ unique }}
+    {% end %}
   end
 
   macro belongs_to(type_declaration, *args, **named_args)


### PR DESCRIPTION
Fixes #999

When using `add_belongs_to` in migrations, it creates an index by default, but if you need an escape hatch to skip that, you can now pass `index: false`. 

```crystal
add_belongs_to user : User, on_delete: :cascade, index: false
```