### PR TITLE
Add join method overloads that accept the query condition as argument

### DIFF
--- a/spec/avram/associations_spec.cr
+++ b/spec/avram/associations_spec.cr
@@ -118,8 +118,8 @@ describe Avram::Model do
         comment = CommentForCustomPost::SaveOperation.create!(body: "bar", post_id: post.id)
         comment.post_with_custom_table.should eq(post)
 
-        CommentForCustomPost::BaseQuery.new.where_post_with_custom_table(PostWithCustomTable::BaseQuery.new.id(post.id)).first.should eq(comment)
-        PostWithCustomTable::BaseQuery.new.where_comments_for_custom_post(CommentForCustomPost::BaseQuery.new.id(comment.id)).first.should eq(post)
+        CommentForCustomPost::BaseQuery.new.join_post_with_custom_table(PostWithCustomTable::BaseQuery.new.id(post.id)).first.should eq(comment)
+        PostWithCustomTable::BaseQuery.new.join_comments_for_custom_post(CommentForCustomPost::BaseQuery.new.id(comment.id)).first.should eq(post)
       end
     end
 

--- a/spec/avram/query_associations_spec.cr
+++ b/spec/avram/query_associations_spec.cr
@@ -50,11 +50,11 @@ describe "Query associations" do
       .create
 
     posts = Post::BaseQuery.new
-      .where_comments(CommentQuery.new.body_eq("matching"))
+      .join_comments(CommentQuery.new.body_eq("matching"))
     posts.results.should eq([post_with_matching_comment])
 
     posts = Post::BaseQuery.new
-      .where_comments(Comment::BaseQuery.new.body("matching"))
+      .join_comments(Comment::BaseQuery.new.body("matching"))
     posts.results.should eq([post_with_matching_comment])
   end
 
@@ -72,8 +72,7 @@ describe "Query associations" do
       .create
 
     posts = Post::BaseQuery.new
-      .inner_join_comments
-      .where_comments(Comment::BaseQuery.new.body.eq("matching"), auto_inner_join: false)
+      .inner_join_comments(Comment::BaseQuery.new.body.eq("matching"))
     posts.to_sql[0].should contain "INNER JOIN"
     posts.results.should eq([post_with_matching_comment])
   end
@@ -92,8 +91,7 @@ describe "Query associations" do
       .create
 
     posts = Post::BaseQuery.new
-      .left_join_comments
-      .where_comments(Comment::BaseQuery.new.body.eq("matching"), auto_inner_join: false)
+      .left_join_comments(Comment::BaseQuery.new.body.eq("matching"))
     posts.to_sql[0].should contain "LEFT JOIN"
     posts.results.should eq([post_with_matching_comment])
   end
@@ -112,8 +110,7 @@ describe "Query associations" do
       .create
 
     posts = Post::BaseQuery.new
-      .right_join_comments
-      .where_comments(Comment::BaseQuery.new.body.eq("matching"), auto_inner_join: false)
+      .right_join_comments(where_comments: Comment::BaseQuery.new.body.eq("matching"))
     posts.to_sql[0].should contain "RIGHT JOIN"
     posts.results.should eq([post_with_matching_comment])
   end
@@ -132,15 +129,14 @@ describe "Query associations" do
       .create
 
     posts = Post::BaseQuery.new
-      .full_join_comments
-      .where_comments(Comment::BaseQuery.new.body.eq("matching"), auto_inner_join: false)
+      .full_join_comments(Comment::BaseQuery.new.body.eq("matching"))
     posts.to_sql[0].should contain "FULL JOIN"
     posts.results.should eq([post_with_matching_comment])
   end
 
   it "can query associations on namespaced models" do
     orgs = NamedSpaced::Organization::BaseQuery.new
-      .where_locations(NamedSpaced::Location::BaseQuery.new.name("Home"))
+      .join_locations(NamedSpaced::Location::BaseQuery.new.name("Home"))
     orgs.to_sql[0].should contain "INNER JOIN"
 
     staff = NamedSpaced::Staff::BaseQuery.new
@@ -154,9 +150,9 @@ describe "Query associations" do
 
     line_item_query = LineItemQuery.new
       .id(item.id)
-      .where_associated_products(ProductQuery.new.id(product.id))
+      .join_associated_products(ProductQuery.new.id(product.id))
     result = LineItemProductQuery.new
-      .where_line_item(line_item_query)
+      .join_line_item(line_item_query)
       .find(line_item_product.id)
 
     result.should eq(line_item_product)
@@ -169,9 +165,9 @@ describe "Query associations" do
 
     line_item_query = LineItemQuery.new
       .id(item.id)
