### PR TITLE
Allow defining separate reader and writer databases

### DIFF
--- a/spec/avram/multi_database_spec.cr
+++ b/spec/avram/multi_database_spec.cr
@@ -10,6 +10,16 @@ private class ModelWithBadDatabase < BaseModel
   end
 end
 
+private class BaseModelWithSeparateReadWrite < Avram::Model
+  def self.read_database : Avram::Database.class
+    TestDatabase
+  end
+
+  def self.write_database : Avram::Database.class
+    TestDatabase
+  end
+end
+
 describe "Configuring and connecting to different databases" do
   it "tries to connect to the configured database" do
     # It will fail to connect which is what we expect since we configured
@@ -21,4 +31,9 @@ describe "Configuring and connecting to different databases" do
       ModelWithBadDatabase::BaseQuery.new.select_count
     end
   end
+
+  # context "when read and write are separate DBs" do
+  #   it "uses the read_database" do
+  #   end
+  # end
 end

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -16,7 +16,7 @@ class Avram::BaseQueryTemplate
 
       {% if named_args[:materialized_view] %}
       def self.refresh_view(*, concurrent : Bool = false)
-        {{ type }}.database.exec("REFRESH MATERIALIZED VIEW #{concurrent ? "CONCURRENTLY" : ""} #{{{ type }}.table_name}")
+        {{ type }}.write_database.exec("REFRESH MATERIALIZED VIEW #{concurrent ? "CONCURRENTLY" : ""} #{{{ type }}.table_name}")
       end
       {% end %}
 
@@ -39,7 +39,7 @@ class Avram::BaseQueryTemplate
           end
         {% end %}
 
-        database.exec(
+        write_database.exec(
           query.statement_for_update(_changes, return_columns: false),
           args: query.args_for_update(_changes)
         ).rows_affected

--- a/src/avram/delete_operation.cr
+++ b/src/avram/delete_operation.cr
@@ -35,13 +35,13 @@ abstract class Avram::DeleteOperation(T)
     T.name.underscore
   end
 
-  delegate :database, :table_name, :primary_key_name, to: T
+  delegate :write_database, :table_name, :primary_key_name, to: T
 
   def delete : Bool
     before_delete
 
     if valid?
-      transaction_committed = database.transaction do
+      transaction_committed = write_database.transaction do
         @record = delete_or_soft_delete(record)
         after_delete(record)
         true

--- a/src/avram/model.cr
+++ b/src/avram/model.cr
@@ -19,8 +19,38 @@ abstract class Avram::Model
     nil
   end
 
+  def self.database
+    {% raise <<-ERROR
+        The class method `database` must be defined on the BaseModel,
+        or defined as separate `read_database` and `write_database` class methods.
+
+        Example:
+          def self.database : Avram::Database.class
+            AppDatabase
+          end
+
+        Or separated as:
+          def self.read_database : Avram::Database.class
+            ReadDatabase
+          end
+
+          def self.write_database : Avram::Database.class
+            WriteDatabase
+          end
+        ERROR
+    %}
+  end
+
+  def self.read_database : Avram::Database.class
+    database
+  end
+
+  def self.write_database : Avram::Database.class
+    database
+  end
+
   def self.database_table_info : Avram::Database::TableInfo?
-    database.database_info.table(table_name.to_s)
+    read_database.database_info.table(table_name.to_s)
   end
 
   def model_name : String


### PR DESCRIPTION
Fixes #138

This PR adds in two new model methods `read_database` and `write_database`. By default they both point to the same database, so in theory, you would be able to update Avram and everything works like normal. Then when you need to start using a read replica, it becomes as each as just overriding a method.

There are a few things I'm sort of overlooking here as I don't want to get too complicated... The concept of multi-tenant sharding won't exist (yet, at least). I have no clue how we would handle that. Same goes for doing any sort of load balancing. My guess is with it being in a method, that's probably something you could implement if you really needed.

The last bits I really want before I mark this as ready for review would be

* How do I test this?
* How can we do a temp override on the fly?

```crystal
# How would I do this?
Avram.use_database(OtherDB) do
  # uses OtherDB instead of the normal one
  UserQuery.new
end

# uses your normal DB...
UserQuery.new
```