### PR TITLE
Updating min Crystal and postgres versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,11 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Install pg_client tools
+      - name: Install pg_client tools v${{ matrix.postgres_version }}
         run: |
+          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
           sudo apt install postgresql-client-${{ matrix.postgres_version }} -y
 
       - uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.6.2
+          crystal: latest
       - name: Install shards
         run: shards install
       - name: Format
@@ -32,11 +32,11 @@ jobs:
         shard_file:
           - shard.yml
         postgres_version:
-          - 12
-          - 13
           - 14
+          - 15
+          - 16
         crystal_version:
-          - 1.6.2
+          - 1.10.0
           - latest
         experimental:
           - false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
+      - name: Install pg_client tools
+        run: sudo apt install postgresql-client-${{ matrix.postgres_version }} -y
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{matrix.crystal_version}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,10 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Setup PostgreSQL
+      - name: Setup PostgreSQL Client v${{ matrix.postgres_version }}
         uses: tj-actions/install-postgresql@v3
         with:
           postgresql-version: ${{ matrix.postgres_version }}
-      # - name: Install pg_client tools v${{ matrix.postgres_version }}
-      #   run: |
-      #     sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-      #     sudo apt-get update
-      #     curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-      #     sudo apt install postgresql-client-${{ matrix.postgres_version }} -y
 
       - uses: crystal-lang/install-crystal@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install pg_client tools
-        run: sudo apt install postgresql-client-${{ matrix.postgres_version }} -y
+        run: |
+          sudo apt-get update
+          sudo apt install postgresql-client-${{ matrix.postgres_version }} -y
+
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{matrix.crystal_version}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,16 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Install pg_client tools v${{ matrix.postgres_version }}
-        run: |
-          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update
-          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-          sudo apt install postgresql-client-${{ matrix.postgres_version }} -y
+      - name: Setup PostgreSQL
+        uses: tj-actions/install-postgresql@v3
+        with:
+          postgresql-version: ${{ matrix.postgres_version }}
+      # - name: Install pg_client tools v${{ matrix.postgres_version }}
+      #   run: |
+      #     sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+      #     sudo apt-get update
+      #     curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+      #     sudo apt install postgresql-client-${{ matrix.postgres_version }} -y
 
       - uses: crystal-lang/install-crystal@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Generate docs"
         run: crystal docs
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.6.2
+FROM crystallang/crystal:1.10.0
 WORKDIR /data
 
 # install base dependencies
@@ -6,13 +6,13 @@ RUN apt-get update && \
   apt-get install -y gnupg libgconf-2-4 curl libreadline-dev && \
   # postgres 11 installation
   curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-  echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | tee /etc/apt/sources.list.d/postgres.list && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" | tee /etc/apt/sources.list.d/postgres.list && \
   apt-get update && \
-  apt-get install -y postgresql-11 && \
+  apt-get install -y postgresql-14 && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Lucky cli
-RUN git clone https://github.com/luckyframework/lucky_cli --branch v0.30.0 --depth 1 /usr/local/lucky_cli && \
+RUN git clone https://github.com/luckyframework/lucky_cli --branch v1.1.0 --depth 1 /usr/local/lucky_cli && \
   cd /usr/local/lucky_cli && \
   shards install && \
   crystal build src/lucky.cr -o /usr/local/bin/lucky

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   db:
-    image: postgres:11.1-alpine
+    image: postgres:14-alpine
     environment:
       POSTGRES_USER: lucky
       POSTGRES_PASSWORD: developer

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: avram
 version: 1.1.1
 
-crystal: ">= 1.6.0"
+crystal: ">= 1.10.0"
 
 license: MIT
 


### PR DESCRIPTION
While there's no breaking changes back to 1.6.2, I don't think we need to continue supporting the older Crystal versions with 1.12 released, and 1.13 well in the works. 

Since I was in here, I decided to also bump the postgres versions. We've been testing against 12, 13, and 14, but 15 and 16 are both out with 17 in the works. 