### PR TITLE
Adds 2 new JSON critera query methods

### DIFF
--- a/spec/avram/json_criteria_spec.cr
+++ b/spec/avram/json_criteria_spec.cr
@@ -38,6 +38,34 @@ describe JSON::Any::Lucky::Criteria do
       preferences.not.has_all_keys(["theme", "style"]).to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE NOT(users.preferences ?& $1)", ["theme", "style"]]
     end
   end
+
+  describe "includes" do
+    it "@>" do
+      json = JSON::Any.new({"theme" => JSON::Any.new("dark")})
+      critera = preferences.includes(json)
+      critera.to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE users.preferences @> $1", "{\"theme\":\"dark\"}"]
+    end
+
+    it "negates with NOT()" do
+      json = JSON::Any.new({"theme" => JSON::Any.new("dark")})
+      critera = preferences.not.includes(json)
+      critera.to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE NOT(users.preferences @> $1)", "{\"theme\":\"dark\"}"]
+    end
+  end
+
+  describe "in" do
+    it "<@" do
+      json = JSON::Any.new({"theme" => JSON::Any.new("dark"), "style" => JSON::Any.new("cyberpunk"), "version" => JSON::Any.new(2i64)})
+      critera = preferences.in(json)
+      critera.to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE users.preferences <@ $1", "{\"theme\":\"dark\",\"style\":\"cyberpunk\",\"version\":2}"]
+    end
+
+    it "negates with NOT()" do
+      json = JSON::Any.new({"theme" => JSON::Any.new("dark"), "style" => JSON::Any.new("cyberpunk"), "version" => JSON::Any.new(2i64)})
+      critera = preferences.not.in(json)
+      critera.to_sql.should eq ["SELECT #{QueryMe::COLUMN_SQL} FROM users WHERE NOT(users.preferences <@ $1)", "{\"theme\":\"dark\",\"style\":\"cyberpunk\",\"version\":2}"]
+    end
+  end
 end
 
 private def preferences

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -92,13 +92,13 @@ struct JSON::Any
       end
 
       # performs `WHERE jsonb @> other_json`
-      def includes(other_json : JSON::Any)
-        add_clause(Avram::Where::JsonbIncludes.new(column, other_json.to_json))
+      def includes(value) : T
+        add_clause(Avram::Where::JsonbIncludes.new(column, value.to_json))
       end
 
       # performs `WHERE jsonb <@ other_json`
-      def in(other_json : JSON::Any)
-        add_clause(Avram::Where::JsonbIn.new(column, other_json.to_json))
+      def in(value) : T
+        add_clause(Avram::Where::JsonbIn.new(column, value.to_json))
       end
     end
   end

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -96,6 +96,7 @@ struct JSON::Any
         add_clause(Avram::Where::JsonbIncludes.new(column, other_json.to_json))
       end
 
+      # performs `WHERE jsonb <@ other_json`
       def in(other_json : JSON::Any)
         add_clause(Avram::Where::JsonbIn.new(column, other_json.to_json))
       end

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -78,17 +78,17 @@ struct JSON::Any
     class Criteria(T, V) < Avram::Criteria(T, V)
       # performs `WHERE jsonb ? string`
       def has_key(value : String) : T
-        add_clause(Avram::Where::JSONHasKey.new(column, value))
+        add_clause(Avram::Where::JsonbHasKey.new(column, value))
       end
 
       # performs `WHERE jsonb ?| array`
       def has_any_keys(keys : Array(String)) : T
-        add_clause(Avram::Where::JSONHasAnyKeys.new(column, keys))
+        add_clause(Avram::Where::JsonbHasAnyKeys.new(column, keys))
       end
 
       # performs `WHERE jsonb ?& array`
       def has_all_keys(keys : Array(String)) : T
-        add_clause(Avram::Where::JSONHasAllKeys.new(column, keys))
+        add_clause(Avram::Where::JsonbHasAllKeys.new(column, keys))
       end
 
       # performs `WHERE jsonb @> other_json`

--- a/src/avram/charms/json_extensions.cr
+++ b/src/avram/charms/json_extensions.cr
@@ -90,6 +90,15 @@ struct JSON::Any
       def has_all_keys(keys : Array(String)) : T
         add_clause(Avram::Where::JSONHasAllKeys.new(column, keys))
       end
+
+      # performs `WHERE jsonb @> other_json`
+      def includes(other_json : JSON::Any)
+        add_clause(Avram::Where::JsonbIncludes.new(column, other_json.to_json))
+      end
+
+      def in(other_json : JSON::Any)
+        add_clause(Avram::Where::JsonbIn.new(column, other_json.to_json))
+      end
     end
   end
 end

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -317,6 +317,54 @@ module Avram::Where
     end
   end
 
