### PR TITLE
Adds new JSON::Any criteria methods for querying jsonb columns

### DIFF
--- a/spec/avram/json_criteria_spec.cr
+++ b/spec/avram/json_criteria_spec.cr
@@ -1,0 +1,45 @@
+require "../spec_helper"
+
+private class QueryMe < BaseModel
+  COLUMN_SQL = "users.id, users.created_at, users.updated_at, users.preferences"
+
+  table users do
+    column preferences : JSON::Any
+  end
+end
+
+describe JSON::Any::Lucky::Criteria do
+  describe "has_key" do
+    it "?" do
+      preferences.has_key("theme").to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE users.preferences ? $1", "theme"]
+    end
+
+    it "negates with NOT()" do
+      preferences.not.has_key("theme").to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE NOT(users.preferences ? $1)", "theme"]
+    end
+  end
+
+  describe "has_any_keys" do
+    it "?|" do
+      preferences.has_any_keys(["theme", "style"]).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE users.preferences ?| $1", ["theme", "style"]]
+    end
+
+    it "negates with NOT()" do
+      preferences.not.has_any_keys(["theme", "style"]).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE NOT(users.preferences ?| $1)", ["theme", "style"]]
+    end
+  end
+
+  describe "has_all_keys" do
+    it "?&" do
+      preferences.has_all_keys(["theme", "style"]).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE users.preferences ?& $1", ["theme", "style"]]
+    end
+
+    it "negates with NOT()" do
+      preferences.not.has_all_keys(["theme", "style"]).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE NOT(users.preferences ?& $1)", ["theme", "style"]]
+    end
+  end
+end
+
+private def preferences
+  QueryMe::BaseQuery.new.preferences
+end

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -76,6 +76,20 @@ struct JSON::Any
     end
 
     class Criteria(T, V) < Avram::Criteria(T, V)
+      # performs `WHERE jsonb ? string`
+      def has_key(value : String) : T
+        add_clause(Avram::Where::JSONHasKey.new(column, value))
+      end
+
+      # performs `WHERE jsonb ?| array`
+      def has_any_keys(keys : Array(String)) : T
+        add_clause(Avram::Where::JSONHasAnyKeys.new(column, keys))
+      end
+
+      # performs `WHERE jsonb ?& array`
+      def has_all_keys(keys : Array(String)) : T
+        add_clause(Avram::Where::JSONHasAllKeys.new(column, keys))
+      end
     end
   end
 end

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -245,6 +245,78 @@ module Avram::Where
     end
   end
 
+  class JSONHasKey < ValueHoldingSqlClause
+    def operator : String
+      "?"
+    end
+
+    def negated : NotJSONHasKey
+      NotJSONHasKey.new(column, value)
+    end
+  end
+
+  class NotJSONHasKey < ValueHoldingSqlClause
+    def operator : String
+      "?"
+    end
+
+    def negated : JSONHasKey
+      JSONHasKey.new(column, value)
+    end
+
+    def prepare(placeholder_supplier : Proc(String)) : String
+      "NOT(#{column} #{operator} #{placeholder_supplier.call})"
+    end
+  end
+
+  class JSONHasAnyKeys < ValueHoldingSqlClause
+    def operator : String
+      "?|"
+    end
+
+    def negated : NotJSONHasAnyKeys
+      NotJSONHasAnyKeys.new(column, value)
+    end
+  end
+
+  class NotJSONHasAnyKeys < ValueHoldingSqlClause
+    def operator : String
+      "?|"
+    end
+
+    def negated : JSONHasAnyKeys
+      JSONHasAnyKeys.new(column, value)
+    end
+
+    def prepare(placeholder_supplier : Proc(String)) : String
+      "NOT(#{column} #{operator} #{placeholder_supplier.call})"
+    end
+  end
+
+  class JSONHasAllKeys < ValueHoldingSqlClause
+    def operator : String
+      "?&"
+    end
+
+    def negated : NotJSONHasAllKeys
+      NotJSONHasAllKeys.new(column, value)
+    end
+  end
+
+  class NotJSONHasAllKeys < ValueHoldingSqlClause
+    def operator : String
+      "?&"
+    end
+
+    def negated : JSONHasAllKeys
+      JSONHasAllKeys.new(column, value)
+    end
+
+    def prepare(placeholder_supplier : Proc(String)) : String
+      "NOT(#{column} #{operator} #{placeholder_supplier.call})"
+    end
+  end
+
   class Raw < Condition
     @clause : String
 


### PR DESCRIPTION
Ref #197

This PR adds in 3 new criteria method for `JSON::Any` columns

* `has_key` which performs `WHERE jsonb ? 'some_key'`. 
* `has_any_keys` which performs `WHERE jsonb ?| '{"this_key", "or_that_key"}'`
* `has_all_keys` which performs `WHERE jsonb ?& '{"this_key", "and_this_key"}'`

This makes doing queries on JSON columns a little easier since you can't do raw WHERE queries on these because they use the `?` character which the PG shard uses as a placeholder [ref](https://github.com/luckyframework/avram/issues/939)

```crystal
class User < BaseModel
  table do
    column preferences : JSON::Any
  end
end

UserQuery.new.preferences.has_key("theme")
UserQuery.new.preferences.has_any_keys(["theme", "color_mode"])
UserQuery.new.preferences.has_all_keys(["theme", "style"])
```


*Side note*: I'm not having this PR close the issue because I want to add 2 more in a separate PR to perform `@>` and `<@`