### PR TITLE
Adding a helpful error message for "Could not connect"

### DIFF
--- a/src/avram/errors.cr
+++ b/src/avram/errors.cr
@@ -94,6 +94,7 @@ module Avram
         message << "  ▸ Check connection settings in 'config/database.cr'\n"
         message << "  ▸ Be sure the database exists (lucky db.create)\n"
         message << "  ▸ Check that you have access to connect to #{connection_details.host} on port #{connection_details.port || DEFAULT_PG_PORT}\n"
+        message << "  ▸ If this is your first run, create a database named '#{connection_details.user}' that this same user will have access to\n"
         if connection_details.password.blank?
           message << "  ▸ You didn't supply a password, did you mean to?\n"
         end


### PR DESCRIPTION
Fixes #983

I just got bit by this again. If your default user is `postgres`, you generally already have a database called `postgres`; however, in the case of Avram specs, we use the user `lucky`. This means you have to have a local db call `lucky` in order to run `lucky db.create`. This is because when we removed the `pg_client` dependency we no longer have access to `createdb`. Instead, we have to connect to the DB server and run some SQL... but postgres doesn't let you connect to the server without being attached to some database.. :chicken: :egg: :man_shrugging:  

This PR just adds an error message that tells you

> ▸ If this is your first run, create a database named 'lucky' that this same user will have access to

That should at least point to a common fix for this problem.