### PR TITLE
Adding table locking.

### DIFF
--- a/src/avram/database.cr
+++ b/src/avram/database.cr
@@ -84,6 +84,21 @@ abstract class Avram::Database
     end
   end
 
+  # Creates a lock on the table in `mode`
+  # ```
+  # AppDatabase.with_lock_on(User, mode: :row_exclusive) do
+  #   user = UserQuery.new.id(1).for_update.first
+  #   SaveUser.update!(user, name: "New Name")
+  # end
+  # ```
+  def self.with_lock_on(model : Avram::Model.class, mode : Avram::TableLockMode, &)
+    exec("BEGIN")
+    exec("LOCK TABLE #{model.table_name} IN #{mode} MODE")
+    yield
+  ensure
+    exec("END")
+  end
+
   # Methods without a block
   {% for crystal_db_alias in [:exec, :scalar, :query, :query_all, :query_one, :query_one?] %}
     # Same as crystal-db's `DB::QueryMethods#{{ crystal_db_alias.id }}` but with instrumentation

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -14,6 +14,7 @@ class Avram::QueryBuilder
   @prepared_statement_placeholder = 0
   @distinct : Bool = false
   @delete : Bool = false
+  @for_update : Bool = false
 
   def initialize(@table)
   end
@@ -116,7 +117,7 @@ class Avram::QueryBuilder
   end
 
   private def sql_condition_clauses
-    [joins_sql, wheres_sql, group_sql, order_sql, limit_sql, offset_sql]
+    [joins_sql, wheres_sql, group_sql, order_sql, limit_sql, offset_sql, locking_sql]
   end
 
   def delete : self
@@ -155,6 +156,11 @@ class Avram::QueryBuilder
   end
 
   def offset(@offset : Int32?) : self
+    self
+  end
+
+  def for_update : self
+    @for_update = true
     self
   end
 
@@ -383,5 +389,11 @@ class Avram::QueryBuilder
 
   private def delete_sql : String
     "DELETE FROM #{table}"
+  end
+
+  private def locking_sql : String?
+    if @for_update
+      "FOR UPDATE"
+    end
   end
 end

--- a/src/avram/queryable.cr
+++ b/src/avram/queryable.cr
@@ -196,6 +196,10 @@ module Avram::Queryable(T)
     clone.tap &.query.offset(amount)
   end
 
+  def for_update : self
+    clone.tap &.query.for_update
+  end
+
   def first? : T?
     with_ordered_query
       .limit(1)

--- a/src/avram/table_lock_mode.cr
+++ b/src/avram/table_lock_mode.cr
@@ -1,0 +1,16 @@
+module Avram
+  enum TableLockMode
+    ACCESS_SHARE
+    ROW_SHARE
+    ROW_EXCLUSIVE
+    SHARE_UPDATE_EXCLUSIVE
+    SHARE
+    SHARE_ROW_EXCLUSIVE
+    EXCLUSIVE
+    ACCESS_EXCLUSIVE
+
+    def to_s
+      member_name.to_s.gsub("_", " ")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #594

This adds some options for doing table and row locks.

```crystal
AppDatabase.with_lock_on(User, mode: :row_exclusive) do
  user = UserQuery.new.id(1).for_update.first
  SaveUser.update!(user, name: "New Name")
end
```

Testing it in a real app, and it seems to work... I'm not sure how to test this other than just ensuring the correct SQL is generated.