### PR TITLE
Add avram attachment

### DIFF
--- a/db/migrations/20260314174133_create_attachable_items.cr
+++ b/db/migrations/20260314174133_create_attachable_items.cr
@@ -1,0 +1,14 @@
+class CreateAttachableItems::V20260314174133 < Avram::Migrator::Migration::V1
+  def migrate
+    create table_for(AttachableItem) do
+      primary_key id : Int64
+      add_timestamps
+
+      add image : JSON::Any?
+    end
+  end
+
+  def rollback
+    drop table_for(AttachableItem)
+  end
+end

--- a/spec/avram/attachment_spec.cr
+++ b/spec/avram/attachment_spec.cr
@@ -6,10 +6,69 @@ describe Avram::Attachment::Model do
 
     item.image.should be_nil
   end
+
+  it "deletes the file from storage when the record is deleted" do
+    image_file = TestUploadedFile.new("photo.png")
+    item = AttachableItem::SaveOperation.create!(image_file: image_file).reload
+    stored = item.image.not_nil!
+
+    TestImageUploader::StoredFile.reset_deleted_ids
+    AttachableItem::DeleteOperation.delete!(item)
+
+    TestImageUploader::StoredFile.deleted_ids.should contain(stored.id)
+  end
 end
 
 describe Avram::Attachment::SaveOperation do
+  it "caches and promotes the attachment on save" do
+    image_file = TestUploadedFile.new("photo.png")
+    item = AttachableItem::SaveOperation.create!(image_file: image_file).reload
+
+    item.image.should_not be_nil
+    item.image.not_nil!.storage_key.should eq("store")
+    item.image.not_nil!.id.should contain("attachable_item")
+    item.image.not_nil!.id.should contain("image")
+    item.image.not_nil!.id.should contain("photo.png")
+  end
+
+  it "deletes the old attachment when uploading a new one" do
+    image_file = TestUploadedFile.new("old_photo.png")
+    item = AttachableItem::SaveOperation.create!(image_file: image_file)
+
+    image_file = TestUploadedFile.new("new_photo.png")
+    AttachableItem::SaveOperation.update!(item, image_file: image_file)
+
+    item.reload.image.not_nil!.id.should contain("new_photo.png")
+  end
+
+  it "deletes the attachment when delete_image is true" do
+    image_file = TestUploadedFile.new("old.png")
+    item = AttachableItem::SaveOperation.create!(image_file: image_file)
+
+    AttachableItem::SaveOperation.update!(item, delete_image: true)
+
+    item.reload.image.should be_nil
+  end
 end
 
-describe Avram::Attachment::DeleteOperation do
+private class TestUploadedFile
+  include Avram::Uploadable
+
+  getter tempfile : File
+  getter metadata : HTTP::FormData::FileMetadata
+
+  def initialize(filename : String, content : String = "test content")
+    @tempfile = File.tempfile(filename)
+    @tempfile.print(content)
+    @tempfile.rewind
+    @metadata = HTTP::FormData::FileMetadata.new(filename: filename)
+  end
+
+  def filename : String
+    @metadata.filename || ""
+  end
+
+  def blank? : Bool
+    filename.blank?
+  end
 end

--- a/spec/avram/attachment_spec.cr
+++ b/spec/avram/attachment_spec.cr
@@ -10,7 +10,7 @@ describe Avram::Attachment::Model do
   it "deletes the file from storage when the record is deleted" do
     image_file = TestUploadedFile.new("photo.png")
     item = AttachableItem::SaveOperation.create!(image_file: image_file).reload
-    stored = item.image.not_nil!
+    stored = item.image.as(TestImageUploader::StoredFile)
 
     TestImageUploader::StoredFile.reset_deleted_ids
     AttachableItem::DeleteOperation.delete!(item)
@@ -25,10 +25,12 @@ describe Avram::Attachment::SaveOperation do
     item = AttachableItem::SaveOperation.create!(image_file: image_file).reload
 
     item.image.should_not be_nil
-    item.image.not_nil!.storage_key.should eq("store")
-    item.image.not_nil!.id.should contain("attachable_item")
-    item.image.not_nil!.id.should contain("image")
-    item.image.not_nil!.id.should contain("photo.png")
+    if image = item.image
+      image.storage_key.should eq("store")
+      image.id.should contain("attachable_item")
+      image.id.should contain("image")
+      image.id.should contain("photo.png")
+    end
   end
 
   it "deletes the old attachment when uploading a new one" do
