### PR TITLE
Sort operation needs by presence of default value

### DIFF
--- a/src/avram/needy_initializer.cr
+++ b/src/avram/needy_initializer.cr
@@ -8,7 +8,11 @@ module Avram::NeedyInitializer
   end
 
   macro needs(type_declaration)
-    {% OPERATION_NEEDS << type_declaration %}
+    {% if type_declaration.value.is_a?(Nop) %}
+      {% OPERATION_NEEDS.unshift(type_declaration) %}
+    {% else %}
+      {% OPERATION_NEEDS.push(type_declaration) %}
+    {% end %}
     property {{ type_declaration.var }} : {{ type_declaration.type }}
   end
 

--- a/src/avram/needy_initializer_and_delete_methods.cr
+++ b/src/avram/needy_initializer_and_delete_methods.cr
@@ -8,7 +8,11 @@ module Avram::NeedyInitializerAndDeleteMethods
   end
 
   macro needs(type_declaration)
-    {% OPERATION_NEEDS << type_declaration %}
+    {% if type_declaration.value.is_a?(Nop) %}
+      {% OPERATION_NEEDS.unshift(type_declaration) %}
+    {% else %}
+      {% OPERATION_NEEDS.push(type_declaration) %}
+    {% end %}
     property {{ type_declaration.var }} : {{ type_declaration.type }}
   end
 

--- a/src/avram/needy_initializer_and_save_methods.cr
+++ b/src/avram/needy_initializer_and_save_methods.cr
@@ -8,7 +8,11 @@ module Avram::NeedyInitializerAndSaveMethods
   end
 
   macro needs(type_declaration)
-    {% OPERATION_NEEDS << type_declaration %}
+    {% if type_declaration.value.is_a?(Nop) %}
+      {% OPERATION_NEEDS.unshift(type_declaration) %}
+    {% else %}
+      {% OPERATION_NEEDS.push(type_declaration) %}
+    {% end %}
     @{{ type_declaration.var }} : {{ type_declaration.type }}
     property {{ type_declaration.var }}
   end


### PR DESCRIPTION
Fixes #1118 

This fixes a compilation error where an operation is made with a `need` that has a default value and there are needs defined after it without a default. I'm not sure if it matters, but `OPERATION_NEEDS` will be in a different order now. All needs without a default value will be in the reverse order they were defined and at the front of the list, and needs with a default value will be in the order they were defined but at the end of the list. If the ordering needs to be maintained, everywhere that uses the list in the needy initializer files will need to sort it first.