### PR TITLE
Allow alternate languages and behaviors in the create_function SQL helper

### DIFF
--- a/spec/avram/migrator/create_function_statement_spec.cr
+++ b/spec/avram/migrator/create_function_statement_spec.cr
@@ -25,4 +25,22 @@ describe Avram::Migrator::CreateFunctionStatement do
     full_statement.should contain "RETURNS integer"
     full_statement.should contain "RETURN i + 1;"
   end
+
+  it "allows specifying alternate languages" do
+    sql = <<-SQL
+    SELECT true
+    SQL
+
+    statement = Avram::Migrator::CreateFunctionStatement.new("always_true", sql, returns: "boolean", language: "sql", behavior: :immutable)
+    full_statement = statement.build
+    full_statement.should eq <<-SQL
+    CREATE OR REPLACE FUNCTION always_true()
+      RETURNS boolean
+    AS $$
+      SELECT true
+    $$
+    LANGUAGE sql
+    IMMUTABLE;
+    SQL
+  end
 end

--- a/src/avram/migrator/create_function_statement.cr
+++ b/src/avram/migrator/create_function_statement.cr
@@ -1,5 +1,11 @@
 class Avram::Migrator::CreateFunctionStatement
-  def initialize(@name : String, @body : String, @returns : String = "trigger")
+  enum Behavior
+    IMMUTABLE
+    STABLE
+    VOLATILE
+  end
+
+  def initialize(@name : String, @body : String, @returns : String = "trigger", @language : String = "plpgsql", @behavior : Behavior = Behavior::VOLATILE)
   end
 
   def function_name
@@ -13,11 +19,12 @@ class Avram::Migrator::CreateFunctionStatement
   def build
     <<-SQL
     CREATE OR REPLACE FUNCTION #{function_name}
-      RETURNS #{@returns} AS $$
-    BEGIN
+      RETURNS #{@returns}
+    AS $$
       #{@body}
-    END
-    $$ LANGUAGE 'plpgsql';
+    $$
+    LANGUAGE #{@language}
+    #{@behavior};
     SQL
   end
 end

--- a/src/avram/migrator/statement_helpers.cr
+++ b/src/avram/migrator/statement_helpers.cr
@@ -64,8 +64,8 @@ module Avram::Migrator::StatementHelpers
     prepared_statements << Avram::Migrator::AlterExtensionStatement.new(name, to: to).build
   end
 
-  def create_function(name : String, body : String, returns : String = "trigger")
-    prepared_statements << Avram::Migrator::CreateFunctionStatement.new(name, body: body, returns: returns).build
+  def create_function(name : String, body : String, returns : String = "trigger", language : String = "plpgsql", behavior : Avram::Migrator::CreateFunctionStatement::Behavior = Avram::Migrator::CreateFunctionStatement::Behavior::VOLATILE)
+    prepared_statements << Avram::Migrator::CreateFunctionStatement.new(name, body: body, returns: returns, language: language, behavior: behavior).build
   end
 
   def drop_function(name : String)


### PR DESCRIPTION
Fixes #1120

Previously it was always assumed you would be using Postgres, so the function would always be setup using `plpgsql`. That's still default, but now you can specify just `sql` if you want. However, it turns out that when using `sql` you can't have a `BEGIN END`, so I had to remove those. We also used to just use the default `VOLATILE` behavior, but if you needed to specify `IMMUTABLE` then you couldn't, but now you can.