### PR TITLE
More criteria functions

### DIFF
--- a/spec/avram/float_criteria_spec.cr
+++ b/spec/avram/float_criteria_spec.cr
@@ -14,6 +14,12 @@ describe Float64::Lucky::Criteria do
       amount.abs.eq(39.99).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM purchases WHERE ABS(purchases.amount) = $1", "39.99"]
     end
   end
+
+  describe "ceil" do
+    it "uses CEIL" do
+      amount.ceil.eq(40.0).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM purchases WHERE CEIL(purchases.amount) = $1", "40.0"]
+    end
+  end
 end
 
 private def amount

--- a/spec/avram/float_criteria_spec.cr
+++ b/spec/avram/float_criteria_spec.cr
@@ -20,6 +20,12 @@ describe Float64::Lucky::Criteria do
       amount.ceil.eq(40.0).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM purchases WHERE CEIL(purchases.amount) = $1", "40.0"]
     end
   end
+
+  describe "floor" do
+    it "uses FLOOR" do
+      amount.floor.eq(39.0).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM purchases WHERE FLOOR(purchases.amount) = $1", "39.0"]
+    end
+  end
 end
 
 private def amount

--- a/spec/avram/float_criteria_spec.cr
+++ b/spec/avram/float_criteria_spec.cr
@@ -1,0 +1,21 @@
+require "../spec_helper"
+
+private class QueryMe < BaseModel
+  COLUMN_SQL = "purchases.id, purchases.created_at, purchases.updated_at, purchases.amount"
+
+  table purchases do
+    column amount : Float64
+  end
+end
+
+describe Float64::Lucky::Criteria do
+  describe "abs" do
+    it "uses ABS" do
+      amount.abs.eq(39.99).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM purchases WHERE ABS(purchases.amount) = $1", "39.99"]
+    end
+  end
+end
+
+private def amount
+  QueryMe::BaseQuery.new.amount
+end

--- a/spec/avram/integer_criteria_spec.cr
+++ b/spec/avram/integer_criteria_spec.cr
@@ -1,0 +1,34 @@
+require "../spec_helper"
+
+private class QueryMe < BaseModel
+  COLUMN_SQL = "transactions.id, transactions.created_at, transactions.updated_at, transactions.small_amount, transactions.amount, transactions.big_amount"
+
+  table transactions do
+    column small_amount : Int16
+    column amount : Int32
+    column big_amount : Int64
+  end
+end
+
+# These specs handle all ints: Int16, Int32, Int64
+describe "Int::Lucky::Criteria" do
+  describe "abs" do
+    it "uses ABS" do
+      small_amount.abs.eq(4).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM transactions WHERE ABS(transactions.small_amount) = $1", "4"]
+      amount.abs.eq(400).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM transactions WHERE ABS(transactions.amount) = $1", "400"]
+      big_amount.abs.eq(40000).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM transactions WHERE ABS(transactions.big_amount) = $1", "40000"]
+    end
+  end
+end
+
+private def small_amount
+  QueryMe::BaseQuery.new.small_amount
+end
+
+private def amount
+  QueryMe::BaseQuery.new.amount
+end
+
+private def big_amount
+  QueryMe::BaseQuery.new.big_amount
+end

--- a/spec/avram/string_criteria_spec.cr
+++ b/spec/avram/string_criteria_spec.cr
@@ -52,6 +52,12 @@ describe String::Lucky::Criteria do
       end
     end
   end
+
+  describe "length" do
+    it "uses LENGTH" do
+      name.length.eq(4).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE LENGTH(users.name) = $1", "4"]
+    end
+  end
 end
 
 private def name

--- a/spec/avram/string_criteria_spec.cr
+++ b/spec/avram/string_criteria_spec.cr
@@ -58,6 +58,12 @@ describe String::Lucky::Criteria do
       name.length.eq(4).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE LENGTH(users.name) = $1", "4"]
     end
   end
+
+  describe "reverse" do
+    it "uses REVERSE" do
+      name.reverse.eq("revir").to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE REVERSE(users.name) = $1", "revir"]
+    end
+  end
 end
 
 private def name

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -72,6 +72,7 @@ struct Float64
 
       define_function_criteria(abs, V)
       define_function_criteria(ceil, V)
+      define_function_criteria(floor, V)
     end
   end
 end

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -71,6 +71,7 @@ struct Float64
       end
 
       define_function_criteria(abs, V)
+      define_function_criteria(ceil, V)
     end
   end
 end

--- a/src/avram/charms/float64_extensions.cr
+++ b/src/avram/charms/float64_extensions.cr
@@ -69,6 +69,8 @@ struct Float64
       def select_sum! : Float64
         select_sum || 0_f64
       end
+
+      define_function_criteria(abs, V)
     end
   end
 end

--- a/src/avram/charms/int16_extensions.cr
+++ b/src/avram/charms/int16_extensions.cr
@@ -58,6 +58,8 @@ struct Int16
       def select_sum! : Int64
         select_sum || 0_i64
       end
+
+      define_function_criteria(abs, V)
     end
   end
 end

--- a/src/avram/charms/int32_extensions.cr
+++ b/src/avram/charms/int32_extensions.cr
@@ -59,6 +59,8 @@ struct Int32
       def select_sum! : Int64
         select_sum || 0_i64
       end
+
+      define_function_criteria(abs, V)
     end
   end
 end

--- a/src/avram/charms/int64_extensions.cr
+++ b/src/avram/charms/int64_extensions.cr
@@ -57,6 +57,8 @@ struct Int64
       def select_sum! : Int64
         select_sum || 0_i64
       end
+
+      define_function_criteria(abs, V)
     end
   end
 end

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -42,6 +42,7 @@ class String
       define_function_criteria(lower, V)
       define_function_criteria(trim, String)
       define_function_criteria(length, Int64)
+      define_function_criteria(reverse, String)
     end
   end
 end

--- a/src/avram/charms/string_extensions.cr
+++ b/src/avram/charms/string_extensions.cr
@@ -41,6 +41,7 @@ class String
       define_function_criteria(upper, V)
       define_function_criteria(lower, V)
       define_function_criteria(trim, String)
+      define_function_criteria(length, Int64)
     end
   end
 end


### PR DESCRIPTION
I was having a little fun and decided to add just a few more I thought may be helpful.

This adds a few extra Criteria functions

* LENGTH()
* REVERSE()
* ABS()
* CEIL()
* FLOOR()

```crystal
# Find all users that have a username length of 6 characters
UserQuery.new.username.length.eq(6)

# Find all users where the secret in reverse is equal to "terces"
UserQuery.new.secret.reverse.eq("terces")

# Find all transactions where the abs amount is 400 (i.e. matches 400 and -400)
TransactionQuery.new.amount.abs.eq(400)

# Find all purchases where the amount rounded up is equal to 40.0
PurchaseQuery.new.amount.ceil.eq(40.0)

# Find all purchases where the amount rounded down is equal to 30.0
PurchaseQuery.new.amount.floor.eq(30.0)
```