@@ -38,7 +40,8 @@ describe Avram::Attachment::SaveOperation do
     image_file = TestUploadedFile.new("new_photo.png")
     AttachableItem::SaveOperation.update!(item, image_file: image_file)
 
-    item.reload.image.not_nil!.id.should contain("new_photo.png")
+    item.reload.image.as(TestImageUploader::StoredFile).id
+      .should contain("new_photo.png")
   end
 
   it "deletes the attachment when delete_image is true" do

--- a/spec/avram/attachment_spec.cr
+++ b/spec/avram/attachment_spec.cr
@@ -1,0 +1,15 @@
+require "../spec_helper"
+
+describe Avram::Attachment::Model do
+  it "has an attachment" do
+    item = AttachableItemFactory.create
+
+    item.image.should be_nil
+  end
+end
+
+describe Avram::Attachment::SaveOperation do
+end
+
+describe Avram::Attachment::DeleteOperation do
+end

--- a/spec/avram/validations_spec.cr
+++ b/spec/avram/validations_spec.cr
@@ -25,6 +25,37 @@ struct TestI18nBackend < Avram::I18nBackend
   end
 end
 
+class TestStoredFile
+  alias MetadataValue = String | Int64 | Int32 | Float64 | Bool | Nil
+  alias MetadataHash = Hash(String, MetadataValue)
+
+  property size : Int64?
+  property mime_type : String?
+
+  def initialize(@size : Int64? = nil, @mime_type : String? = nil)
+  end
+
+  def size? : Int64?
+    @size
+  end
+
+  def mime_type? : String?
+    @mime_type
+  end
+end
+
+private def file_attribute(file : T) : Avram::Attribute(T) forall T
+  Avram::Attribute.new(value: file, param: nil, param_key: "fake", name: :fake)
+end
+
+private def nil_file_attribute : Avram::Attribute(TestStoredFile?)
+  Avram::Attribute(TestStoredFile?).new(value: nil, param: nil, param_key: "fake", name: :fake)
+end
+
+private def stored_file(size : Int64? = nil, mime_type : String? = nil) : TestStoredFile
+  TestStoredFile.new(size: size, mime_type: mime_type)
+end
+
 private def attribute(value : T) : Avram::Attribute(T) forall T
   Avram::Attribute.new(value: value, param: nil, param_key: "fake", name: :fake)
 end
@@ -488,6 +519,141 @@ describe Avram::Validations do
       result.should eq(false)
       bad_attribute.valid?.should be_false
       bad_attribute.errors.should eq ["must be a valid URL beginning with https"]
