### PR TITLE
Adding new create_many factory method

### DIFF
--- a/spec/avram/factory_spec.cr
+++ b/spec/avram/factory_spec.cr
@@ -60,6 +60,22 @@ describe Avram::Factory do
     end
   end
 
+  describe "create_many" do
+    it "creates N factories" do
+      tags = TagFactory.create_many(4)
+      tags.size.should eq(4)
+      tags.should be_a(Array(Tag))
+    end
+
+    it "takes a block to customize the factories" do
+      tags = TagFactory.create_many(4) do |factory|
+        factory.name(factory.sequence("tag-me"))
+      end
+      tags.size.should eq(4)
+      tags.map(&.name).should eq(["tag-me-1", "tag-me-2", "tag-me-3", "tag-me-4"])
+    end
+  end
+
   describe "before_save" do
     it "sets the association before saving" do
       factory = ScanFactory.new

--- a/src/avram/factory.cr
+++ b/src/avram/factory.cr
@@ -85,6 +85,37 @@ abstract class Avram::Factory
     run_after_save_callbacks(record)
   end
 
+  # Returns an array with `number` instances of the model from the Factory.
+  #
+  # Usage:
+  #
+  # ```
+  # tags = TagFactory.create_many(2)
+  # typeof(tags) # => Array(Tag)
+  # tags.size    # => 2
+  # ```
+  def self.create_many(number : Int32)
+    create_many(number) { |factory| factory }
+  end
+
+  # Similar to `create_many(n)`, but accepts a block which yields the factory instance.
+  #
+  # All factories receive the same argument values.
+  #
+  # Usage:
+  #
+  # ```
+  # TagFactory.create_many(2) do |factory|
+  #   # set both factories name to "test"
+  #   factory.name("test")
+  # end
+  # ```
+  def self.create_many(number : Int32, &)
+    (1..number).to_a.map do |_|
+      self.create { |factory| yield(factory) }
+    end
+  end
+
   # Returns an array with 2 instances of the model from the Factory.
   #
   # Usage:
@@ -95,7 +126,7 @@ abstract class Avram::Factory
   # tags.size    # => 2
   # ```
   def self.create_pair
-    create_pair { |factory| factory }
+    create_many(2)
   end
 
   # Similar to `create_pair`, but accepts a block which yields the factory instance.
@@ -111,8 +142,8 @@ abstract class Avram::Factory
   # end
   # ```
   def self.create_pair(&)
-    [1, 2].map do |_|
-      self.create { |factory| yield(factory) }
+    create_many(2) do |factory|
+      yield factory
     end
   end
 


### PR DESCRIPTION
Fixes #1113

Adds a new `create_many` factory method that essentially works the same as `create_pair` but allowing you to specify the number you want to create. Then `create_pair` just proxies to `create_many(2)`.

```crystal
TagFactory.create_many(3)
TagFactory.create_many(3, &.name("test"))
```