### PR TITLE
Fix `Avram::SaveOperation#new_record?` for when id is set explicitly

### DIFF
--- a/spec/avram/operations/save_operation_spec.cr
+++ b/spec/avram/operations/save_operation_spec.cr
@@ -913,6 +913,14 @@ describe "Avram::SaveOperation" do
         operation.save.should be_true
         operation.new_record?.should be_true
       end
+
+      it "returns 'true' even if primary key is set" do
+        operation = SaveUser.new(id: 123, name: "Dan", age: 34, joined_at: Time.utc)
+
+        operation.new_record?.should be_true
+        operation.save.should be_true
+        operation.new_record?.should be_true
+      end
     end
 
     context "when updating" do

--- a/src/avram/save_operation.cr
+++ b/src/avram/save_operation.cr
@@ -267,7 +267,7 @@ abstract class Avram::SaveOperation(T)
   # This method should always return `true` for a create or `false`
   # for an update, independent of the stage we are at in the operation.
   def new_record? : Bool
-    {{ T.constant(:PRIMARY_KEY_NAME).id }}.value.nil?
+    {{ T.constant(:PRIMARY_KEY_NAME).id }}.original_value.nil?
   end
 
   private def insert_or_update


### PR DESCRIPTION
Fixes #1105 