### PR TITLE
Added new `Undefined` constant

### DIFF
--- a/src/avram.cr
+++ b/src/avram.cr
@@ -12,6 +12,7 @@ require "cadmium_transliterator"
 
 require "./ext/db/*"
 require "./ext/pg/*"
+require "./avram/nothing"
 require "./avram/object_extensions"
 require "./avram/criteria"
 require "./avram/type"

--- a/src/avram/attribute.cr
+++ b/src/avram/attribute.cr
@@ -76,7 +76,7 @@ class Avram::Attribute(T)
     errors.empty?
   end
 
-  def changed?(from : T? | Nothing = Nothing.new, to : T? | Nothing = Nothing.new) : Bool
+  def changed?(from : T? | Nothing = Undefined, to : T? | Nothing = Undefined) : Bool
     from = from.is_a?(Nothing) ? true : from == original_value
     to = to.is_a?(Nothing) ? true : to == value
     value != original_value && from && to

--- a/src/avram/attribute.cr
+++ b/src/avram/attribute.cr
@@ -76,7 +76,7 @@ class Avram::Attribute(T)
     errors.empty?
   end
 
-  def changed?(from : T? | Nothing = Undefined, to : T? | Nothing = Undefined) : Bool
+  def changed?(from : T? | Nothing = IGNORE, to : T? | Nothing = IGNORE) : Bool
     from = from.is_a?(Nothing) ? true : from == original_value
     to = to.is_a?(Nothing) ? true : to == value
     value != original_value && from && to

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -22,7 +22,7 @@ class Avram::BaseQueryTemplate
 
       def update(
           {% for column in columns %}
-            {{ column[:name] }} : {{ column[:type] }} | Avram::Nothing{% if column[:nilable] %} | Nil{% end %} = Undefined,
+            {{ column[:name] }} : {{ column[:type] }} | Avram::Nothing{% if column[:nilable] %} | Nil{% end %} = IGNORE,
           {% end %}
         ) : Int64
 

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -22,7 +22,7 @@ class Avram::BaseQueryTemplate
 
       def update(
           {% for column in columns %}
-            {{ column[:name] }} : {{ column[:type] }} | Avram::Nothing{% if column[:nilable] %} | Nil{% end %} = Avram::Nothing.new,
+            {{ column[:name] }} : {{ column[:type] }} | Avram::Nothing{% if column[:nilable] %} | Nil{% end %} = Undefined,
           {% end %}
         ) : Int64
 

--- a/src/avram/needy_initializer.cr
+++ b/src/avram/needy_initializer.cr
@@ -42,8 +42,8 @@ module Avram::NeedyInitializer
     #
     # attribute_method_args would look something like:
     #
-    #   name : String | Avram::Nothing = Avram::Nothing.new,
-    #   email : String | Nil | Avram::Nothing = Avram::Nothing.new
+    #   name : String | Avram::Nothing = Undefined,
+    #   email : String | Nil | Avram::Nothing = Undefined
     #
     # This can be passed to macros as a string, and then the macro can call .id
     # on it to output the string as code!
@@ -58,7 +58,7 @@ module Avram::NeedyInitializer
     {% attribute_params = "" %}
 
     {% for attribute in ATTRIBUTES %}
-      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Avram::Nothing.new,\n" %}
+      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Undefined,\n" %}
       {% attribute_params = attribute_params + "#{attribute.var}: #{attribute.var},\n" %}
     {% end %}
 

--- a/src/avram/needy_initializer.cr
+++ b/src/avram/needy_initializer.cr
@@ -42,8 +42,8 @@ module Avram::NeedyInitializer
     #
     # attribute_method_args would look something like:
     #
-    #   name : String | Avram::Nothing = Undefined,
-    #   email : String | Nil | Avram::Nothing = Undefined
+    #   name : String | Avram::Nothing = IGNORE,
+    #   email : String | Nil | Avram::Nothing = IGNORE
     #
     # This can be passed to macros as a string, and then the macro can call .id
     # on it to output the string as code!
@@ -58,7 +58,7 @@ module Avram::NeedyInitializer
     {% attribute_params = "" %}
 
     {% for attribute in ATTRIBUTES %}
