### PR TITLE
Fixes #1038: type cast fails in select_min/max

### DIFF
--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -616,6 +616,22 @@ describe Avram::Queryable do
       min.should eq 1
     end
 
+    it "works with strings" do
+      UserFactory.create &.name("Third")
+      UserFactory.create &.name("Second")
+      UserFactory.create &.name("First")
+      min = UserQuery.new.name.select_min
+      min.should eq "First"
+    end
+
+    it "works with floats" do
+      UserFactory.create &.average_score(0.7)
+      UserFactory.create &.average_score(0.71)
+      UserFactory.create &.average_score(0.52)
+      min = UserQuery.new.average_score.select_min
+      min.should eq 0.52
+    end
+
     it "works with chained where clauses" do
       UserFactory.create &.age(2)
       UserFactory.create &.age(1)
@@ -646,6 +662,22 @@ describe Avram::Queryable do
       UserFactory.create &.age(3)
       max = UserQuery.new.age.select_max
       max.should eq 3
+    end
+
+    it "works with strings" do
+      UserFactory.create &.name("Third")
+      UserFactory.create &.name("Second")
+      UserFactory.create &.name("First")
+      max = UserQuery.new.name.select_max
+      max.should eq "Third"
+    end
+
+    it "works with floats" do
+      UserFactory.create &.average_score(0.7)
+      UserFactory.create &.average_score(0.71)
+      UserFactory.create &.average_score(0.52)
+      max = UserQuery.new.average_score.select_max
+      max.should eq 0.71
     end
 
     it "works with chained where clauses" do

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -129,12 +129,12 @@ class Avram::Criteria(T, V)
     add_clause(Avram::Where::LessThanOrEqualTo.new(column, V.adapter.to_db!(value)))
   end
 
-  def select_min : V?
-    rows.exec_scalar(&.select_min(column)).as(V?)
+  def select_min
+    to_expected_type(rows.exec_scalar(&.select_min(column)))
   end
 
-  def select_max : V?
-    rows.exec_scalar(&.select_max(column)).as(V?)
+  def select_max
+    to_expected_type(rows.exec_scalar(&.select_max(column)))
   end
 
   def select_average : Float64?
@@ -185,6 +185,18 @@ class Avram::Criteria(T, V)
     else
       sql_clause
     end
+  end
+
+  # :nodoc:
+  # given the value in input it casts it to the expected output type (e.g: an PG::Int becomes a Int)
+  private def to_expected_type(value)
+    value.as(V?)
+  end
+
+  # :nodoc:
+  # special case: PG::Numeric cannot be cast to float, so we need to explicitly call to_f on it
+  private def to_expected_type(value : PG::Numeric?)
+    value.try &.to_f64
   end
 
   macro define_function_criteria(name, output_type = V, sql_name = nil)


### PR DESCRIPTION
Fixes #1038 .
Basically, when we are doing a PG:something -> SomethingElse conversion, it usually works as long as you can cast safely from one another.
Eg: 1 (PG::Int) can be cast to int with .as(Int). Same for strings
However that is not the case for Numeric values - for them the simple .as(Float) does not work - but we need to get through the .to_f method.
This pull request does exactly this, it adds one new method (to_expected_type) with one overload in the specific case of the input being a PG::numeric.
It also fixes the select_max, which was having the same issue
