### PR TITLE
Add `skip_transaction` support to single migrations

### DIFF
--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -77,7 +77,7 @@ abstract class Avram::Migrator::Migration::V1
     end
   end
 
-  def skip_transaction (value : Bool)
+  def skip_transaction(value : Bool)
     @skip_transaction = value
   end
 

--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -18,6 +18,9 @@ abstract class Avram::Migrator::Migration::V1
     end
   end
 
+  def initialize(@skip_transaction = false)
+  end
+
   abstract def migrate
   abstract def version : Int64
 
@@ -74,6 +77,10 @@ abstract class Avram::Migrator::Migration::V1
     end
   end
 
+  def skip_transaction (value : Bool)
+    @skip_transaction = value
+  end
+
   private def track_migration(db : Avram::Database.class)
     db.exec "INSERT INTO migrations(version) VALUES ($1)", version
   end
@@ -99,9 +106,14 @@ abstract class Avram::Migrator::Migration::V1
   # ```
   private def execute_in_transaction(statements : Array(String), &)
     database = Avram.settings.database_to_migrate
-    database.transaction do
+    if @skip_transaction
       statements.each { |s| database.exec s }
       yield database
+    else
+      database.transaction do
+        statements.each { |s| database.exec s }
+        yield database
+      end
     end
   rescue e : PQ::PQError
     raise FailedMigration.new(migration: self.class.name, statements: statements, cause: e)


### PR DESCRIPTION
This adds support for calling `skip_transaction true` inside the `migrate` method in a single migration so that the statements are run outside the default transaction.

Motivation / real example (CockroachDB does not allow that ALTER TABLE inside a transaction):

```cr
class ChangeUsernameInUsers::V20240411185756 < Avram::Migrator::Migration::V1
  def migrate
    skip_transaction true

    # Sized strings require experimental flag
    # https://www.cockroachlabs.com/docs/stable/collate#details
    execute "SET enable_experimental_alter_column_type_general = true;"

    # Case-insensitive collation (CockroachDB does not support CITEXT)
    execute "ALTER TABLE users ALTER username TYPE STRING(30) COLLATE \"en-US-u-ks-level2\";"
  end

  def rollback
    # no-op since it alters existing column in backwards-compatible way
  end
end
```
` ▸ Error message unimplemented: ALTER COLUMN TYPE is not supported inside a transaction. Query ALTER TABLE users ALTER COLUMN username TYPE STRING(30) COLLATE "en-US-u-ks-level2";.`

TODO:
- [ ] tests - my local setup isn't ideal (I don't run Docker) so I'm not able to run tests locally atm
- [ ] cleanup
