### PR TITLE
Adding new base_query_class arg for associations.

### DIFF
--- a/db/migrations/20240224173636_create_transactions.cr
+++ b/db/migrations/20240224173636_create_transactions.cr
@@ -1,0 +1,15 @@
+class CreateTransactions::V20240224173636 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(Transaction) do
+      primary_key id : Int64
+      add_timestamps
+      add type : Int32
+      add soft_deleted_at : Time?
+      add_belongs_to user : User, on_delete: :cascade
+    end
+  end
+
+  def rollback
+    drop table_for(Transaction)
+  end
+end

--- a/db/migrations/20240225160631_create_follows.cr
+++ b/db/migrations/20240225160631_create_follows.cr
@@ -1,0 +1,15 @@
+class CreateFollows::V20240225160631 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(Follow) do
+      primary_key id : Int64
+      add_timestamps
+      add soft_deleted_at : Time?
+      add_belongs_to follower : User, on_delete: :cascade
+      add_belongs_to followee : User, on_delete: :cascade
+    end
+  end
+
+  def rollback
+    drop table_for(Follow)
+  end
+end

--- a/spec/avram/preloading/preloading_has_many_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_spec.cr
@@ -278,6 +278,8 @@ describe "Preloading has_many associations" do
       deleted_txn = TransactionFactory.create(&.user(user).soft_deleted_at(1.day.ago))
 
       u = UserQuery.new.preload_transactions.first
+      u.transactions_count.should eq(1)
+      u.transactions.size.should eq(1)
       ids = u.transactions.map(&.id)
       ids.should contain(good_txn.id)
       ids.should_not contain(deleted_txn.id)
@@ -289,6 +291,10 @@ describe "Preloading has_many associations" do
       deleted_txn = TransactionFactory.create(&.user(user).soft_deleted_at(1.day.ago))
 
       u = UserQuery.new.preload_transactions(Transaction::BaseQuery.new).first
+      # NOTE: This is an edge case. It uses the base_query_class defined on the association
+      # not what was preloaded.
+      u.transactions_count.should eq(1)
+      u.transactions.size.should eq(2)
       ids = u.transactions.map(&.id)
       ids.should contain(good_txn.id)
       ids.should contain(deleted_txn.id)
@@ -301,6 +307,8 @@ describe "Preloading has_many associations" do
       special_txn = TransactionFactory.create(&.user(user).type(Transaction::Type::Special))
 
       u = UserQuery.new.preload_transactions(&.special).first
+      u.transactions_count.should eq(2)
+      u.transactions.size.should eq(1)
       ids = u.transactions.map(&.id)
       ids.should_not contain(non_special_txn.id)
       ids.should_not contain(deleted_txn.id)

--- a/spec/avram/preloading/preloading_has_many_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_spec.cr
@@ -278,7 +278,6 @@ describe "Preloading has_many associations" do
       deleted_txn = TransactionFactory.create(&.user(user).soft_deleted_at(1.day.ago))
 
       u = UserQuery.new.preload_transactions.first
-      u.transactions_count.should eq(1)
       ids = u.transactions.map(&.id)
       ids.should contain(good_txn.id)
       ids.should_not contain(deleted_txn.id)
@@ -290,7 +289,6 @@ describe "Preloading has_many associations" do
       deleted_txn = TransactionFactory.create(&.user(user).soft_deleted_at(1.day.ago))
 
       u = UserQuery.new.preload_transactions(Transaction::BaseQuery.new).first
-      u.transactions_count.should eq(2)
       ids = u.transactions.map(&.id)
       ids.should contain(good_txn.id)
       ids.should contain(deleted_txn.id)
@@ -303,7 +301,6 @@ describe "Preloading has_many associations" do
       special_txn = TransactionFactory.create(&.user(user).type(Transaction::Type::Special))
 
       u = UserQuery.new.preload_transactions(&.special).first
-      u.transactions_count.should eq(1)
       ids = u.transactions.map(&.id)
       ids.should_not contain(non_special_txn.id)
       ids.should_not contain(deleted_txn.id)

--- a/spec/avram/preloading/preloading_has_many_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_spec.cr
@@ -271,7 +271,7 @@ describe "Preloading has_many associations" do
     end
   end
 
