### PR TITLE
Support camelcase when generate migration file, Fix #1045

### DIFF
--- a/src/avram/tasks/gen/migration.cr
+++ b/src/avram/tasks/gen/migration.cr
@@ -3,19 +3,18 @@ require "./migration_generator"
 class Gen::Migration < LuckyTask::Task
   summary "Generate a new migration"
   help_message <<-TEXT
-  Generate a new migration using the passed in migration name.
+  Generate a new migration using the passed in migration file name.
 
-  The migration name must be CamelCase. No other options are available.
+  The migration file name can be underscore or CamelCase. No other options are available.
 
   Examples:
 
-    lucky gen.migration CreateUsers
+    lucky gen.migration create_users
     lucky gen.migration AddAgeToUsers
-    lucky gen.migration MakeUserNameOptional
 
   TEXT
 
-  positional_arg :migration_name, "The migration class name", format: /^[A-Z]/
+  positional_arg :migration_file_name, "The migration file name"
 
   Habitat.create do
     setting io : IO = STDOUT
@@ -29,7 +28,7 @@ class Gen::Migration < LuckyTask::Task
 
   def call
     Avram::Migrator.run do
-      Avram::Migrator::MigrationGenerator.new(name: migration_name, io: output).generate
+      Avram::Migrator::MigrationGenerator.new(name: migration_file_name, io: output).generate
     end
   end
 end

--- a/src/avram/tasks/gen/migration_generator.cr
+++ b/src/avram/tasks/gen/migration_generator.cr
@@ -18,7 +18,7 @@ class Avram::Migrator::MigrationGenerator
   end
 
   def generate(@_version = @_version)
-    ensure_camelcase_name
+    @name = name.camelcase
     make_migrations_folder_if_missing
     ensure_unique
     File.write(file_path, contents)
@@ -49,16 +49,6 @@ class Avram::Migrator::MigrationGenerator
         string << "\n"
       end
     end.chomp
-  end
-
-  private def ensure_camelcase_name
-    if name.camelcase != name
-      raise <<-ERROR
-      Migration must be in camel case.
-
-        #{green_arrow} Try this instead: #{"lucky gen.migration #{name.camelcase}".colorize(:green)}
-      ERROR
-    end
   end
 
   private def ensure_unique


### PR DESCRIPTION
Test on both CamelCase and underscore form, it should work.

```
 ╰─ $ lucky gen.migration add_some_column_into_universities
Created AddSomeColumnIntoUniversities::V20240524171815 in ./db/migrations/20240524171815_add_some_column_into_universities.cr
```

```
 ╰─ $ lucky gen.migration AddSomeColumnIntoUniversities
Created AddSomeColumnIntoUniversities::V20240524172255 in ./db/migrations/20240524172255_add_some_column_into_universities.cr
```

BTW: i remove the CamelCase check completely, i consider those code is unnecessary, if a user can user task to create migration, we assume it know how to form the migration name.
