### PR TITLE
Add option to create indexes concurrently

### DIFF
--- a/spec/avram/migrator/create_index_statement_spec.cr
+++ b/spec/avram/migrator/create_index_statement_spec.cr
@@ -7,6 +7,9 @@ describe Avram::Migrator::CreateIndexStatement do
 
     statement = Avram::Migrator::CreateIndexStatement.new(:users, columns: :email, using: :btree, unique: true).build
     statement.should eq %(CREATE UNIQUE INDEX users_email_index ON users USING btree ("email");)
+
+    statement = Avram::Migrator::CreateIndexStatement.new(:users, columns: :email, using: :btree, concurrently: true).build
+    statement.should eq %(CREATE INDEX CONCURRENTLY users_email_index ON users USING btree ("email");)
   end
 
   it "supports other index types" do

--- a/src/avram/migrator/create_index_statement.cr
+++ b/src/avram/migrator/create_index_statement.cr
@@ -36,7 +36,7 @@ class Avram::Migrator::CreateIndexStatement
     Brin
   end
 
-  def initialize(@table : TableName, @columns : Columns, using : Symbol = :btree, @unique = false, @name : String? | Symbol? = nil)
+  def initialize(@table : TableName, @columns : Columns, using : Symbol = :btree, @unique : Bool = false, @concurrently : Bool = false, @name : String? | Symbol? = nil)
     @using = IndexTypes.parse?(using.to_s)
     raise "index type '#{using}' not supported" if @using.nil?
   end
@@ -49,7 +49,9 @@ class Avram::Migrator::CreateIndexStatement
     String.build do |index|
       index << "CREATE"
       index << " UNIQUE" if @unique
-      index << " INDEX " << index_name
+      index << " INDEX "
+      index << "CONCURRENTLY " if @concurrently
+      index << index_name
       index << " ON " << @table
       index << " USING " << @using.to_s.downcase
       index << " (" << mapped_columns << ");"

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -36,8 +36,8 @@ module Avram::Migrator::StatementHelpers
     prepared_statements << DropForeignKeyStatement.new(from, references, column).build
   end
 
-  def create_index(table_name : TableName, columns : Columns, unique = false, using = :btree, name : String? | Symbol? = nil)
-    prepared_statements << CreateIndexStatement.new(table_name, columns, using, unique, name).build
+  def create_index(table_name : TableName, columns : Columns, unique = false, concurrently = false, using = :btree, name : String? | Symbol? = nil)
+    prepared_statements << CreateIndexStatement.new(table_name, columns, using, unique, concurrently, name).build
   end
 
   def drop_index(table_name : TableName, columns : Columns? = nil, if_exists = false, on_delete = :do_nothing, name : String? | Symbol? = nil)


### PR DESCRIPTION
Fixes #1124

This allows you to run your new indexes concurrently.

```crystal
create_index :users, [:page_title], concurrently: true
```