+    end
+  end
+
+  describe "validate_file_size_of" do
+    it "returns true when the attribute has no file" do
+      result = Avram::Validations.validate_file_size_of(nil_file_attribute, max: 5_000_000_i64)
+      result.should eq(true)
+    end
+
+    it "validates the file is not too small" do
+      small_file = file_attribute(stored_file(size: 500_i64))
+      result = Avram::Validations.validate_file_size_of(small_file, min: 1_000_i64)
+      result.should eq(false)
+      small_file.errors.should eq(["must be at least 1000 bytes"])
+    end
+
+    it "validates the file is not too large" do
+      large_file = file_attribute(stored_file(size: 10_000_000_i64))
+      result = Avram::Validations.validate_file_size_of(large_file, max: 5_000_000_i64)
+      result.should eq(false)
+      large_file.errors.should eq(["must not be larger than 5000000 bytes"])
+    end
+
+    it "validates within a min and max range" do
+      valid_file = file_attribute(stored_file(size: 2_000_i64))
+      result = Avram::Validations.validate_file_size_of(valid_file, min: 1_000_i64, max: 5_000_000_i64)
+      result.should eq(true)
+      valid_file.valid?.should be_true
+    end
+
+    it "fails when size is nil and allow_blank is false" do
+      no_size_file = file_attribute(stored_file)
+      result = Avram::Validations.validate_file_size_of(no_size_file, min: 1_000_i64)
+      result.should eq(false)
+      no_size_file.errors.should eq(["must be at least 1000 bytes"])
+    end
+
+    it "passes when size is nil and allow_blank is true" do
+      no_size_file = file_attribute(stored_file)
+      result = Avram::Validations.validate_file_size_of(no_size_file, min: 1_000_i64, allow_blank: true)
+      result.should eq(true)
+      no_size_file.valid?.should be_true
+    end
+
+    it "supports a custom message" do
+      large_file = file_attribute(stored_file(size: 10_000_000_i64))
+      result = Avram::Validations.validate_file_size_of(large_file, max: 5_000_000_i64, message: "is way too big")
+      result.should eq(false)
+      large_file.errors.should eq(["is way too big"])
+    end
+  end
+
+  describe "validate_file_mime_type_of" do
+    describe "with an allowed list" do
+      it "returns true when the attribute has no file" do
+        result = Avram::Validations.validate_file_mime_type_of(nil_file_attribute, in: ["image/png"])
+        result.should eq(true)
+      end
+
+      it "passes when the MIME type is in the allowed list" do
+        png_file = file_attribute(stored_file(mime_type: "image/png"))
+        result = Avram::Validations.validate_file_mime_type_of(png_file, in: ["image/png", "image/jpeg"])
+        result.should eq(true)
+        png_file.valid?.should be_true
+      end
+
+      it "fails when the MIME type is not in the allowed list" do
+        gif_file = file_attribute(stored_file(mime_type: "image/gif"))
+        result = Avram::Validations.validate_file_mime_type_of(gif_file, in: ["image/png", "image/jpeg"])
+        result.should eq(false)
+        gif_file.errors.should eq(["is not an accepted file type"])
+      end
+
+      it "fails when the MIME type is nil and allow_blank is false" do
+        no_mime_file = file_attribute(stored_file)
+        result = Avram::Validations.validate_file_mime_type_of(no_mime_file, in: ["image/png"])
+        result.should eq(false)
+        no_mime_file.errors.should eq(["is not an accepted file type"])
+      end
+
+      it "passes when the MIME type is nil and allow_blank is true" do
+        no_mime_file = file_attribute(stored_file)
+        result = Avram::Validations.validate_file_mime_type_of(no_mime_file, in: ["image/png"], allow_blank: true)
+        result.should eq(true)
+        no_mime_file.valid?.should be_true
+      end
+
+      it "supports a custom message" do
+        gif_file = file_attribute(stored_file(mime_type: "image/gif"))
+        result = Avram::Validations.validate_file_mime_type_of(gif_file, in: ["image/png"], message: "wrong file type")
+        result.should eq(false)
+        gif_file.errors.should eq(["wrong file type"])
+      end
+    end
+
+    describe "with a pattern" do
+      it "returns true when the attribute has no file" do
+        result = Avram::Validations.validate_file_mime_type_of(nil_file_attribute, with: /image\/.*/)
+        result.should eq(true)
+      end
+
+      it "passes when the MIME type matches the pattern" do
+        png_file = file_attribute(stored_file(mime_type: "image/png"))
+        result = Avram::Validations.validate_file_mime_type_of(png_file, with: /image\/.*/)
+        result.should eq(true)
+        png_file.valid?.should be_true
+      end
+
+      it "fails when the MIME type does not match the pattern" do
+        video_file = file_attribute(stored_file(mime_type: "video/mp4"))
+        result = Avram::Validations.validate_file_mime_type_of(video_file, with: /image\/.*/)
+        result.should eq(false)
+        video_file.errors.should eq(["is not an accepted file type"])
+      end
+
+      it "fails when the MIME type is nil and allow_blank is false" do
+        no_mime_file = file_attribute(stored_file)
+        result = Avram::Validations.validate_file_mime_type_of(no_mime_file, with: /image\/.*/)
+        result.should eq(false)
+        no_mime_file.errors.should eq(["is not an accepted file type"])
+      end
+
+      it "passes when the MIME type is nil and allow_blank is true" do
+        no_mime_file = file_attribute(stored_file)
+        result = Avram::Validations.validate_file_mime_type_of(no_mime_file, with: /image\/.*/, allow_blank: true)
+        result.should eq(true)
+        no_mime_file.valid?.should be_true
+      end
+
+      it "supports a custom message" do
+        video_file = file_attribute(stored_file(mime_type: "video/mp4"))
+        result = Avram::Validations.validate_file_mime_type_of(video_file, with: /image\/.*/, message: "images only")
+        result.should eq(false)
+        video_file.errors.should eq(["images only"])
+      end
     end
   end
 end

