### PR TITLE
Fixing Crystal nightly issues related to upcoming 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             crystal_version: latest
             postgres_version: 14
             experimental: true
-          - shard_file: shard.yml
+          - shard_file: shard.override.yml
             crystal_version: nightly
             postgres_version: 14
             experimental: true

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,4 +1,7 @@
-# dependencies:
+dependencies:
+  habitat:
+    github: luckyframework/habitat
+    branch: main
 development_dependencies:
   lucky:
     github: luckyframework/lucky


### PR DESCRIPTION
Closes #1025

The issues are actually related to Habitat and Lucky, but since this shard has dependencies on them, it also started failing. Now that those shards have been resolved, we can test using them to make sure all of these specs turn green again.