### PR TITLE
Add have any criteria

### DIFF
--- a/spec/avram/array_column_spec.cr
+++ b/spec/avram/array_column_spec.cr
@@ -47,33 +47,33 @@ describe "Array Columns" do
     bucket.enums.should eq([Bucket::Size::Small])
   end
 
-  describe "the #have_any? method" do
+  describe "the #have_any method" do
     it "returns the records with have at least one element of the provided ones" do
       BucketFactory.new.numbers([1, 2]).create
       BucketFactory.new.numbers([1, 3]).create
 
-      bucket = BucketQuery.new.numbers.have_any?([1, 2, 3]).select_count
+      bucket = BucketQuery.new.numbers.have_any([1, 2, 3]).select_count
       bucket.should eq 2
 
-      bucket = BucketQuery.new.numbers.have_any?([1, 3]).select_count
+      bucket = BucketQuery.new.numbers.have_any([1, 3]).select_count
       bucket.should eq 2
 
-      bucket = BucketQuery.new.numbers.have_any?([3, 4]).select_count
+      bucket = BucketQuery.new.numbers.have_any([3, 4]).select_count
       bucket.should eq 1
 
-      bucket = BucketQuery.new.numbers.have_any?([4]).select_count
+      bucket = BucketQuery.new.numbers.have_any([4]).select_count
       bucket.should eq 0
     end
 
     it "returns nothing with an empty array" do
       BucketFactory.new.numbers([1, 2]).create
-      bucket = BucketQuery.new.numbers.have_any?([] of Int64).select_count
+      bucket = BucketQuery.new.numbers.have_any([] of Int64).select_count
       bucket.should eq 0
     end
 
     it "negates with not" do
       BucketFactory.new.numbers([1, 2]).create
-      bucket = BucketQuery.new.numbers.not.have_any?([3]).select_count
+      bucket = BucketQuery.new.numbers.not.have_any([3]).select_count
       bucket.should eq 1
     end
   end

--- a/spec/avram/array_column_spec.cr
+++ b/spec/avram/array_column_spec.cr
@@ -46,4 +46,35 @@ describe "Array Columns" do
     bucket = SaveBucket.update!(bucket, enums: [Bucket::Size::Small])
     bucket.enums.should eq([Bucket::Size::Small])
   end
+
+  describe "the #have_any? method" do
+    it "returns the records with have at least one element of the provided ones" do
+      BucketFactory.new.numbers([1, 2]).create
+      BucketFactory.new.numbers([1, 3]).create
+
+      bucket = BucketQuery.new.numbers.have_any?([1, 2, 3]).select_count
+      bucket.should eq 2
+
+      bucket = BucketQuery.new.numbers.have_any?([1, 3]).select_count
+      bucket.should eq 2
+
+      bucket = BucketQuery.new.numbers.have_any?([3, 4]).select_count
+      bucket.should eq 1
+
+      bucket = BucketQuery.new.numbers.have_any?([4]).select_count
+      bucket.should eq 0
+    end
+
+    it "returns nothing with an empty array" do
+      BucketFactory.new.numbers([1, 2]).create
+      bucket = BucketQuery.new.numbers.have_any?([] of Int64).select_count
+      bucket.should eq 0
+    end
+
+    it "negates with not" do
+      BucketFactory.new.numbers([1, 2]).create
+      bucket = BucketQuery.new.numbers.not.have_any?([3]).select_count
+      bucket.should eq 1
+    end
+  end
 end

--- a/spec/avram/migrator/alter_table_statement_spec.cr
+++ b/spec/avram/migrator/alter_table_statement_spec.cr
@@ -89,6 +89,27 @@ describe Avram::Migrator::AlterTableStatement do
     built.statements[2].should eq "ALTER TABLE ONLY test_defaults ALTER COLUMN money SET DEFAULT '29.99';"
   end
 
