### PR TITLE
Fix missing nested param error for nested array params

### DIFF
--- a/src/avram/add_column_attributes.cr
+++ b/src/avram/add_column_attributes.cr
@@ -24,7 +24,7 @@ module Avram::AddColumnAttributes
       return {} of String => Array(String) | String if @@permitted_param_keys.empty?
 
       single_values = @params.nested(self.class.param_key).reject {|k,v| k.ends_with?("[]")}
-      array_values = @params.nested_arrays?(self.class.param_key) || {} of String => Array(String)
+      array_values = @params.nested_arrays?(self.class.param_key)
       new_params = single_values.merge(array_values)
       new_params.select(@@permitted_param_keys)
     end

--- a/src/avram/attribute.cr
+++ b/src/avram/attribute.cr
@@ -102,7 +102,7 @@ class Avram::Attribute(T)
 
   private def extract(params, type : Avram::Uploadable.class)
     file = params.nested_file?(param_key)
-    @param = param_val = file.try(&.[]?(name.to_s))
+    @param = param_val = file[name.to_s]?
     return if param_val.nil?
 
     parse_result = Avram::Uploadable.adapter.parse(param_val)

--- a/src/avram/attribute.cr
+++ b/src/avram/attribute.cr
@@ -87,7 +87,7 @@ class Avram::Attribute(T)
   end
 
   private def extract(params, type : Array(T).class) forall T
-    nested_params = params.nested_arrays(param_key)
+    nested_params = params.nested_arrays?(param_key)
     param_val = nested_params[name.to_s]?
     @param = param_val.try(&.first?)
     return if param_val.nil?


### PR DESCRIPTION
Even if nested params is not empty, Lucky would still raise `Lucky::MissingNestedParamError` if any array attributes are not set.

You had to fill in the array attribute to avoid the error:

```crystal
response = client.exec(Features::Create, feature: {
  choices: Array(String).new, # Without this, you get "Missing param key: 'feature' (Lucky::MissingNestedParamError)..."
  maximum: 99,
  minimum: 3,
  name: "Number of Kitchens",
  type: :integer
})
```

See <https://github.com/luckyframework/lucky/issues/1949>