### PR TITLE
Add change nullability statement

### DIFF
--- a/spec/avram/migrator/alter_table_statement_spec.cr
+++ b/spec/avram/migrator/alter_table_statement_spec.cr
@@ -89,6 +89,16 @@ describe Avram::Migrator::AlterTableStatement do
     built.statements[2].should eq "ALTER TABLE ONLY test_defaults ALTER COLUMN money SET DEFAULT '29.99';"
   end
 
+  it "changes defaults after changing the type" do
+    built = Avram::Migrator::AlterTableStatement.new(:users).build do
+      change_type id : Int64
+      change_default id : Int64, default: 54
+    end
+    built.statements.size.should eq 2
+    built.statements[0].should eq "ALTER TABLE users ALTER COLUMN id SET DATA TYPE bigint;"
+    built.statements[1].should eq "ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT '54';"
+  end
+
   it "can change column nullability" do
     built = Avram::Migrator::AlterTableStatement.new(:users).build do
       forbid_nulls_for :id

--- a/spec/avram/migrator/alter_table_statement_spec.cr
+++ b/spec/avram/migrator/alter_table_statement_spec.cr
@@ -89,6 +89,17 @@ describe Avram::Migrator::AlterTableStatement do
     built.statements[2].should eq "ALTER TABLE ONLY test_defaults ALTER COLUMN money SET DEFAULT '29.99';"
   end
 
+  it "can change column nullability" do
+    built = Avram::Migrator::AlterTableStatement.new(:users).build do
+      forbid_nulls_for :id
+      allow_nulls_for :age
+    end
+
+    built.statements.size.should eq 2
+    built.statements[0].should eq "ALTER TABLE users ALTER COLUMN id SET NOT NULL;"
+    built.statements[1].should eq "ALTER TABLE users ALTER COLUMN age DROP NOT NULL;"
+  end
+
   describe "fill_existing_with" do
     it "fills existing with value and sets column to be non-null for non-null types" do
       built = Avram::Migrator::AlterTableStatement.new(:users).build do

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -105,38 +105,12 @@ class Avram::Migrator::AlterTableStatement
     "ALTER TABLE #{@table_name} ALTER COLUMN #{column_name} #{nullability ? "DROP" : "SET"} NOT NULL;"
   end
 
-  macro change_nullability_of(type_declaration)
-    {%
-      if !type_declaration.is_a?(TypeDeclaration)
-        raise "Must pass a type declaration to 'change_nullability_of'. Example: change_nullability_of count : Int32?"
-      end
-    %}
-    {%
-      type = type_declaration.type.resolve
-      nilable = false
-      if type.nilable?
-        type = type.union_types.reject(&.==(Nil)).first
-        nilable = true
-      end
-    %}
-    %column = ::Avram::Migrator::Columns::{{ type }}Column({{ type }}).new(
-      name: {{ type_declaration.var.stringify }},
-      nilable: {{ nilable }},
-      default: nil
-    )
-    add_change_nullability_statement %column
-  end
-
   def add_change_type_statement(column : ::Avram::Migrator::Columns::Base)
     change_type_statements << column.build_change_type_statement(@table_name)
   end
 
   def add_change_default_statement(column : ::Avram::Migrator::Columns::Base)
     change_default_statements << column.build_change_default_statement(@table_name)
-  end
-
-  def add_change_nullability_statement(column : ::Avram::Migrator::Columns::Base)
-    change_nullability_statements << column.build_change_nullability_statement(@table_name)
   end
 
   # Accepts a block to alter a table using the `add` method. The generated sql
@@ -165,7 +139,7 @@ class Avram::Migrator::AlterTableStatement
   end
 
   def statements
-    alter_statements + change_default_statements + change_type_statements + change_nullability_statements + index_statements + fill_existing_with_statements
+    alter_statements + change_type_statements + change_default_statements + change_nullability_statements + index_statements + fill_existing_with_statements
   end
 
   def if_exists_statement

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -11,6 +11,7 @@ class Avram::Migrator::AlterTableStatement
   getter fill_existing_with_statements = [] of String
   getter change_type_statements = [] of String
   getter change_default_statements = [] of String
+  getter change_nullability_statements = [] of String
   private getter? if_exists : Bool = false
 
   def initialize(@table_name : TableName, *, @if_exists : Bool = false)
@@ -80,12 +81,62 @@ class Avram::Migrator::AlterTableStatement
     add_change_default_statement %column
   end
 
+  # Change the column's nullability from whatever it is currently to true.
+  # ```
+  # alter table_for(User) do
+  #   allow_nulls_for :email
+  # end
+  # ```
+  macro allow_nulls_for(column_name)
+    change_nullability_statements << build_nullability_statement({{column_name.id.stringify}}, true)
+  end
+
+  # Change the column's nullability from whatever it is currently to false.
+  # ```
+  # alter table_for(User) do
+  #   forbid_nulls_for :email
+  # end
+  # ```
+  macro forbid_nulls_for(column_name)
+    change_nullability_statements  << build_nullability_statement({{column_name.id.stringify}}, false)
+  end
+
+  def build_nullability_statement(column_name, nullability)
+    "ALTER TABLE #{@table_name} ALTER COLUMN #{column_name} #{nullability ? "DROP" : "SET"} NOT NULL;"
+  end
+
+  macro change_nullability_of(type_declaration)
+    {%
+      if !type_declaration.is_a?(TypeDeclaration)
+        raise "Must pass a type declaration to 'change_nullability_of'. Example: change_nullability_of count : Int32?"
+      end
+    %}
+    {%
+      type = type_declaration.type.resolve
+      nilable = false
+      if type.nilable?
+        type = type.union_types.reject(&.==(Nil)).first
+        nilable = true
+      end
+    %}
+    %column = ::Avram::Migrator::Columns::{{ type }}Column({{ type }}).new(
+      name: {{ type_declaration.var.stringify }},
+      nilable: {{ nilable }},
+      default: nil
+    )
+    add_change_nullability_statement %column
+  end
+
   def add_change_type_statement(column : ::Avram::Migrator::Columns::Base)
     change_type_statements << column.build_change_type_statement(@table_name)
   end
 
   def add_change_default_statement(column : ::Avram::Migrator::Columns::Base)
     change_default_statements << column.build_change_default_statement(@table_name)
+  end
+
+  def add_change_nullability_statement(column : ::Avram::Migrator::Columns::Base)
+    change_nullability_statements << column.build_change_nullability_statement(@table_name)
   end
 
   # Accepts a block to alter a table using the `add` method. The generated sql
@@ -114,7 +165,7 @@ class Avram::Migrator::AlterTableStatement
   end
 
   def statements
-    alter_statements + change_default_statements + change_type_statements + index_statements + fill_existing_with_statements
+    alter_statements + change_default_statements + change_type_statements + change_nullability_statements + index_statements + fill_existing_with_statements
   end
 
   def if_exists_statement


### PR DESCRIPTION
This PR attempts to fix two things:

#### provide a way to change the nullability of a column in the migrator.
Related to #1039 
Two new macros have been created:
- allow_nulls_for :column, which allows for the :column to receive null values
- forbid_nulls for :column, which set the not null constraint
it is split from the change_type statement, so that you can theoretically do something like
```
change_type the_column : String
# migrate somehow the null fields present in the table
forbid_nulls_for :the_column
```

#### changes the order of the change_default statement with respect to the change_type statement
Currently, if you had something like:
```
change_type a : String
change_default a : String, default: "Whatever"
```
it would generate first the change of default, then the change of type, which is probably counterintuitive.
Now, it generates first the change of type, then the change of default