+  class JsonbIncludes < ValueHoldingSqlClause
+    def operator : String
+      "@>"
+    end
+
+    def negated : JsonbExcludes
+      JsonbExcludes.new(column, value)
+    end
+  end
+
+  class JsonbExcludes < ValueHoldingSqlClause
+    def operator : String
+      "@>"
+    end
+
+    def negated : JsonbIncludes
+      JsonbIncludes.new(column, value)
+    end
+
+    def prepare(placeholder_supplier : Proc(String)) : String
+      "NOT(#{column} #{operator} #{placeholder_supplier.call})"
+    end
+  end
+
+  class JsonbIn < ValueHoldingSqlClause
+    def operator : String
+      "<@"
+    end
+
+    def negated : JsonbNotIn
+      JsonbNotIn.new(column, value)
+    end
+  end
+
+  class JsonbNotIn < ValueHoldingSqlClause
+    def operator : String
+      "<@"
+    end
+
+    def negated : JsonbIn
+      JsonbIn.new(column, value)
+    end
+
+    def prepare(placeholder_supplier : Proc(String)) : String
+      "NOT(#{column} #{operator} #{placeholder_supplier.call})"
+    end
+  end
+
   class Raw < Condition
     @clause : String
 

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -245,23 +245,23 @@ module Avram::Where
     end
   end
 
-  class JSONHasKey < ValueHoldingSqlClause
+  class JsonbHasKey < ValueHoldingSqlClause
     def operator : String
       "?"
     end
 
-    def negated : NotJSONHasKey
-      NotJSONHasKey.new(column, value)
+    def negated : NotJsonbHasKey
+      NotJsonbHasKey.new(column, value)
     end
   end
 
-  class NotJSONHasKey < ValueHoldingSqlClause
+  class NotJsonbHasKey < ValueHoldingSqlClause
     def operator : String
       "?"
     end
 
-    def negated : JSONHasKey
-      JSONHasKey.new(column, value)
+    def negated : JsonbHasKey
+      JsonbHasKey.new(column, value)
     end
 
     def prepare(placeholder_supplier : Proc(String)) : String
@@ -269,23 +269,23 @@ module Avram::Where
     end
   end
 
-  class JSONHasAnyKeys < ValueHoldingSqlClause
+  class JsonbHasAnyKeys < ValueHoldingSqlClause
     def operator : String
       "?|"
     end
 
-    def negated : NotJSONHasAnyKeys
-      NotJSONHasAnyKeys.new(column, value)
+    def negated : NotJsonbHasAnyKeys
+      NotJsonbHasAnyKeys.new(column, value)
     end
   end
 
-  class NotJSONHasAnyKeys < ValueHoldingSqlClause
+  class NotJsonbHasAnyKeys < ValueHoldingSqlClause
     def operator : String
       "?|"
     end
 
-    def negated : JSONHasAnyKeys
-      JSONHasAnyKeys.new(column, value)
+    def negated : JsonbHasAnyKeys
+      JsonbHasAnyKeys.new(column, value)
     end
 
     def prepare(placeholder_supplier : Proc(String)) : String
@@ -293,23 +293,23 @@ module Avram::Where
     end
   end
 
-  class JSONHasAllKeys < ValueHoldingSqlClause
+  class JsonbHasAllKeys < ValueHoldingSqlClause
     def operator : String
       "?&"
     end
 
-    def negated : NotJSONHasAllKeys
-      NotJSONHasAllKeys.new(column, value)
+    def negated : NotJsonbHasAllKeys
+      NotJsonbHasAllKeys.new(column, value)
     end
   end
 
-  class NotJSONHasAllKeys < ValueHoldingSqlClause
+  class NotJsonbHasAllKeys < ValueHoldingSqlClause
     def operator : String
       "?&"
     end
 
-    def negated : JSONHasAllKeys
-      JSONHasAllKeys.new(column, value)
+    def negated : JsonbHasAllKeys
+      JsonbHasAllKeys.new(column, value)
     end
 
     def prepare(placeholder_supplier : Proc(String)) : String


### PR DESCRIPTION
Fixes #197 

This PR adds 2 more query methods following #1015

* `includes` which performs `WHERE jsonb @> '{"some":"json"}'`
* `in` which performs `WHERE jsonb <@ '{"some":"json"}'`

Also while I was in there I decided to rename the previously added Where classes from `JSON..` to `Jsonb...`. While reading the class names that seemed to make it a little more clear for me.

```crystal
class User < BaseModel
  table do
    column preferences : JSON::Any
  end
end

# query where preferences includes this json in it
UserQuery.new.preferences.includes(JSON::Any.new({"theme" => JSON::Any.new("dark")}))

# query where preferences is included in this json
UserQuery.new.preferences.in(JSON::Any.new({"theme" => JSON::Any.new("dark")}))
```