### PR TITLE
Give Join a way to alias the joining table.

### DIFF
--- a/spec/avram/join_spec.cr
+++ b/spec/avram/join_spec.cr
@@ -36,4 +36,10 @@ describe Avram::Join do
       .to_sql
       .should eq "INNER JOIN managers USING (company_id, department_id)"
   end
+
+  it "allows aliasing the to table" do
+    Avram::Join::Inner.new(from: :purchases, to: :users, alias_to: :sellers, primary_key: :seller_id, foreign_key: :id)
+      .to_sql
+      .should eq "INNER JOIN users AS sellers ON purchases.seller_id = sellers.id"
+  end
 end


### PR DESCRIPTION
Fixes #1007

This gives you a way to set an alias for the join table when building `Avram::Join` directly.