### PR TITLE
Adding create_sequence and drop_sequence migration helpers.

### DIFF
--- a/spec/avram/migrator/create_sequence_statement_spec.cr
+++ b/spec/avram/migrator/create_sequence_statement_spec.cr
@@ -1,0 +1,14 @@
+require "../../spec_helper"
+
+describe Avram::Migrator::CreateSequenceStatement do
+  it "generates correct CREATE SEQUENCE sql" do
+    statement = Avram::Migrator::CreateSequenceStatement.new(:accounts_number).build
+    statement.should eq "CREATE SEQUENCE accounts_number_seq OWNED BY NONE;"
+
+    statement = Avram::Migrator::CreateSequenceStatement.new(:accounts_number, if_not_exists: true).build
+    statement.should eq "CREATE SEQUENCE IF NOT EXISTS accounts_number_seq OWNED BY NONE;"
+
+    statement = Avram::Migrator::CreateSequenceStatement.new(:accounts_number, owned_by: "accounts.number").build
+    statement.should eq "CREATE SEQUENCE accounts_number_seq OWNED BY accounts.number;"
+  end
+end

--- a/spec/avram/migrator/drop_sequence_statement_spec.cr
+++ b/spec/avram/migrator/drop_sequence_statement_spec.cr
@@ -1,0 +1,8 @@
+require "../../spec_helper"
+
+describe Avram::Migrator::DropSequenceStatement do
+  it "generates correct DROP SEQUENCE sql" do
+    statement = Avram::Migrator::DropSequenceStatement.new(:accounts_number).build
+    statement.should eq "DROP SEQUENCE IF EXISTS accounts_number_seq;"
+  end
+end

--- a/src/avram/migrator/create_sequence_statement.cr
+++ b/src/avram/migrator/create_sequence_statement.cr
@@ -1,0 +1,26 @@
+# Builds an SQL statement for creating a sequence using the given name appending "_seq".
+# Additional options may be provided for extra customization.
+#
+# ### Usage
+#
+# ```
+# CreateSequenceStatement.new(:accounts_number, if_not_exists: true, owned_by: "accounts.number").build
+# # => "CREATE SEQUENCE accounts_number_seq;"
+# ```
+class Avram::Migrator::CreateSequenceStatement
+  private getter? if_not_exists : Bool = false
+
+  def initialize(@name : String | Symbol, *, @if_not_exists : Bool = false, @owned_by : String = "NONE")
+  end
+
+  def build
+    name = "#{@name}_seq"
+
+    String.build do |io|
+      io << "CREATE SEQUENCE "
+      io << "IF NOT EXISTS " if if_not_exists?
+      io << name
+      io << " OWNED BY #{@owned_by};"
+    end
+  end
+end

--- a/src/avram/migrator/drop_sequence_statement.cr
+++ b/src/avram/migrator/drop_sequence_statement.cr
@@ -1,0 +1,22 @@
+# Builds an SQL statement for dropping a sequence using the given name.
+#
+# ### Usage
+#
+# ```
+# DropSequenceStatement.new(:accounts_number, if_not_exists: true, owned_by: "accounts.number").build
+# # => "CREATE SEQUENCE accounts_number_seq;"
+# ```
+class Avram::Migrator::DropSequenceStatement
+  def initialize(@name : String | Symbol)
+  end
+
+  def build
+    name = "#{@name}_seq"
+
+    String.build do |io|
+      io << "DROP SEQUENCE IF EXISTS "
+      io << name
+      io << ';'
+    end
+  end
+end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -93,4 +93,15 @@ module Avram::Migrator::StatementHelpers
   def drop_trigger(table_name : TableName, name : String)
     prepared_statements << Avram::Migrator::DropTriggerStatement.new(table_name, name).build
   end
+
+  def create_sequence(table : TableName, column : Symbol)
+    sequence_name = "#{table}_#{column}"
+    owned_by = "#{table}.#{column}"
+    prepared_statements << Avram::Migrator::CreateSequenceStatement.new(sequence_name, if_not_exists: true, owned_by: owned_by).build
+  end
+
+  def drop_sequence(table : TableName, column : Symbol)
+    sequence_name = "#{table}_#{column}"
+    prepared_statements << Avram::Migrator::DropSequenceStatement.new(sequence_name).build
+  end
 end


### PR DESCRIPTION
Fixes #910

This adds new `create_sequence` and `drop_sequence` migration helpers.

```crystal
def migrate
  create_sequence table_for(Account), :number
end

def rollback
  drop_sequence table_for(Account), :number
end
```