--- a/spec/support/factories/attachable_item_factory.cr
+++ b/spec/support/factories/attachable_item_factory.cr
@@ -1,0 +1,2 @@
+class AttachableItemFactory < BaseFactory
+end

--- a/spec/support/models/attachable_item.cr
+++ b/spec/support/models/attachable_item.cr
@@ -25,9 +25,40 @@ struct TestImageUploader < Lucky::Attachment::Uploader
     ":model/:id/:attachment"
   end
 
+  def self.cache(io : IO, path_prefix : String, filename : String?) : StoredFile
+    StoredFile.new(
+      id: File.join(path_prefix, filename || "test.png"),
+      storage_key: "cache"
+    )
+  end
+
+  def self.promote(file : StoredFile, location : String) : StoredFile
+    StoredFile.new(
+      id: location,
+      storage_key: "store"
+    )
+  end
+
   class StoredFile < ::Lucky::Attachment::StoredFile
     def self.adapter
       Lucky(self)
+    end
+
+    @@deleted_ids = [] of String
+
+    def self.deleted_ids : Array(String)
+      @@deleted_ids
+    end
+
+    def self.reset_deleted_ids : Nil
+      @@deleted_ids.clear
+    end
+
+    getter id = "file_id"
+    getter storage_key = "store"
+
+    def delete : Nil
+      @@deleted_ids << @id
     end
   end
 end
@@ -42,4 +73,8 @@ class AttachableItem < BaseModel
     attach image : TestImageUploader::StoredFile?
     timestamps
   end
+end
+
+class AttachableItem::SaveOperation
+  attach image
 end

--- a/spec/support/models/attachable_item.cr
+++ b/spec/support/models/attachable_item.cr
@@ -21,24 +21,6 @@ abstract class Lucky::Attachment::StoredFile
 end
 
 struct TestImageUploader < Lucky::Attachment::Uploader
-  def self.path_prefix : String
-    ":model/:id/:attachment"
-  end
-
-  def self.cache(io : IO, path_prefix : String, filename : String?) : StoredFile
-    StoredFile.new(
-      id: File.join(path_prefix, filename || "test.png"),
-      storage_key: "cache"
-    )
-  end
-
-  def self.promote(file : StoredFile, location : String) : StoredFile
-    StoredFile.new(
-      id: location,
-      storage_key: "store"
-    )
-  end
-
   class StoredFile < ::Lucky::Attachment::StoredFile
     def self.adapter
       Lucky(self)
@@ -60,6 +42,24 @@ struct TestImageUploader < Lucky::Attachment::Uploader
     def delete : Nil
       @@deleted_ids << @id
     end
+  end
+
+  def self.path_prefix : String
+    ":model/:id/:attachment"
+  end
+
+  def self.cache(io : IO, path_prefix : String, filename : String?) : TestImageUploader::StoredFile
+    StoredFile.new(
+      id: File.join(path_prefix, filename || "test.png"),
+      storage_key: "cache"
+    )
+  end
+
+  def self.promote(file : StoredFile, location : String) : TestImageUploader::StoredFile
+    StoredFile.new(
+      id: location,
+      storage_key: "store"
+    )
   end
 end
 

--- a/spec/support/models/attachable_item.cr
+++ b/spec/support/models/attachable_item.cr
@@ -48,14 +48,21 @@ struct TestImageUploader < Lucky::Attachment::Uploader
     ":model/:id/:attachment"
   end
 
-  def self.cache(io : IO, path_prefix : String, filename : String?) : TestImageUploader::StoredFile
+  def self.cache(
+    upoaded_file : Avram::Uploadable,
+    path_prefix : String,
+    filename : String?,
+  ) : TestImageUploader::StoredFile
     StoredFile.new(
       id: File.join(path_prefix, filename || "test.png"),
       storage_key: "cache"
     )
   end
 