-      .where_line_items_products(LineItemProductQuery.new.id(line_item_product.id))
+      .join_line_items_products(LineItemProductQuery.new.id(line_item_product.id))
     result = ProductQuery.new
-      .where_line_items(line_item_query)
+      .join_line_items(line_item_query)
       .find(product.id)
 
     result.should eq(product)

--- a/spec/avram/queryable_spec.cr
+++ b/spec/avram/queryable_spec.cr
@@ -1364,7 +1364,7 @@ describe Avram::Queryable do
       manager1 = ManagerFactory.create(&.name("Mr. Krabs"))
       manager2 = ManagerFactory.create(&.name("Mr. Robot"))
       EmployeeFactory.create(&.name("Spongebob Alderson").manager_id(manager1.id))
-      Employee::BaseQuery.new.where_manager(Manager::BaseQuery.new.id(manager1.id)).update(manager_id: manager2.id)
+      Employee::BaseQuery.new.join_manager(Manager::BaseQuery.new.id(manager1.id)).update(manager_id: manager2.id)
       manager1.employees!.first?.should be_nil
       manager2.employees!.first.name.should eq("Spongebob Alderson")
     end
@@ -1405,7 +1405,7 @@ describe Avram::Queryable do
 
   describe "#asc_order" do
     it "orders by a joined table" do
-      query = Post::BaseQuery.new.where_comments(Comment::BaseQuery.new.created_at.asc_order)
+      query = Post::BaseQuery.new.join_comments(Comment::BaseQuery.new.created_at.asc_order)
       query.to_sql[0].should contain %(ORDER BY "comments"."created_at" ASC)
     end
 
@@ -1481,7 +1481,7 @@ describe Avram::Queryable do
       post = PostFactory.create
       CommentFactory.create &.post_id(post.id)
 
-      original_query = Post::BaseQuery.new.where_comments(Comment::BaseQuery.new.created_at.asc_order)
+      original_query = Post::BaseQuery.new.join_comments(Comment::BaseQuery.new.created_at.asc_order)
       new_query = original_query.clone.select_count
 
       original_query.first.should_not eq nil
@@ -1597,7 +1597,7 @@ describe Avram::Queryable do
         line_item = LineItemFactory.create &.name("Thing 1")
         price = PriceFactory.create &.in_cents(100).line_item_id(line_item.id)
 
-        query = PriceQuery.new.where_line_item(LineItemQuery.new.name("Thing 1"))
+        query = PriceQuery.new.inner_join_line_item(LineItemQuery.new.name("Thing 1"))
         query.first.should eq price
       end
     end
@@ -1607,7 +1607,7 @@ describe Avram::Queryable do
         line_item = LineItemFactory.create &.name("Thing 1")
         PriceFactory.create &.in_cents(100).line_item_id(line_item.id)
 
-        query = LineItemQuery.new.where_price(PriceQuery.new.in_cents(100))
+        query = LineItemQuery.new.inner_join_price(PriceQuery.new.in_cents(100))
         query.first.should eq line_item
       end
     end

--- a/src/avram/base_query_template.cr
+++ b/src/avram/base_query_template.cr
@@ -62,6 +62,10 @@ class Avram::BaseQueryTemplate
           inner_join_{{ assoc[:assoc_name] }}
         end
 
+        def join_{{ assoc[:assoc_name] }}(where_{{ assoc[:assoc_name] }} : {{ assoc[:type] }}::BaseQuery)
+          inner_join_{{ assoc[:assoc_name] }}(where_{{ assoc[:assoc_name] }})
+        end
+
         {% for join_type in ["Inner", "Left", "Right", "Full"] %}
           def {{ join_type.downcase.id }}_join_{{ assoc[:assoc_name] }}
             {% if assoc[:relationship_type] == :belongs_to %}
@@ -98,9 +102,13 @@ class Avram::BaseQueryTemplate
               )
             {% end %}
           end
+
+          def {{ join_type.downcase.id }}_join_{{ assoc[:assoc_name] }}(where_{{ assoc[:assoc_name] }} : {{ assoc[:type] }}::BaseQuery)
+            {{ join_type.downcase.id }}_join_{{ assoc[:assoc_name] }}.merge_query(where_{{ assoc[:assoc_name] }}.query)
+          end
         {% end %}
 
-
+        @[Deprecated("Use any of the join methods with a where_{{ assoc[:assoc_name] }} argument instead")]
         def where_{{ assoc[:assoc_name] }}(assoc_query : {{ assoc[:type] }}::BaseQuery, auto_inner_join : Bool = true)
           if auto_inner_join
             join_{{ assoc[:assoc_name] }}.merge_query(assoc_query.query)


### PR DESCRIPTION
This deprecates `#where_*` join methods to which the query condition was delegated.

Closes #1088 