-  describe "override base_query_class", focus: true do
+  describe "override base_query_class" do
     it "uses the custom query class to ignore soft_deleted records" do
       user = UserFactory.create
       good_txn = TransactionFactory.create(&.user(user))

--- a/spec/avram/preloading/preloading_has_many_through_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_through_spec.cr
@@ -210,4 +210,34 @@ describe "Preloading has_many through associations" do
       end
     end
   end
+
+  describe "override base_query_class" do
+    it "uses the custom query class to ignore soft_deleted records" do
+      user = UserFactory.create
+      new_friend = UserFactory.create
+      not_friend = UserFactory.create
+      FollowFactory.create(&.followee(user).follower(new_friend))
+      FollowFactory.create(&.followee(user).follower(not_friend).soft_deleted_at(1.day.ago))
+
+      u = UserQuery.new.preload_followers.first
+      u.followers_count.should eq(1)
+      ids = u.followers.map(&.id)
+      ids.should contain(new_friend.id)
+      ids.should_not contain(not_friend.id)
+    end
+
+    # it "has an escape hatch" do
+    #   user = UserFactory.create
+    #   new_friend = UserFactory.create
+    #   not_friend = UserFactory.create
+    #   FollowFactory.create(&.followee(user).follower(new_friend))
+    #   FollowFactory.create(&.followee(user).follower(not_friend).soft_deleted_at(1.day.ago))
+
+    #   u = UserQuery.new.preload_followers(&.preload_follows(Follow::BaseQuery.new)).first
+    #   u.followers_count.should eq(2)
+    #   ids = u.followers.map(&.id)
+    #   ids.should contain(new_friend.id)
+    #   ids.should contain(not_friend.id)
+    # end
+  end
 end

--- a/spec/avram/preloading/preloading_has_many_through_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_through_spec.cr
@@ -232,8 +232,19 @@ describe "Preloading has_many through associations" do
       FollowFactory.create(&.followee(user).follower(new_friend))
       FollowFactory.create(&.followee(user).follower(not_friend).soft_deleted_at(1.day.ago))
 
-      # TODO: Need to figure out how to override this join
-      u = UserQuery.new.preload_follows(Follow::BaseQuery.new).preload_followers.first
+      # Preloads work in a lot of different ways, so we need to account for
+      # all of the different method options
+      u = UserQuery.new.preload_followers(through: Follow::BaseQuery.new).id(user.id).first
+      ids = u.followers.map(&.id)
+      ids.should contain(new_friend.id)
+      ids.should contain(not_friend.id)
+
+      u = UserQuery.new.preload_followers(User::BaseQuery.new, through: Follow::BaseQuery.new).id(user.id).first
+      ids = u.followers.map(&.id)
+      ids.should contain(new_friend.id)
+      ids.should contain(not_friend.id)
+
+      u = UserQuery.new.preload_followers(through: Follow::BaseQuery.new, &.preload_follows).id(user.id).first
       ids = u.followers.map(&.id)
       ids.should contain(new_friend.id)
       ids.should contain(not_friend.id)

--- a/spec/avram/preloading/preloading_has_many_through_spec.cr
+++ b/spec/avram/preloading/preloading_has_many_through_spec.cr
@@ -220,24 +220,23 @@ describe "Preloading has_many through associations" do
       FollowFactory.create(&.followee(user).follower(not_friend).soft_deleted_at(1.day.ago))
 
       u = UserQuery.new.preload_followers.first
-      u.followers_count.should eq(1)
       ids = u.followers.map(&.id)
       ids.should contain(new_friend.id)
       ids.should_not contain(not_friend.id)
     end
 
-    # it "has an escape hatch" do
-    #   user = UserFactory.create
-    #   new_friend = UserFactory.create
-    #   not_friend = UserFactory.create
-    #   FollowFactory.create(&.followee(user).follower(new_friend))
-    #   FollowFactory.create(&.followee(user).follower(not_friend).soft_deleted_at(1.day.ago))
+    it "has an escape hatch" do
+      user = UserFactory.create
+      new_friend = UserFactory.create
+      not_friend = UserFactory.create
+      FollowFactory.create(&.followee(user).follower(new_friend))
+      FollowFactory.create(&.followee(user).follower(not_friend).soft_deleted_at(1.day.ago))
 