-  def self.promote(file : StoredFile, location : String) : TestImageUploader::StoredFile
+  def self.promote(
+    file : StoredFile,
+    location : String,
+  ) : TestImageUploader::StoredFile
     StoredFile.new(
       id: location,
       storage_key: "store"

--- a/spec/support/models/attachable_item.cr
+++ b/spec/support/models/attachable_item.cr
@@ -1,0 +1,45 @@
+require "json"
+
+abstract struct Lucky::Attachment::Uploader
+end
+
+abstract class Lucky::Attachment::StoredFile
+  alias MetadataValue = String | Int64 | Int32 | Float64 | Bool | Nil
+  alias MetadataHash = Hash(String, MetadataValue)
+
+  include JSON::Serializable
+
+  @[JSON::Field(ignore: true)]
+  @io : IO?
+
+  def initialize(
+    @id : String,
+    @storage_key : String,
+    @metadata : MetadataHash = MetadataHash.new,
+  )
+  end
+end
+
+struct TestImageUploader < Lucky::Attachment::Uploader
+  def self.path_prefix : String
+    ":model/:id/:attachment"
+  end
+
+  class StoredFile < ::Lucky::Attachment::StoredFile
+    def self.adapter
+      Lucky(self)
+    end
+  end
+end
+
+class AttachableItem < BaseModel
+  include Avram::Attachment::Model
+
+  skip_default_columns
+
+  table do
+    primary_key id : Int64
+    attach image : TestImageUploader::StoredFile?
+    timestamps
+  end
+end

--- a/src/avram/attachment/model.cr
+++ b/src/avram/attachment/model.cr
@@ -1,0 +1,151 @@
+module Avram::Attachment::Model
+  macro included
+    class ::{{ @type }}::SaveOperation < Avram::SaveOperation({{ @type }})
+      include Avram::Attachment::SaveOperation
+    end
+
+    macro finished
+      class ::{{ @type }}::DeleteOperation < Avram::DeleteOperation({{ @type }})
+        include Avram::Attachment::DeleteOperation
+      end
+    end
+  end
+
+  # Registers a serializable column for an attachment and takes and uploader
+  # class as the type.
+  #
+  # ```
+  # attach avatar : ImageUploader::StoredFile
+  # # or
+  # attach avatar : ImageUploader::StoredFile?
+  # ```
+  #
+  # It is assumed that a `jsonb` column exists with the same name. So in your
+  # migration, you'll need to add the column as follows:
+  #
+  # ```
+  # add avatar : JSON::Any
+  # # or
+  # add avatar : JSON::Any?
+  # ```
+  #
+  # The data of a stored file can then be accessed through the `avatar` method:
+  #
+  # ```
+  # user.avatar.class
+  # # => ImageUploader::StoredFile
+  #
+  # user.avatar.url
+  # # => "https://bucket.s3.amazonaws.com/user/1/avatar/abc123.jpg"
+  #
+  # # for presigned URLs
+  # user.avatar.url(expires_in: 1.hour)
+  # ```
+  #
+  macro attach(type_declaration)
+    {% name = type_declaration.var %}
+    {% if type_declaration.type.is_a?(Union) %}
+      {% stored_file = type_declaration.type.types.first %}
+      {% nilable = true %}
+    {% else %}
+      {% stored_file = type_declaration.type %}
+      {% nilable = false %}
+    {% end %}
+    {% uploader = stored_file.stringify.split("::")[0..-2].join("::").id %}
+
+    # Registers a path prefix for the attachment.
+    {% if !@type.constant(:ATTACHMENT_PREFIXES) %}
+      ATTACHMENT_PREFIXES = {} of Symbol => String
+    {% end %}
+
+    ATTACHMENT_PREFIXES[:{{ name }}] = {{ uploader }}.path_prefix
+      .gsub(/:model/, {{ @type.stringify.gsub(/::/, "_").underscore }})
+      .gsub(/:attachment/, {{ name.stringify }})
+
+    # Registers the configured uploader class for the attachment.
+    {% if !@type.constant(:ATTACHMENT_UPLOADERS) %}
+      ATTACHMENT_UPLOADERS = {} of Symbol => ::Lucky::Attachment::Uploader.class
+    {% end %}
+    ATTACHMENT_UPLOADERS[:{{ name }}] = {{ uploader }}
+
+    column {{ name }} : ::{{ stored_file }}{% if nilable %}?{% end %}, serialize: true
+  end
+end
+
+module Avram::Attachment::SaveOperation
+  # Registers a file attribute for an existing attachment on the model.
+  #
+  # ```
+  # # The field name in the form will be "avatar_file"
+  # attach avatar
+  #
+  # # With a custom field name
+  # attach avatar, field_name: "avatar_upload"
+  # ```
+  #
+  # The attachment will then be uploaded to the cache store, and after
+  # committing to the database the attachment will be moved to the permanent
+  # storage.
+  #
+  macro attach(name, field_name = nil)
+    {%
+      field_name = "#{name}_file".id if field_name.nil?
+
+      unless column = T.constant(:COLUMNS).find { |col| col[:name].stringify == name.stringify }
+        raise %(The `#{T.name}` model does not have a column named `#{name}`)
+      end
+    %}
+
+    file_attribute :{{ field_name }}
+
+    {% if nilable = column[:nilable] %}
+      attribute delete_{{ name }} : Bool = false
+    {% end %}
+
+    before_save __cache_{{ field_name }}
+    after_commit __process_{{ field_name }}
+
+    # Moves uploaded file to the cache storage.
+    private def __cache_{{ field_name }} : Nil
+      {% if nilable %}
+        {{ name }}.value = nil if delete_{{ name }}.value
+      {% end %}
+
+      return unless upload = {{ field_name }}.value
+
+      record_id = {{ T.constant(:PRIMARY_KEY_NAME).id }}.value
+      {{ name }}.value = T::ATTACHMENT_UPLOADERS[:{{ name }}].cache(
+        upload.tempfile,
+        path_prefix: T::ATTACHMENT_PREFIXES[:{{ name }}].gsub(/:id/, record_id),
+        filename:  upload.filename.presence
+      )
+    end
+
+    # Deletes or promotes the attachment and updates the record.
+    private def __process_{{ field_name }}(record) : Nil
+      {% if nilable %}
+        if delete_{{ name }}.value && (file = {{ name }}.original_value)
+          file.delete
+        end
+      {% end %}
+
+      return unless {{ field_name }}.value && (cached = {{ name }}.value)
+
+      stored = T::ATTACHMENT_UPLOADERS[:{{ name }}].promote(cached)
+      T::SaveOperation.update!(record, {{ name }}: stored)
+    end
+  end
+end
+
+module Avram::Attachment::DeleteOperation
+  # Cleans up the files of any attachments this records still has.
+  macro included
+    after_delete do |_|
+      {% for name in T.constant(:ATTACHMENT_UPLOADERS) %}
+        if attachment = {{ name }}.value
+          attachment.delete
+        end
+      {% end %}
+    end
+  end
+end

--- a/src/avram/attachment/model.cr
+++ b/src/avram/attachment/model.cr
@@ -21,12 +21,6 @@ module Avram::Attachment::Model
     class ::{{ @type }}::SaveOperation < Avram::SaveOperation({{ @type }})
       include Avram::Attachment::SaveOperation
     end
-
-    macro finished
-      class ::{{ @type }}::DeleteOperation < Avram::DeleteOperation({{ @type }})
-        include Avram::Attachment::DeleteOperation
-      end
-    end
   end
 
   # Registers a serializable column for an attachment and takes and uploader
@@ -88,6 +82,10 @@ module Avram::Attachment::Model
     ATTACHMENT_UPLOADERS[:{{ name }}] = {{ uploader }}
 
     column {{ name }} : ::{{ stored_file }}{% if nilable %}?{% end %}, serialize: true
+
+    class ::{{ @type }}::DeleteOperation < Avram::DeleteOperation({{ @type }})
+      after_delete { |record| record.{{ name }}.try(&.delete) }
+    end
   end
 end
 
@@ -132,10 +130,13 @@ module Avram::Attachment::SaveOperation
 
       return unless upload = {{ field_name }}.value
 
-      record_id = {{ T.constant(:PRIMARY_KEY_NAME).id }}.value
+      record_id = new_record? ?
+        UUID.random.to_s :
+        {{ T.constant(:PRIMARY_KEY_NAME).id }}.value
+      prefix = T::ATTACHMENT_PREFIXES[:{{ name }}].gsub(/:id/, record_id)
       {{ name }}.value = T::ATTACHMENT_UPLOADERS[:{{ name }}].cache(
         upload.tempfile,
-        path_prefix: T::ATTACHMENT_PREFIXES[:{{ name }}].gsub(/:id/, record_id),
+        path_prefix: prefix,
         filename:  upload.filename.presence
       )
     end
@@ -150,21 +151,17 @@ module Avram::Attachment::SaveOperation
 
       return unless {{ field_name }}.value && (cached = {{ name }}.value)
 
-      stored = T::ATTACHMENT_UPLOADERS[:{{ name }}].promote(cached)
-      T::SaveOperation.update!(record, {{ name }}: stored)
-    end
-  end
-end
+      if old_file = {{ name }}.original_value
+        old_file.delete
+      end
 
-module Avram::Attachment::DeleteOperation
-  # Cleans up the files of any attachments this records still has.
-  macro included
-    after_delete do |_|
-      {% for name in T.constant(:ATTACHMENT_UPLOADERS) %}
-        if attachment = {{ name }}.value
-          attachment.delete
-        end
-      {% end %}
+      record_id = record.{{ T.constant(:PRIMARY_KEY_NAME).id }}.to_s
+      prefix = T::ATTACHMENT_PREFIXES[:{{ name }}].gsub(/:id/, record_id)
+      stored = T::ATTACHMENT_UPLOADERS[:{{ name }}].promote(
+        cached,
+        location: File.join(prefix, File.basename(cached.id))
+      )
+      T::SaveOperation.update!(record, {{ name }}: stored)
     end
   end
 end

--- a/src/avram/attachment/model.cr
+++ b/src/avram/attachment/model.cr
@@ -1,3 +1,21 @@
+# Add methods for uploading files using `Lucky::Attachment`.
+#
+# Include this module in your model to be able to use the `attach` macro
+# required by Lucky's upload implementation.
+#
+# ```
+# class User < BaseModel
+#   include Avram::Attachment::Model
+#
+#   table do
+#     attach avatar : ImageUploader::StoredFile?
+#   end
+# end
+# ```
+#
+# By including this module, the model's operation classes will also receive the
+# required macros and methods to seamlessly integrate with Lucky's upload.
+#
 module Avram::Attachment::Model
   macro included
     class ::{{ @type }}::SaveOperation < Avram::SaveOperation({{ @type }})
@@ -66,6 +84,7 @@ module Avram::Attachment::Model
     {% if !@type.constant(:ATTACHMENT_UPLOADERS) %}
       ATTACHMENT_UPLOADERS = {} of Symbol => ::Lucky::Attachment::Uploader.class
     {% end %}
+
     ATTACHMENT_UPLOADERS[:{{ name }}] = {{ uploader }}
 
     column {{ name }} : ::{{ stored_file }}{% if nilable %}?{% end %}, serialize: true

--- a/src/avram/attachment/model.cr
+++ b/src/avram/attachment/model.cr
@@ -135,7 +135,7 @@ module Avram::Attachment::SaveOperation
         {{ T.constant(:PRIMARY_KEY_NAME).id }}.value
       prefix = T::ATTACHMENT_PREFIXES[:{{ name }}].gsub(/:id/, record_id)
       {{ name }}.value = T::ATTACHMENT_UPLOADERS[:{{ name }}].cache(
-        upload.tempfile,
+        upload,
         path_prefix: prefix,
         filename:  upload.filename.presence
       )

--- a/src/avram/i18n_backend.cr
+++ b/src/avram/i18n_backend.cr
@@ -20,6 +20,9 @@ struct Avram::I18n < Avram::I18nBackend
       validate_required:           "is required",
       validate_uniqueness_of:      "is already taken",
       validate_url_format:         "must be a valid URL beginning with %s",
+      validate_min_file_size_of:   "must be at least %d bytes",
+      validate_max_file_size_of:   "must not be larger than %d bytes",
+      validate_file_mime_type_of:  "is not an accepted file type",
     }[key]
   end
 end

