### PR TITLE
Allow updates with columns similar to keywords

### DIFF
--- a/db/migrations/20180612221318_create_businesses.cr
+++ b/db/migrations/20180612221318_create_businesses.cr
@@ -18,6 +18,7 @@ class CreateBusinesses::V20180612221318 < Avram::Migrator::Migration::V1
     create :email_addresses do
       primary_key id : Int64
       add_timestamps
+      add default : Bool, default: true
       add address : String, case_sensitive: false
       add_belongs_to business : Business?, on_delete: :cascade
     end

--- a/spec/avram/operations/nested_save_operation_spec.cr
+++ b/spec/avram/operations/nested_save_operation_spec.cr
@@ -185,7 +185,7 @@ describe "Avram::SaveOperation with nested operation" do
   context "when all forms are valid" do
     it "sets the relationship and creates both" do
       params = FakeNestedParams.new business: {"name" => "Fubar", "latitude" => "46.383488", "longitude" => "22.774896"},
-        email_address: {"address" => "foo@bar.com"},
+        email_address: {"address" => "foo@bar.com", "default" => "false"},
         tax_id: {"number" => "123"}
 
       operation = SaveBusiness.new(params)
@@ -201,6 +201,7 @@ describe "Avram::SaveOperation with nested operation" do
       business = operation.record.as(Business)
       business.name.should eq "Fubar"
       business.email_address!.address.should eq "foo@bar.com"
+      business.email_address!.default.should eq false
       business.tax_id!.number.should eq 123
     end
 

--- a/spec/avram/operations/nested_save_operation_spec.cr
+++ b/spec/avram/operations/nested_save_operation_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 private class SaveBusiness < Business::SaveOperation
   class SaveEmailAddress < EmailAddress::SaveOperation
-    permit_columns address
+    permit_columns address, default
   end
 
   class SaveTaxId < TaxId::SaveOperation

--- a/spec/avram/query_builder_spec.cr
+++ b/spec/avram/query_builder_spec.cr
@@ -171,7 +171,7 @@ describe Avram::QueryBuilder do
         .where(Avram::Where::Equal.new(:id, "1"))
         .limit(1)
 
-      query.statement_for_update(params).should eq "UPDATE users SET first_name = $1, last_name = $2 WHERE id = $3 LIMIT 1 RETURNING *"
+      query.statement_for_update(params).should eq %(UPDATE users SET "first_name" = $1, "last_name" = $2 WHERE id = $3 LIMIT 1 RETURNING *)
       query.args_for_update(params).should eq ["Paul", nil, "1"]
     end
 
@@ -181,8 +181,18 @@ describe Avram::QueryBuilder do
         .where(Avram::Where::Equal.new(:id, "1"))
         .limit(1)
 
-      query.statement_for_update(params).should eq "UPDATE users SET first_name = $1, last_name = $2 WHERE id = $3 LIMIT 1 RETURNING *"
-      query.statement_for_update(params).should eq "UPDATE users SET first_name = $1, last_name = $2 WHERE id = $3 LIMIT 1 RETURNING *"
+      query.statement_for_update(params).should eq %(UPDATE users SET "first_name" = $1, "last_name" = $2 WHERE id = $3 LIMIT 1 RETURNING *)
+      query.statement_for_update(params).should eq %(UPDATE users SET "first_name" = $1, "last_name" = $2 WHERE id = $3 LIMIT 1 RETURNING *)
+    end
+
+    it "quotes the columns to ensure reserved keywords can be used" do
+      params = {:select => "foobar"}
+      query = new_query
+        .where(Avram::Where::Equal.new(:id, "1"))
+        .limit(1)
+
+      query.statement_for_update(params).should eq %(UPDATE users SET "select" = $1 WHERE id = $2 LIMIT 1 RETURNING *)
+      query.args_for_update(params).should eq ["foobar", "1"]
     end
   end
 

--- a/spec/support/factories/email_address_factory.cr
+++ b/spec/support/factories/email_address_factory.cr
@@ -1,5 +1,6 @@
 class EmailAddressFactory < BaseFactory
   def initialize
     address "foo@bar.com"
+    default true
   end
 end

--- a/spec/support/models/email_address.cr
+++ b/spec/support/models/email_address.cr
@@ -2,7 +2,7 @@ class EmailAddress < BaseModel
   table do
     column address : String
     # This will test that we can update records that use keyword names
-    column default : Bool
+    column default : Bool = true
     belongs_to business : Business?
   end
 end

--- a/spec/support/models/email_address.cr
+++ b/spec/support/models/email_address.cr
@@ -1,6 +1,8 @@
 class EmailAddress < BaseModel
   table do
     column address : String
+    # This will test that we can update records that use keyword names
+    column default : Bool
     belongs_to business : Business?
   end
 end

--- a/src/avram/query_builder.cr
+++ b/src/avram/query_builder.cr
@@ -106,7 +106,7 @@ class Avram::QueryBuilder
 
   private def set_sql_clause(params) : String
     "SET " + params.join(", ") do |key, _|
-      "#{key} = #{next_prepared_statement_placeholder}"
+      %("#{key}" = #{next_prepared_statement_placeholder})
     end
   end
 


### PR DESCRIPTION
Fixes #1141

Previously doing `UPDATE whatever SET default = true` would fail because `default` is a keyword. This quotes the column so now it can be updated.