+  it "changes defaults after changing the type" do
+    built = Avram::Migrator::AlterTableStatement.new(:users).build do
+      change_type id : Int64
+      change_default id : Int64, default: 54
+    end
+    built.statements.size.should eq 2
+    built.statements[0].should eq "ALTER TABLE users ALTER COLUMN id SET DATA TYPE bigint;"
+    built.statements[1].should eq "ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT '54';"
+  end
+
+  it "can change column nullability" do
+    built = Avram::Migrator::AlterTableStatement.new(:users).build do
+      forbid_nulls_for :id
+      allow_nulls_for :age
+    end
+
+    built.statements.size.should eq 2
+    built.statements[0].should eq "ALTER TABLE users ALTER COLUMN id SET NOT NULL;"
+    built.statements[1].should eq "ALTER TABLE users ALTER COLUMN age DROP NOT NULL;"
+  end
+
   describe "fill_existing_with" do
     it "fills existing with value and sets column to be non-null for non-null types" do
       built = Avram::Migrator::AlterTableStatement.new(:users).build do

--- a/spec/avram/where_spec.cr
+++ b/spec/avram/where_spec.cr
@@ -28,5 +28,7 @@ describe Avram::Where do
     should_negate(Avram::Where::In, Avram::Where::NotIn)
     should_negate(Avram::Where::NotIn, Avram::Where::In)
     should_negate(Avram::Where::Null, Avram::Where::NotNull)
+    should_negate(Avram::Where::Any, Avram::Where::NotAny)
+    should_negate(Avram::Where::NotAny, Avram::Where::Any)
   end
 end

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -154,7 +154,7 @@ class Avram::Criteria(T, V)
     add_clause(Avram::Where::In.new(column, values))
   end
 
-  def have_any?(values) : T
+  def have_any(values) : T
     values = values.map { |value| V.adapter.to_db!(value) }
     add_clause(Avram::Where::Any.new(column, values))
   end

--- a/src/avram/criteria.cr
+++ b/src/avram/criteria.cr
@@ -154,6 +154,11 @@ class Avram::Criteria(T, V)
     add_clause(Avram::Where::In.new(column, values))
   end
 
+  def have_any?(values) : T
+    values = values.map { |value| V.adapter.to_db!(value) }
+    add_clause(Avram::Where::Any.new(column, values))
+  end
+
   # :nodoc:
   def private_distinct_on : T
     rows.tap &.query.distinct_on(column)

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -113,6 +113,10 @@ class Avram::Migrator::AlterTableStatement
     change_default_statements << column.build_change_default_statement(@table_name)
   end
 
+  def add_change_nullability_statement(column : ::Avram::Migrator::Columns::Base)
+    change_nullability_statements << column.build_change_nullability_statement(@table_name)
+  end
+
   # Accepts a block to alter a table using the `add` method. The generated sql
   # statements are aggregated in the `statements` getter.
   #

--- a/src/avram/migrator/alter_table_statement.cr
+++ b/src/avram/migrator/alter_table_statement.cr
@@ -113,10 +113,6 @@ class Avram::Migrator::AlterTableStatement
     change_default_statements << column.build_change_default_statement(@table_name)
   end
 
-  def add_change_nullability_statement(column : ::Avram::Migrator::Columns::Base)
-    change_nullability_statements << column.build_change_nullability_statement(@table_name)
-  end
-
   # Accepts a block to alter a table using the `add` method. The generated sql
   # statements are aggregated in the `statements` getter.
   #

--- a/src/avram/where.cr
+++ b/src/avram/where.cr
@@ -217,6 +217,34 @@ module Avram::Where
     end
   end
 
+  class Any < ValueHoldingSqlClause
+    def operator : String
+      "&&"
+    end
+
+    def negated : NotAny
+      NotAny.new(column, value)
+    end
+
+    def prepare(placeholder_supplier : Proc(String)) : String
+      "#{column} #{operator} (#{placeholder_supplier.call})"
+    end
+  end
+
+  class NotAny < ValueHoldingSqlClause
+    def operator : String
+      "&&"
+    end
+
+    def negated : Any
+      Any.new(column, value)
+    end
+
+    def prepare(placeholder_supplier : Proc(String)) : String
+      "NOT(#{column} #{operator} (#{placeholder_supplier.call}))"
+    end
+  end
+
   class Includes < ValueHoldingSqlClause
     def operator : String
       "= ANY"


### PR DESCRIPTION
Implements the feature in #1030 
However, the method was renamed to `have_any?`, instead of `has_any`, just because an array column will prolly be called in the plural form (e.g: `Users.tags`) and have_any just sounded better.