### PR TITLE
Require migrations to have a rollback method defined

### DIFF
--- a/src/avram/migrator/migration.cr
+++ b/src/avram/migrator/migration.cr
@@ -32,6 +32,7 @@ abstract class Avram::Migrator::Migration::V1
   end
 
   abstract def migrate
+  abstract def rollback
   abstract def version : Int64
 
   getter prepared_statements = [] of String


### PR DESCRIPTION
Fixes #1139