### PR TITLE
Adding the database method back in to Save and Delete operations

### DIFF
--- a/spec/avram/operations/delete_operation_spec.cr
+++ b/spec/avram/operations/delete_operation_spec.cr
@@ -134,4 +134,16 @@ describe "Avram::DeleteOperation" do
       end
     end
   end
+
+  describe "#database" do
+    it "has access to the database via a helper method" do
+      post = PostFactory.create &.title("sandbox")
+
+      DeleteOperationWithAccessToModelValues.delete(post) do |operation, _deleted_post|
+        expect_raises(Avram::Rollback) do
+          operation.database.rollback
+        end
+      end
+    end
+  end
 end

--- a/spec/avram/operations/save_operation_spec.cr
+++ b/spec/avram/operations/save_operation_spec.cr
@@ -1015,6 +1015,17 @@ describe "Avram::SaveOperation" do
       end
     end
   end
+
+  describe "#database" do
+    it "has access to the database via a helper method" do
+      post = PostFactory.create
+      AllowBlankComment.create(post_id: post.id, body: "") do |op, _new_comment|
+        expect_raises(Avram::Rollback) do
+          op.database.rollback
+        end
+      end
+    end
+  end
 end
 
 private def now_as_string

--- a/src/avram/delete_operation.cr
+++ b/src/avram/delete_operation.cr
@@ -37,6 +37,12 @@ abstract class Avram::DeleteOperation(T)
 
   delegate :write_database, :table_name, :primary_key_name, to: T
 
+  # A helper method to backfill accesing the database
+  # before they were split in to read/write methods
+  def database : Avram::Database.class
+    write_database
+  end
+
   def delete : Bool
     before_delete
 

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -54,6 +54,12 @@ abstract class Avram::SaveOperation(T)
 
   delegate :write_database, :table_name, :primary_key_name, to: T
 
+  # A helper method to backfill accesing the database
+  # before they were split in to read/write methods
+  def database : Avram::Database.class
+    write_database
+  end
+
   private def publish_save_failed_event
     Avram::Events::SaveFailedEvent.publish(
       operation_class: self.class.name,


### PR DESCRIPTION
Fixes #1101

Previously we had delegated the `database` method to the model, but that method won't always exist now since splitting them in to read/write access. This PR adds the method back in as a helper method to avoid breaking changes with existing apps.