### PR TITLE
Checking Crystal 1.19 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
         with:
@@ -31,38 +31,35 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
+          - windows-latest
         shard_file:
           - shard.yml
         postgres_version:
           - 14
-          - 16
+          - 18
         crystal_version:
-          - 1.15.1
+          - 1.16.3
           - latest
         experimental:
           - false
         include:
-          - os: windows-latest
-            shard_file: shard.yml
-            crystal_version: latest
-            postgres_version: 16
-            experimental: true
           - shard_file: shard.edge.yml
             crystal_version: latest
-            postgres_version: 14
+            postgres_version: 18
             experimental: true
             os: ubuntu-latest
           - shard_file: shard.override.yml
             crystal_version: nightly
-            postgres_version: 14
+            postgres_version: 18
             experimental: true
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup PostgreSQL v${{ matrix.postgres_version }}
-        uses: ikalnytskyi/action-setup-postgres@v6
+        uses: ikalnytskyi/action-setup-postgres@v8
         with:
           username: lucky
           password: developer

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: crystal-lang/install-crystal@v1

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: avram
 version: 1.4.2
 
-crystal: ">= 1.15.1"
+crystal: ">= 1.16.3"
 
 license: MIT
 

--- a/src/avram/params.cr
+++ b/src/avram/params.cr
@@ -3,7 +3,7 @@ class Avram::Params
 
   @hash : Hash(String, Array(String) | String) |  \
     Hash(String, Array(String)) |  \
-    Hash(String, String)
+      Hash(String, String)
 
   def initialize
     @hash = {} of String => String


### PR DESCRIPTION
## Purpose
Validating Crystal 1.19 works

## Description
This bumps the min supported Crystal version to 1.16. Though, lower versions of Crystal may work, Avram will only guarantee that 1.16.3 at a minimum will be supported. Also making sure all the things are updated.