-    #   u = UserQuery.new.preload_followers(&.preload_follows(Follow::BaseQuery.new)).first
-    #   u.followers_count.should eq(2)
-    #   ids = u.followers.map(&.id)
-    #   ids.should contain(new_friend.id)
-    #   ids.should contain(not_friend.id)
-    # end
+      # TODO: Need to figure out how to override this join
+      u = UserQuery.new.preload_follows(Follow::BaseQuery.new).preload_followers.first
+      ids = u.followers.map(&.id)
+      ids.should contain(new_friend.id)
+      ids.should contain(not_friend.id)
+    end
   end
 end

--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -1247,7 +1247,7 @@ describe Avram::Queryable do
       UserQuery.new.select_count.should eq 10
       # NOTE: we don't test rows_affected here because this isn't
       # available with a truncate statement
-      UserQuery.truncate
+      UserQuery.truncate(cascade: true)
       UserQuery.new.select_count.should eq 0
     end
 

--- a/spec/support/factories/follow_factory.cr
+++ b/spec/support/factories/follow_factory.cr
@@ -1,0 +1,20 @@
+class FollowFactory < BaseFactory
+  def initialize
+    before_save do
+      if operation.follower_id.value.nil?
+        follower(UserFactory.create)
+      end
+      if operation.followee_id.value.nil?
+        followee(UserFactory.create)
+      end
+    end
+  end
+
+  def follower(u : User)
+    follower_id(u.id)
+  end
+
+  def followee(u : User)
+    followee_id(u.id)
+  end
+end

--- a/spec/support/factories/transaction_factory.cr
+++ b/spec/support/factories/transaction_factory.cr
@@ -1,0 +1,13 @@
+class TransactionFactory < BaseFactory
+  def initialize
+    before_save do
+      if operation.user_id.value.nil?
+        user(UserFactory.create)
+      end
+    end
+  end
+
+  def user(u : User)
+    user_id(u.id)
+  end
+end

--- a/spec/support/models/follow.cr
+++ b/spec/support/models/follow.cr
@@ -1,0 +1,18 @@
+class Follow < BaseModel
+  include Avram::SoftDelete::Model
+
+  table do
+    column soft_deleted_at : Time?
+
+    belongs_to follower : User
+    belongs_to followee : User
+  end
+end
+
+class FollowQuery < Follow::BaseQuery
+  include Avram::SoftDelete::Query
+
+  def initialize
+    defaults &.only_kept
+  end
+end

--- a/spec/support/models/transaction.cr
+++ b/spec/support/models/transaction.cr
@@ -1,0 +1,26 @@
+class Transaction < BaseModel
+  include Avram::SoftDelete::Model
+
+  enum Type
+    Unknown
+    Special
+  end
+
+  table do
+    column type : Transaction::Type = Transaction::Type::Unknown
+    column soft_deleted_at : Time?
+    belongs_to user : User
+  end
+end
+
+class TransactionQuery < Transaction::BaseQuery
+  include Avram::SoftDelete::Query
+
+  def initialize
+    defaults &.only_kept
+  end
+
+  def special
+    type(Transaction::Type::Special)
+  end
+end

--- a/spec/support/models/user.cr
+++ b/spec/support/models/user.cr
@@ -12,6 +12,8 @@ class User < BaseModel
     column available_for_hire : Bool?
     has_one sign_in_credential : SignInCredential?
     has_many transactions : Transaction, base_query_class: TransactionQuery
+    has_many follows : Follow, foreign_key: :followee_id, base_query_class: FollowQuery
+    has_many followers : User, through: [:follows, :follower]
   end
 end
 

--- a/spec/support/models/user.cr
+++ b/spec/support/models/user.cr
@@ -11,6 +11,7 @@ class User < BaseModel
     column average_score : Float64?
     column available_for_hire : Bool?
     has_one sign_in_credential : SignInCredential?
+    has_many transactions : Transaction, base_query_class: TransactionQuery
   end
 end
 

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -127,7 +127,7 @@ module Avram::Associations::HasMany
         preload_{{ assoc_name }}({{ query_class }}.new)
       end
 