--- a/src/avram/params.cr
+++ b/src/avram/params.cr
@@ -2,8 +2,7 @@ class Avram::Params
   include Avram::Paramable
 
   @hash : Hash(String, Array(String) | String) |  \
-    Hash(String, Array(String)) |  \
-    Hash(String, String)
+    Hash(String, Array(String)) | Hash(String, String)
 
   def initialize
     @hash = {} of String => String

--- a/src/avram/params.cr
+++ b/src/avram/params.cr
@@ -3,7 +3,7 @@ class Avram::Params
 
   @hash : Hash(String, Array(String) | String) |  \
     Hash(String, Array(String)) |  \
-      Hash(String, String)
+    Hash(String, String)
 
   def initialize
     @hash = {} of String => String

--- a/src/avram/validations.cr
+++ b/src/avram/validations.cr
@@ -331,6 +331,18 @@ module Avram::Validations
     true
   end
 
+  # Validates that the attribute value is a valid URL with the given scheme
+  #
+  # By default only `https` URLs are considered valid. Pass a `scheme` argument
+  # to allow a different scheme.
+  #
+  # ```
+  # validate_url_format website
+  # validate_url_format repository, scheme: "http"
+  # ```
+  #
+  # Note that blank values are considered valid. Use `validate_required` in
+  # addition if the field is required.
   def validate_url_format(
     attribute : Avram::Attribute(String),
     scheme : String = "https",
@@ -342,6 +354,87 @@ module Avram::Validations
         attribute.add_error(message % scheme)
         return false
       end
+    end
+
+    true
+  end
+
+  # Validate the size of a file attachment
+  #
+  # ```
+  # validate_file_size_of avatar, max: 5_000_000
+  # validate_file_size_of avatar, min: 1_000, max: 5_000_000
+  # ```
+  def validate_file_size_of(
+    attribute : Avram::Attribute(T),
+    min : Int64 = 0_i64,
+    max : Int64? = nil,
+    message : Avram::Attribute::ErrorMessage? = nil,
+    allow_blank : Bool = false,
+  ) : Bool forall T
+    return true unless file = attribute.value
+    size = file.size?
+    return true if allow_blank && !size
+
+    if (size || 0_i64) < min
+      attribute.add_error(
+        (message || Avram.settings.i18n_backend.get(:validate_min_file_size_of)) % min
+      )
+      return false
+    end
+
+    if (max_size = max) && (size || 0_i64) > max_size
+      attribute.add_error(
+        (message || Avram.settings.i18n_backend.get(:validate_max_file_size_of)) % max_size
+      )
+      return false
+    end
+
+    true
+  end
+
+  # Validates that the file attachment has one of the allowed MIME types
+  #
+  # ```
+  # validate_file_mime_type_of avatar, in: %w[image/png image/jpeg]
+  # ```
+  def validate_file_mime_type_of(
+    attribute : Avram::Attribute(T),
+    in allowed : Enumerable(String),
+    message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_file_mime_type_of),
+    allow_blank : Bool = false,
+  ) : Bool forall T
+    return true unless file = attribute.value
+    mime_type = file.mime_type?
+    return true if allow_blank && !mime_type
+
+    unless allowed.includes?(mime_type)
+      attribute.add_error(message)
+      return false
+    end
+
+    true
+  end
+
+  # Validates that the file attachment MIME type matches the given pattern
+  #
+  # ```
+  # validate_file_mime_type_of avatar, with: /image\/.*/
+  # validate_file_mime_type_of attachment, with: /video\/.*/
+  # ```
+  def validate_file_mime_type_of(
+    attribute : Avram::Attribute(T),
+    with pattern : Regex,
+    message : Avram::Attribute::ErrorMessage = Avram.settings.i18n_backend.get(:validate_file_mime_type_of),
+    allow_blank : Bool = false,
+  ) : Bool forall T
+    return true unless file = attribute.value
+    mime_type = file.mime_type?
+    return true if allow_blank && !mime_type
+
+    unless mime_type.to_s.match(pattern)
+      attribute.add_error(message)
+      return false
     end
 
     true


### PR DESCRIPTION
This is the Avram counterpart of https://github.com/luckyframework/lucky/pull/2016. It adds the necessary macros and callbacks for models, save operations, and delete operations.

This PR also adds some validations for `StoredFile` attributes:
```crystal
# MIME type
validate_file_mime_type_of avatar, in: %w[image/png image/jpeg]
validate_file_mime_type_of avatar, with: /image\/.*/

# File size
validate_file_size_of avatar, max: 5_000_000
validate_file_size_of avatar, min: 1_000, max: 5_000_000
validate_file_size_of avatar, min: 1_000
```