-      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Undefined,\n" %}
+      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = IGNORE,\n" %}
       {% attribute_params = attribute_params + "#{attribute.var}: #{attribute.var},\n" %}
     {% end %}
 

--- a/src/avram/needy_initializer_and_delete_methods.cr
+++ b/src/avram/needy_initializer_and_delete_methods.cr
@@ -44,8 +44,8 @@ module Avram::NeedyInitializerAndDeleteMethods
     #
     # attribute_method_args would look something like:
     #
-    #   name : String | Avram::Nothing = Avram::Nothing.new,
-    #   email : String | Nil | Avram::Nothing = Avram::Nothing.new
+    #   name : String | Avram::Nothing = Undefined,
+    #   email : String | Nil | Avram::Nothing = Undefined
     #
     # This can be passed to macros as a string, and then the macro can call .id
     # on it to output the string as code!
@@ -63,14 +63,14 @@ module Avram::NeedyInitializerAndDeleteMethods
       {% for attribute in COLUMN_ATTRIBUTES.uniq %}
         {% attribute_method_args = attribute_method_args + "#{attribute[:name]} : #{attribute[:type]} | Avram::Nothing" %}
         {% if attribute[:nilable] %}{% attribute_method_args = attribute_method_args + " | Nil" %}{% end %}
-        {% attribute_method_args = attribute_method_args + " = Avram::Nothing.new,\n" %}
+        {% attribute_method_args = attribute_method_args + " = Undefined,\n" %}
 
         {% attribute_params = attribute_params + "#{attribute[:name]}: #{attribute[:name]},\n" %}
       {% end %}
     {% end %}
 
     {% for attribute in ATTRIBUTES %}
-      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Avram::Nothing.new,\n" %}
+      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Undefined,\n" %}
       {% attribute_params = attribute_params + "#{attribute.var}: #{attribute.var},\n" %}
     {% end %}
 

--- a/src/avram/needy_initializer_and_delete_methods.cr
+++ b/src/avram/needy_initializer_and_delete_methods.cr
@@ -44,8 +44,8 @@ module Avram::NeedyInitializerAndDeleteMethods
     #
     # attribute_method_args would look something like:
     #
-    #   name : String | Avram::Nothing = Undefined,
-    #   email : String | Nil | Avram::Nothing = Undefined
+    #   name : String | Avram::Nothing = IGNORE,
+    #   email : String | Nil | Avram::Nothing = IGNORE
     #
     # This can be passed to macros as a string, and then the macro can call .id
     # on it to output the string as code!
@@ -63,14 +63,14 @@ module Avram::NeedyInitializerAndDeleteMethods
       {% for attribute in COLUMN_ATTRIBUTES.uniq %}
         {% attribute_method_args = attribute_method_args + "#{attribute[:name]} : #{attribute[:type]} | Avram::Nothing" %}
         {% if attribute[:nilable] %}{% attribute_method_args = attribute_method_args + " | Nil" %}{% end %}
-        {% attribute_method_args = attribute_method_args + " = Undefined,\n" %}
+        {% attribute_method_args = attribute_method_args + " = IGNORE,\n" %}
 
         {% attribute_params = attribute_params + "#{attribute[:name]}: #{attribute[:name]},\n" %}
       {% end %}
     {% end %}
 
     {% for attribute in ATTRIBUTES %}
-      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Undefined,\n" %}
+      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = IGNORE,\n" %}
       {% attribute_params = attribute_params + "#{attribute.var}: #{attribute.var},\n" %}
     {% end %}
 

--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -46,8 +46,8 @@ module Avram::NeedyInitializerAndSaveMethods
     #
     # attribute_method_args would look something like:
     #
-    #   name : String | Avram::Nothing = Undefined,
-    #   email : String | Nil | Avram::Nothing = Undefined
+    #   name : String | Avram::Nothing = IGNORE,
+    #   email : String | Nil | Avram::Nothing = IGNORE
     #
     # This can be passed to macros as a string, and then the macro can call .id
     # on it to output the string as code!
@@ -65,14 +65,14 @@ module Avram::NeedyInitializerAndSaveMethods
       {% for attribute in COLUMN_ATTRIBUTES.uniq %}
         {% attribute_method_args = attribute_method_args + "#{attribute[:name]} : #{attribute[:type]} | Avram::Nothing" %}
         {% if attribute[:nilable] %}{% attribute_method_args = attribute_method_args + " | Nil" %}{% end %}
