### PR TITLE
Use postgres as the default setup db

### DIFF
--- a/src/avram.cr
+++ b/src/avram.cr
@@ -30,6 +30,9 @@ module Avram
     setting time_formats : Array(String) = [] of String
     setting i18n_backend : Avram::I18nBackend = Avram::I18n.new, example: "Avram::I18n.new"
     setting query_cache_enabled : Bool = false
+    # This setting is used to connect to postgres before you've setup your app's DB.
+    # If `postgres` isn't available, you can update to `template1` or some other default DB
+    setting setup_database_name : String = "postgres"
   end
 
   Log            = ::Log.for(Avram)

--- a/src/avram/migrator/runner.cr
+++ b/src/avram/migrator/runner.cr
@@ -69,7 +69,7 @@ class Avram::Migrator::Runner
   end
 
   def self.drop_db(quiet? : Bool = false)
-    DB.connect("#{credentials.connection_string}/#{db_user}") do |db|
+    DB.connect("#{credentials.connection_string}/#{Avram.settings.setup_database_name}") do |db|
       db.exec "DROP DATABASE IF EXISTS #{db_name}"
     end
     unless quiet?
@@ -78,7 +78,7 @@ class Avram::Migrator::Runner
   end
 
   def self.create_db(quiet? : Bool = false)
-    DB.connect("#{credentials.connection_string}/#{db_user}") do |db|
+    DB.connect("#{credentials.connection_string}/#{Avram.settings.setup_database_name}") do |db|
       db.exec "CREATE DATABASE #{db_name}"
     end
     unless quiet?


### PR DESCRIPTION
Fixes #1056

When you setup a postgres server, 99.9% of the time the  `postgres` db will exist. Made this a configurable option. As an alternative, you could use `template0` or `template1` to connect before any other DB is setup. 