-      def preload_{{ assoc_name }} : self
+      def preload_{{ assoc_name }}(&) : self
         modified_query = yield {{ query_class }}.new
         preload_{{ assoc_name }}(modified_query)
       end

--- a/src/avram/associations/has_many.cr
+++ b/src/avram/associations/has_many.cr
@@ -39,7 +39,8 @@ module Avram::Associations::HasMany
       type: {{ type_declaration.type }},
       foreign_key: :{{ foreign_key }},
       through: {{ through }},
-      relationship_type: :has_many
+      relationship_type: :has_many,
+      base_query_class: {{ query_class }}
 
     define_has_many_lazy_loading({{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ through }}, {{ query_class }})
     define_has_many_base_query({{ @type }}, {{ assoc_name }}, {{ model }}, {{ foreign_key }}, {{ through }}, {{ query_class }})

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -178,7 +178,7 @@ abstract class Avram::Model
     {% for assoc in associations %}
       def {{ assoc[:assoc_name] }}_query
         {% if assoc[:relationship_type] == :has_many %}
-          {{ assoc[:type] }}::BaseQuery.new.{{ assoc[:foreign_key].id }}(id)
+          {{ assoc[:base_query_class] }}.new.{{ assoc[:foreign_key].id }}(id)
         {% elsif assoc[:relationship_type] == :belongs_to %}
           {{ assoc[:type] }}::BaseQuery.new.id({{ assoc[:foreign_key].id }})
         {% else %}
@@ -261,7 +261,7 @@ abstract class Avram::Model
     end
   end
 
-  macro association(assoc_name, type, relationship_type, foreign_key = nil, through = nil)
-    {% ASSOCIATIONS << {type: type, assoc_name: assoc_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through} %}
+  macro association(assoc_name, type, relationship_type, foreign_key = nil, through = nil, base_query_class = nil)
+    {% ASSOCIATIONS << {type: type, assoc_name: assoc_name.id, foreign_key: foreign_key, relationship_type: relationship_type, through: through, base_query_class: base_query_class} %}
   end
 end


### PR DESCRIPTION
Fixes #85

This PR adds a new arg that allows you to set the query class used for querying your association. This can be used in conjunction with soft_deleted records to ensure every preload you do only preloads the kept records.

```crystal
class User < BaseModel
  table do
    has_many transactions : Transaction, base_query_class: TransactionQuery
    has_many follows : Follow, foreign_key: :followee_id, base_query_class: FollowQuery
    has_many followers : User, through: [:follows, :follower]
  end
end

class TransactionQuery < Transaction::BaseQuery
  include Avram::SoftDelete::Query

  def initialize
    defaults &.only_kept
  end
end

# This only preloads the kept records
UserQuery.new.preload_transactions
```

The default base_query_class is always `T::BaseQuery`, but with soft_deleted models, you would have to either monkey-patch `T::BaseQuery`, or skip using preloads to avoid cases where you would preload a soft deleted record.

Currently this PR is only adding in `has_many` and `has_many :through` associations. If this works out, we can work out `has_one`, but I'm not sure if `belongs_to` would need this or not :thinking: 

### Side note

There is an edge case that comes up with this. Each association has an extra `_count` method that returns the total count of that association. It uses the `base_query_class` to run a `select_count`. If you use the escape hatch to preload more records than the base query uses, your `_count` method will return more or less than what you've preloaded.

```crystal
u = UserQuery.new.preload_transactions.first
u.transactions_count #=> 10
u.transactions.size #=> 10

# preload ALL transactions, even soft deleted ones
u = UserQuery.new.preload_transactions(Transaction::BaseQuery.new)first
u.transactions_count #=> 10
u.transactions.size #=> 20
```

### Side note 2

How the joins are built when using "has many through" is a bit complex. You generally preload your has_many query, but then that one needs to preload the join internally. If you need an escape hatch out of that default setup, I've added some new args to the preload methods here.

```crystal
# This preload followers and internally the kept follow records
UserQuery.new.preload_followers

# If you need the escape hatch, you have to pass in the base query
# This will now preload all records both kept and soft deleted
UserQuery.new.preload_followers(User::BaseQuery.new, through: Follow::BaseQuery.new)
```
