### PR TITLE
Add safe record reload

### DIFF
--- a/spec/avram/model_spec.cr
+++ b/spec/avram/model_spec.cr
@@ -142,7 +142,7 @@ describe Avram::Model do
       user.reload?.should be_nil
     end
 
-    it "can reload a model with a yielded query" do
+    it "can safely reload a model with a yielded query" do
       with_lazy_load(enabled: false) do
         post = PostFactory.create
 

--- a/src/avram/primary_key_methods.cr
+++ b/src/avram/primary_key_methods.cr
@@ -86,7 +86,7 @@ module Avram::PrimaryKeyMethods
     base_query_class.new.id(id).first?
   end
 
-  # Same as `reload` but allows passing a block to customize the query.
+  # Same as `reload?` but allows passing a block to customize the query.
   #
   # This is almost always used to preload additional relationships.
   #


### PR DESCRIPTION
As discussed in the Discord, this adds the `.reload?` and `.reload?(&)` methods to safely reload records without raising a `Avram::RecordNotFoundError` and returning `Nil` instead.