-        {% attribute_method_args = attribute_method_args + " = Undefined,\n" %}
+        {% attribute_method_args = attribute_method_args + " = IGNORE,\n" %}
 
         {% attribute_params = attribute_params + "#{attribute[:name]}: #{attribute[:name]},\n" %}
       {% end %}
     {% end %}
 
     {% for attribute in ATTRIBUTES.uniq %}
-      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Undefined,\n" %}
+      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = IGNORE,\n" %}
       {% attribute_params = attribute_params + "#{attribute.var}: #{attribute.var},\n" %}
     {% end %}
 

--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -46,8 +46,8 @@ module Avram::NeedyInitializerAndSaveMethods
     #
     # attribute_method_args would look something like:
     #
-    #   name : String | Avram::Nothing = Avram::Nothing.new,
-    #   email : String | Nil | Avram::Nothing = Avram::Nothing.new
+    #   name : String | Avram::Nothing = Undefined,
+    #   email : String | Nil | Avram::Nothing = Undefined
     #
     # This can be passed to macros as a string, and then the macro can call .id
     # on it to output the string as code!
@@ -65,14 +65,14 @@ module Avram::NeedyInitializerAndSaveMethods
       {% for attribute in COLUMN_ATTRIBUTES.uniq %}
         {% attribute_method_args = attribute_method_args + "#{attribute[:name]} : #{attribute[:type]} | Avram::Nothing" %}
         {% if attribute[:nilable] %}{% attribute_method_args = attribute_method_args + " | Nil" %}{% end %}
-        {% attribute_method_args = attribute_method_args + " = Avram::Nothing.new,\n" %}
+        {% attribute_method_args = attribute_method_args + " = Undefined,\n" %}
 
         {% attribute_params = attribute_params + "#{attribute[:name]}: #{attribute[:name]},\n" %}
       {% end %}
     {% end %}
 
     {% for attribute in ATTRIBUTES.uniq %}
-      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Avram::Nothing.new,\n" %}
+      {% attribute_method_args = attribute_method_args + "#{attribute.var} : #{attribute.type} | Avram::Nothing = Undefined,\n" %}
       {% attribute_params = attribute_params + "#{attribute.var}: #{attribute.var},\n" %}
     {% end %}
 

--- a/src/avram/nothing.cr
+++ b/src/avram/nothing.cr
@@ -4,3 +4,12 @@
 # :nodoc:
 class Avram::Nothing
 end
+
+# Use this value when you want to ignore updating a column
+# in a SaveOperation, for example.
+# ```
+# # Sets value to x.value or ignores it if x.value is nil
+# SaveThing.create!(
+#   value: x.value || Undefined
+# )
+Undefined = Avram::Nothing.new

--- a/src/avram/nothing.cr
+++ b/src/avram/nothing.cr
@@ -6,10 +6,12 @@ class Avram::Nothing
 end
 
 # Use this value when you want to ignore updating a column
-# in a SaveOperation, for example.
+# in a SaveOperation instead of setting the column value to `nil`.
+#
 # ```
-# # Sets value to x.value or ignores it if x.value is nil
+# # Set value to x.value or ignore it if x.value is nil
 # SaveThing.create!(
-#   value: x.value || Undefined
+#   value: x.value || IGNORE
 # )
-Undefined = Avram::Nothing.new
+# ```
+IGNORE = Avram::Nothing.new


### PR DESCRIPTION
Fixes #1017

This PR adds a single `Avram::Nothing.new` instance assigned to a new constant called `IGNORE`. This does 2 things

1. Uses a single allocated instance everywhere to represent `Avram::Nothing` instead of a new instance for every column. While this doesn't give a ton of memory savings, it's still better
2. For those nasty overload errors, it shrinks them up by a few characters.  

Before:
![image](https://github.com/luckyframework/avram/assets/2391/12dbd45f-f07b-40f7-a1c4-d411ecaa43d2)

After:
![image](https://github.com/luckyframework/avram/assets/2391/824cc50b-85e2-4c05-ae97-a94eb494a2b9)


