### PR TITLE
Allow running certain migrations outside of a transaction.

### DIFF
--- a/spec/avram/migrator/migration_spec.cr
+++ b/spec/avram/migrator/migration_spec.cr
@@ -98,6 +98,21 @@ class MigrationCreateAndDropIndexes::V993 < Avram::Migrator::Migration::V1
   end
 end
 
+class MigrationWithUnsafeSQL::V992 < Avram::Migrator::Migration::V1
+  unsafe_migration
+
+  def migrate
+    execute "CREATE TABLE execution_order (x integer NOT NULL);"
+    # Postgres doesn't like running concurrent index creation inside of a transaction
+    execute "CREATE INDEX CONCURRENTLY fast_index ON execution_order (x)"
+  end
+
+  def rollback
+    execute "DROP INDEX CONCURRENTLY IF EXISTS fast_index"
+    drop :execution_order
+  end
+end
+
 describe Avram::Migrator::Migration::V1 do
   it "executes statements in a transaction" do
     expect_raises Avram::FailedMigration do
@@ -183,6 +198,20 @@ describe Avram::Migrator::Migration::V1 do
       migration.rollback
       sql = migration.prepared_statements.join("\n")
       sql.should contain "DROP SEQUENCE IF EXISTS accounts_number_seq"
+    end
+  end
+
+  # NOTE: This spec is run with truncation to ensure we're not wrapping it in a transaction
+  describe "outside of a transaction", tags: Avram::SpecHelper::TRUNCATE do
+    it "allows running unsafe SQL outside of a transaction" do
+      migration = MigrationWithUnsafeSQL::V992.new
+      migration.up(quiet: true)
+      sql = migration.prepared_statements.join("\n")
+      sql.should contain "CREATE INDEX CONCURRENTLY fast_index ON execution_order (x)"
+
+      migration.down(quiet: true)
+      sql = migration.prepared_statements.join("\n")
+      sql.should contain "DROP INDEX CONCURRENTLY IF EXISTS fast_index"
     end
   end
 end

--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -18,6 +18,19 @@ abstract class Avram::Migrator::Migration::V1
     end
   end
 
+  # This macro will tell the migration to run all prepared statements
+  # outside of a transaction. This is considered "unsafe" as improper
+  # SQL could pose risk to data integrity if not handled correctly
+  macro unsafe_migration
+    def run_in_transaction : Bool
+      false
+    end
+  end
+
+  def run_in_transaction : Bool
+    true
+  end
+
   abstract def migrate
   abstract def version : Int64
 
@@ -34,7 +47,7 @@ abstract class Avram::Migrator::Migration::V1
       else
         reset_prepared_statements
         migrate
-        execute_in_transaction @prepared_statements do |txn|
+        run_prepared_statements @prepared_statements do |txn|
           track_migration(txn)
           unless quiet
             puts "Migrated #{self.class.name.colorize(:green)}"
@@ -52,7 +65,7 @@ abstract class Avram::Migrator::Migration::V1
       else
         reset_prepared_statements
         rollback
-        execute_in_transaction @prepared_statements do |txn|
+        run_prepared_statements @prepared_statements do |txn|
           untrack_migration(txn)
           unless quiet
             puts "Rolled back #{self.class.name.colorize(:green)}"
@@ -93,13 +106,18 @@ abstract class Avram::Migrator::Migration::V1
   # # Usage
   #
   # ```
-  # execute_in_transaction ["DROP TABLE comments;"] do |db|
+  # run_prepared_statements ["DROP TABLE comments;"] do |db|
   #   db.exec "DROP TABLE users;"
   # end
   # ```
-  private def execute_in_transaction(statements : Array(String), &)
+  private def run_prepared_statements(statements : Array(String), &)
     database = Avram.settings.database_to_migrate
-    database.transaction do
+    if run_in_transaction
+      database.transaction do
+        statements.each { |sql| database.exec sql }
+        yield database
+      end
+    else
       statements.each { |sql| database.exec sql }
       yield database
     end


### PR DESCRIPTION
Fixes #1129
Closes #1021

This allows you to specify that your migration is going to potentially run some "unsafe" code which basically just means that you're going to run it outside of a transaction. This can be used for when engines like Cockroach DB require running outside of a migration, or for things like creating indexes concurrently in postgres.

You just add the `unsafe_migration` call to the top of the migration.

```crystal
class MyUnsafeMigration::V1234 < Avram::Migrator::Migration::V1
  unsafe_migration

  def migrate
    execute "some sql that won't run inside of a transaction"
  end

  def rollback
    execute "a rollback that also can't run inside of a transaction"
  end
end
```